### PR TITLE
add metrix prefixes for barns

### DIFF
--- a/numbat/modules/units/misc.nbt
+++ b/numbat/modules/units/misc.nbt
@@ -9,7 +9,8 @@ unit bar: Pressure = 100 kPa
 @aliases(angstroms, Å: short)
 unit angstrom: Length = 1e-10 meter
 
-@aliases(barns)
+@metric_prefixes
+@aliases(barns, b: short)
 unit barn: Area = 1e-28 meter^2
 
 @metric_prefixes

--- a/numbat/modules/units/misc.nbt
+++ b/numbat/modules/units/misc.nbt
@@ -10,7 +10,7 @@ unit bar: Pressure = 100 kPa
 unit angstrom: Length = 1e-10 meter
 
 @metric_prefixes
-@aliases(barns, b: short)
+@aliases(barns)
 unit barn: Area = 1e-28 meter^2
 
 @metric_prefixes


### PR DESCRIPTION
picobarn (and its shorthand `pb`) is a very common unit in High Energy Physics (HEP). Perhaps there is concern that `b` is too likely of a letter to be used elsewhere? If so, I can easily use a custom local configuration to add this shorthand for myself and HEP colleagues.