### PR TITLE
Web: handle query string input line by line

### DIFF
--- a/numbat-wasm/www/index.js
+++ b/numbat-wasm/www/index.js
@@ -58,8 +58,8 @@ function interpret(input) {
     output = result.output;
 
     if (!result.is_error) {
-        combined_input += input + "\n";
-        updateUrlQuery(combined_input.trim());
+        combined_input += input.trim() + "⏎";
+        updateUrlQuery(combined_input);
     }
   }
 
@@ -87,7 +87,12 @@ function main() {
     if (location.search) {
       var queryParams = new URLSearchParams(location.search);
       if (queryParams.has("q")) {
-        term.exec(queryParams.get("q"));
+        // feed in the query line by line, as if the user typed it in
+        for (const line of queryParams.get("q").split("⏎")) {
+          if (line.trim().length > 0) {
+            term.exec(line.trim() + "\n");
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
This changes how input from a query string are handled.  Handling them line by line produces output that more closely resembles how it would have looked like when typed in interactively.

Note that this is technically a breaking change:  existing numbat.dev URLs in the wild that contain newlines in the middle of statements will no longer work.

Closes #205