### PR TITLE
Update the bnf

### DIFF
--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -5,8 +5,8 @@
 //! statement       →   variable_decl | function_decl | dimension_decl | decorator | unit_decl | module_import | procedure_call | expression
 //!
 //! variable_decl   →   "let" identifier ( ":" type_annotation ) ? "=" expression
-//! type_annotation →   boolean | string | dimension_expr
-//! function_decl   →   "fn" identifier ( fn_decl_generic ) ? fn_decl_param "->" type_annotation "=" expression
+//! type_annotation →   "bool" | "str" | dimension_expr
+//! function_decl   →   "fn" identifier ( fn_decl_generic ) ? fn_decl_param ( "->" type_annotation ) ? ( "=" expression ) ?
 //! fn_decl_generic →   "<" ( identifier "," ) * identifier ? ">"
 //! fn_decl_param   →   "(" ( identifier ( ":" dimension_expr ) ? "," )* ( identifier ( ":" dimension_expr ) ) ? ")"
 //! dimension_decl  →   "dimension" identifier ( "=" dimension_expr ) *
@@ -18,8 +18,8 @@
 //! dimension_expr  →   dim_factor
 //! dim_factor      →   dim_power ( (multiply | divide) dim_power ) *
 //! dim_power       →   dim_primary ( power dim_exponent | unicode_exponent ) ?
-//! dim_exponent    →   number | minus dim_exponent | "(" dim_exponent ( divide dim_exponent ) ? ")"
-//! dim_primary     →   identifier | number | ( "(" dimension_expr ")"
+//! dim_exponent    →   integer | minus dim_exponent | "(" dim_exponent ( divide dim_exponent ) ? ")"
+//! dim_primary     →   identifier | "1" | ( "(" dimension_expr ")"
 //!
 //!
 //!
@@ -44,6 +44,7 @@
 //! hex_number      →   /0x[0-9a-fA-F]*/
 //! oct_number      →   /0o[0-7]*/
 //! bin_number      →   /0b[01]*/
+//! integer          →   /[0-9]([0-9_]*[0-9])?/
 //! identifier      →   [a-zA-Z_] [a-zA-Z_0-9] *
 //! boolean         →   true | false
 //! bool            →   true | false

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2,7 +2,7 @@
 //!
 //! Grammar:
 //! ```txt
-//! statement       →   variable_decl | function_decl | dimension_decl | decorator | unit_decl | module_import | procedure_call | expression
+//! statement       →   variable_decl | function_decl | dimension_decl | unit_decl | module_import | procedure_call | expression
 //!
 //! variable_decl   →   "let" identifier ( ":" type_annotation ) ? "=" expression
 //! type_annotation →   "bool" | "str" | dimension_expr
@@ -11,7 +11,7 @@
 //! fn_decl_param   →   "(" ( identifier ( ":" type_annotation ) ? "," )* ( identifier ( ":" type_annotation ) ) ? ")"
 //! dimension_decl  →   "dimension" identifier ( "=" dimension_expr ) *
 //! decorator       →   "@" ( "metric_prefixes" | "binary_prefixes" | ( "aliases(" list_of_aliases ")" ) )
-//! unit_decl       →   "unit" ( ":" dimension_expr ) ? ( "=" expression ) ?
+//! unit_decl       →   decorator * "unit" ( ":" dimension_expr ) ? ( "=" expression ) ?
 //! procedure_call  →   ( "print" | "assert_eq" | "type" ) "(" arguments? ")"
 //! module_import   →   "use" ident ( "::" ident) *
 //!
@@ -20,8 +20,6 @@
 //! dim_power       →   dim_primary ( power dim_exponent | unicode_exponent ) ?
 //! dim_exponent    →   integer | minus dim_exponent | "(" dim_exponent ( divide dim_exponent ) ? ")"
 //! dim_primary     →   identifier | "1" | ( "(" dimension_expr ")"
-//!
-//!
 //!
 //! expression      →   postfix_apply
 //! postfix_apply   →   condition ( "//" identifier ) *
@@ -46,8 +44,7 @@
 //! bin_number      →   /0b[01]*/
 //! integer          →   /[0-9]([0-9_]*[0-9])?/
 //! identifier      →   [a-zA-Z_] [a-zA-Z_0-9] *
-//! boolean         →   true | false
-//! bool            →   true | false
+//! boolean         →   "true" | "false"
 //! plus            →   "+"
 //! minus           →   "-"
 //! multiply        →   "*" | "x" | "×"

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -43,13 +43,13 @@
 //! oct_number      →   /0o[0-7]*/
 //! bin_number      →   /0b[01]*/
 //! integer          →   /[0-9]([0-9_]*[0-9])?/
