### PR TITLE
Unit representation: store direct representation

### DIFF
--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -67,9 +67,12 @@ impl Quantity {
             // to also perform the hour->second conversion, which would be needed, as
             // we go back to base units for now. Removing common factors is just one
             // heuristic, but it would be better to solve this in a more general way.
-            // For more details on this problem, see `examples/xkcd2585.nbt`.
+            // For more details on this problem, see [1].
+            //
+            // [1] https://github.com/sharkdp/numbat/issues/118.
             let mut common_unit_factors = Unit::scalar();
             let target_unit_canonicalized = target_unit.canonicalized();
+
             for factor in self.unit.canonicalized().iter() {
                 if let Some(other_factor) = target_unit_canonicalized
                     .iter()
@@ -128,7 +131,7 @@ impl Quantity {
         }
 
         let removed_exponent = |u: &UnitFactor| {
-            let base_unit = u.unit_id.corresponding_base_unit();
+            let base_unit = u.unit_id.base_unit_and_factor().0;
             if let Some(first_factor) = base_unit.into_iter().next() {
                 first_factor.exponent
             } else {

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -469,8 +469,7 @@ impl Vm {
                     let unit_name = &self.global_identifiers[identifier_idx as usize];
                     let defining_unit = conversion_value.unit();
 
-                    let (base_unit_representation, factor) =
-                        defining_unit.to_base_unit_representation();
+                    let (base_unit_representation, _) = defining_unit.to_base_unit_representation();
 
                     self.unit_registry
                         .add_derived_unit(&unit_name.0, &base_unit_representation)
@@ -479,8 +478,8 @@ impl Vm {
                     self.constants[constant_idx as usize] = Constant::Unit(Unit::new_derived(
                         &unit_name.0,
                         unit_name.1.as_ref().unwrap(),
-                        *conversion_value.unsafe_value() * factor,
-                        base_unit_representation,
+                        *conversion_value.unsafe_value(),
+                        defining_unit.clone(),
                     ));
                 }
                 Op::SetVariable => {


### PR DESCRIPTION
This is a major change to how units are represented in Numbat. Previously, derived units were always defined by their relation to base units. For example: A foot was represented as 0.3048 meter, even though it was defined as 12 inch.

With this change, we represent those unit relationships closer to how they have been defined, i.e. 1 foot is a defined unit with a conversion factor of 12 and a defining unit of inch.

This is preparatory work that will make further changes to unit conversion and quantity simplification possible.

For example: if someone wants to converts feet to inch, we don't have to go through meter as a common base unit, we can take the direct path instead and multiply by 12.