### PR TITLE
Add "did you mean" suggestions for functions and procedures

### DIFF
--- a/numbat/src/diagnostic.rs
+++ b/numbat/src/diagnostic.rs
@@ -81,9 +81,18 @@ impl ErrorDiagnostic for TypeCheckError {
                     .with_message("unknown identifier")])
                     .with_notes(notes)
             }
-            TypeCheckError::UnknownCallable(span, _) => d.with_labels(vec![span
-                .diagnostic_label(LabelStyle::Primary)
-                .with_message("unknown callable")]),
+            TypeCheckError::UnknownCallable(span, _, suggestion) => {
+                let notes = if let Some(suggestion) = suggestion {
+                    vec![format!("Did you mean '{suggestion}'?")]
+                } else {
+                    vec![]
+                };
+
+                d.with_labels(vec![span
+                    .diagnostic_label(LabelStyle::Primary)
+                    .with_message("unknown callable")])
+                    .with_notes(notes)
+            }
             TypeCheckError::IncompatibleDimensions(IncompatibleDimensionsError {
                 operation,
                 span_operation,


### PR DESCRIPTION
Works with built-in functions and procedures, and user-defined functions:

```
>>> fn foo_bar<T>(t: T) = t

  fn foo_bar<T>(t: T) -> T = t

>>> foobar(4)
error: while type checking
  ┌─ <input:5>:1:1
  │
1 │ foobar(4)
  │ ^^^^^^ unknown callable
  │
  = Did you mean 'foo_bar'?

>>> assertt(true)
error: while type checking
  ┌─ <input:6>:1:1
  │
1 │ assertt(true)
  │ ^^^^^^^ unknown callable
  │
  = Did you mean 'assert'?

>>> ceiling(4.5)
error: while type checking
  ┌─ <input:7>:1:1
  │
1 │ ceiling(4.5)
  │ ^^^^^^^ unknown callable
  │
  = Did you mean 'ceil'?
```