-//! identifier      →   [a-zA-Z_] [a-zA-Z_0-9] *
+//! identifier      →   [Unicode XID_Start|Unicode currency symbol|%|°|_] [Unicode XID_Continue |Unicode currency symbol|%|^·] *
 //! boolean         →   "true" | "false"
 //! plus            →   "+"
 //! minus           →   "-"
 //! multiply        →   "*" | "×" | "·"
 //! divide          →   "/" | "÷"
-//! string          →   "\" ... "\""
+//! string          →   "\"" ... "\""
 //! ```
 
 use crate::arithmetic::{Exponent, Rational};

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -47,7 +47,7 @@
 //! boolean         →   "true" | "false"
 //! plus            →   "+"
 //! minus           →   "-"
-//! multiply        →   "*" | "x" | "×"
+//! multiply        →   "*" | "×" | "·"
 //! divide          →   "/" | "÷"
 //! string          →   "\" ... "\""
 //! ```

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -10,10 +10,11 @@
 //! fn_decl_generic →   "<" ( identifier "," ) * identifier ">"
 //! fn_decl_param   →   "(" ( identifier ( ":" type_annotation ) ? "," )* ( identifier ( ":" type_annotation ) ) ? ")"
 //! dimension_decl  →   "dimension" identifier ( "=" dimension_expr ) *
-//! decorator       →   "@" ( "metric_prefixes" | "binary_prefixes" | ( "aliases(" list_of_aliases ")" ) )
 //! unit_decl       →   decorator * "unit" ( ":" dimension_expr ) ? ( "=" expression ) ?
 //! procedure_call  →   ( "print" | "assert_eq" | "type" ) "(" arguments? ")"
 //! module_import   →   "use" ident ( "::" ident) *
+//!
+//! decorator       →   "@" ( "metric_prefixes" | "binary_prefixes" | ( "aliases(" list_of_aliases ")" ) )
 //!
 //! dimension_expr  →   dim_factor
 //! dim_factor      →   dim_power ( (multiply | divide) dim_power ) *

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -7,12 +7,12 @@
 //! variable_decl   →   "let" identifier ( ":" type_annotation ) ? "=" expression
 //! type_annotation →   "bool" | "str" | dimension_expr
 //! function_decl   →   "fn" identifier ( fn_decl_generic ) ? fn_decl_param ( "->" type_annotation ) ? ( "=" expression ) ?
-//! fn_decl_generic →   "<" ( identifier "," ) * identifier ? ">"
-//! fn_decl_param   →   "(" ( identifier ( ":" dimension_expr ) ? "," )* ( identifier ( ":" dimension_expr ) ) ? ")"
+//! fn_decl_generic →   "<" ( identifier "," ) * identifier ">"
+//! fn_decl_param   →   "(" ( identifier ( ":" type_annotation ) ? "," )* ( identifier ( ":" type_annotation ) ) ? ")"
 //! dimension_decl  →   "dimension" identifier ( "=" dimension_expr ) *
-//! decorator       →   "@" ( "metric_prefixes" | "binary_prefixes" | ( "aliases(" list_of_alsiases ")" ) )
+//! decorator       →   "@" ( "metric_prefixes" | "binary_prefixes" | ( "aliases(" list_of_aliases ")" ) )
 //! unit_decl       →   "unit" ( ":" dimension_expr ) ? ( "=" expression ) ?
-//! procedure_call  →   ( "print" | "assert_eq" | "type" ) ( "(" arguments? ")" ) ?
+//! procedure_call  →   ( "print" | "assert_eq" | "type" ) "(" arguments? ")"
 //! module_import   →   "use" ident ( "::" ident) *
 //!
 //! dimension_expr  →   dim_factor
@@ -360,7 +360,7 @@ impl<'a> Parser<'a> {
             if let Some(fn_name) = self.match_exact(TokenKind::Identifier) {
                 let function_name_span = self.last().unwrap().span;
                 let mut type_parameters = vec![];
-                // Parsing the generic parameters if there is any
+                // Parsing the generic parameters if there are any
                 if self.match_exact(TokenKind::LessThan).is_some() {
                     while self.match_exact(TokenKind::GreaterThan).is_none() {
                         if let Some(type_parameter_name) = self.match_exact(TokenKind::Identifier) {


### PR DESCRIPTION
Hello, while writing a tree-sitter integration for numbat [here if you're interested](https://github.com/irevoire/tree-sitter-numbat), I realized that your bnf was not following your parser and thus rewrote most of it.

I left a few regexes at the end for the numbers, that’s not ideal, and I won't keep it in tree-sitter, but for now, it's better than nothing.