### PR TITLE
Improve the "did you mean" suggestions for booleans

### DIFF
--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -382,7 +382,13 @@ impl TypeChecker {
         self.identifiers
             .get(name)
             .ok_or_else(|| {
-                let suggestion = suggestion::did_you_mean(self.identifiers.keys(), name);
+                let suggestion = suggestion::did_you_mean(
+                    self.identifiers
+                        .keys()
+                        .map(|k| k.as_str())
+                        .chain(["true", "false"].into_iter()), // These are parsed as keywords, but can act like identifiers
+                    name,
+                );
                 TypeCheckError::UnknownIdentifier(span, name.into(), suggestion)
             })
             .map(|(type_, _)| type_)


### PR DESCRIPTION
If you misspell `true` or `false`, you get weird "did you mean" suggestions:

```
>>> 4 > 5 == False
error: while type checking
  ┌─ <input:7>:1:10
  │
1 │ 4 > 5 == False
  │          ^^^^^ unknown identifier
  │
  = Did you mean 'floz'?
```

This is because `true` and `false` are keywords, not identifiers, so the "did you mean" code doesn't consider them.

This small patch appends both values to the list sent to `did_you_mean()`.

An alternative way to fix this (arguably a better way) would be to modify the `impl ErrorDiagnostic for TypeCheckError` to check for other suggestions on a `TypeCheckError::UnknownIdentifier` error