### PR TITLE
add `help` (and `?`) commands to numbat REPL

### DIFF
--- a/book/src/cli-usage.md
+++ b/book/src/cli-usage.md
@@ -37,6 +37,7 @@ There is a set of special commands that only work in interactive mode:
 |---------|--------|
 | `list`, `ll`, `ls` | List all constants, units, and dimensions |
 | `clear` | Clear screen |
+| `help`, `?` | View short help text |
 | `quit`, `exit` | Quit the session |
 
 ### Key bindings

--- a/book/src/web-usage.md
+++ b/book/src/web-usage.md
@@ -25,6 +25,7 @@ There is a set of special commands that only work in the web version:
 | Command | Action |
 |---------|--------|
 | `list`, `ll`, `ls` | List all constants, units, and dimensions |
+| `help`, `?` | View short help text |
 | `reset` | Reset state (clear constants, functions, units, …) |
 | `clear` | Clear screen |
 

--- a/numbat-cli/Cargo.toml
+++ b/numbat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numbat-cli"
-description = " A statically typed programming language for scientific computations with first class support for physical dimensions and units"
+description = "A statically typed programming language for scientific computations with first class support for physical dimensions and units."
 authors = ["David Peter <mail@david-peter.de>"]
 categories = ["command-line-utilities", "science", "mathematics", "compilers"]
 keywords = ["language", "compiler", "physics", "units", "calculation"]

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -286,12 +286,7 @@ impl Cli {
                                 return Ok(());
                             }
                             "help" | "?" => {
-                                let pretty_print = match self.args.pretty_print {
-                                    PrettyPrintMode::Always => true,
-                                    PrettyPrintMode::Never => false,
-                                    PrettyPrintMode::Auto => true,
-                                };
-                                let help = help_markup(pretty_print);
+                                let help = help_markup();
                                 print!("{}", ansi_format(&help, true));
                                 // currently, the ansi formatter adds indents
                                 // _after_ each newline and so we need to manually

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -292,7 +292,11 @@ impl Cli {
                                     PrettyPrintMode::Auto => true,
                                 };
                                 let help = help_markup(pretty_print);
-                                print!("{}", ansi_format(&help, false));
+                                print!("{}", ansi_format(&help, true));
+                                // currently, the ansi formatter adds indents
+                                // _after_ each newline and so we need to manually
+                                // add an extra blank line to absorb this indent
+                                println!();
                             }
                             _ => {
                                 let result = self.parse_and_evaluate(

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -13,7 +13,7 @@ use numbat::markup as m;
 use numbat::module_importer::{BuiltinModuleImporter, ChainedImporter, FileSystemImporter};
 use numbat::pretty_print::PrettyPrint;
 use numbat::resolver::CodeSource;
-use numbat::{Context, ExitStatus, InterpreterResult, NumbatError};
+use numbat::{Context, InterpreterResult, NumbatError};
 use numbat::{InterpreterSettings, NameResolutionError};
 
 use anyhow::{bail, Context as AnyhowContext, Result};
@@ -30,7 +30,13 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::{fs, thread};
 
-type ControlFlow = std::ops::ControlFlow<numbat::ExitStatus>;
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExitStatus {
+    Success,
+    Error,
+}
+
+type ControlFlow = std::ops::ControlFlow<ExitStatus>;
 
 const PROMPT: &str = ">>> ";
 
@@ -389,7 +395,6 @@ impl Cli {
                         ControlFlow::Continue(())
                     }
                     InterpreterResult::Continue => ControlFlow::Continue(()),
-                    InterpreterResult::Exit(exit_status) => ControlFlow::Break(exit_status),
                 }
             }
             Err(NumbatError::ResolverError(e)) => {

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -130,6 +130,45 @@ impl Cli {
         }
     }
 
+    fn help(&mut self) -> Result<()> {
+        let output = m::nl()
+            + m::keyword("numbat")
+            + m::space()
+            + m::text(env!("CARGO_PKG_DESCRIPTION"))
+            + m::nl()
+            + m::text("You can start by trying one of the examples:")
+            + m::nl();
+
+        println!("{}", ansi_format(&output, false));
+
+        let examples = vec![
+            "8 km / (1 h + 25 min)",
+            "atan2(30 cm, 1 m) -> deg",
+            r#"print("Energy of red photons: {ℏ 2 π c / 660 cm -> eV}")"#,
+        ];
+        for example in examples.iter() {
+            println!("{}{}", PROMPT, example);
+            let eg_result = self.parse_and_evaluate(
+                example,
+                CodeSource::Internal,
+                ExecutionMode::Normal,
+                self.args.pretty_print,
+            );
+            if eg_result.is_break() {
+                bail!("Interpreter failed during help examples")
+            }
+        }
+
+        let output = m::nl() // extra whitespace after last example
+            +m::text("Full documentation:")
+            +m::space()
+            +m::keyword("https://numbat.dev/doc/")
+            +m::nl();
+        println!("{}", ansi_format(&output, false));
+
+        Ok(())
+    }
+
     fn run(&mut self) -> Result<()> {
         let load_prelude = !self.args.no_prelude;
         let load_init = !(self.args.no_prelude || self.args.no_init);
@@ -283,6 +322,12 @@ impl Cli {
                             }
                             "quit" | "exit" => {
                                 return Ok(());
+                            }
+                            "help" | "?" => {
+                                // purposefully ignoring result of help
+                                // because if the examples are failing I am assuming
+                                // the user is a developer intentionally changing numbat
+                                let _ = self.help();
                             }
                             _ => {
                                 let result = self.parse_and_evaluate(

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -14,7 +14,7 @@ use numbat::module_importer::{BuiltinModuleImporter, ChainedImporter, FileSystem
 use numbat::pretty_print::PrettyPrint;
 use numbat::resolver::CodeSource;
 use numbat::{Context, ExitStatus, InterpreterResult, NumbatError};
-use numbat::{InterpreterSettings, NameResolutionError, Type};
+use numbat::{InterpreterSettings, NameResolutionError};
 
 use anyhow::{bail, Context as AnyhowContext, Result};
 use clap::{Parser, ValueEnum};
@@ -380,32 +380,12 @@ impl Cli {
                     println!();
                 }
 
+                let result_markup = interpreter_result.to_markup(statements.last(), &registry);
+                print!("{}", ansi_format(&result_markup, false));
+
                 match interpreter_result {
-                    InterpreterResult::Value(value) => {
-                        let type_ = statements.last().map_or(m::empty(), |s| {
-                            if let numbat::Statement::Expression(e) = s {
-                                let type_ = e.get_type();
-
-                                if type_ == Type::scalar() {
-                                    m::empty()
-                                } else {
-                                    m::dimmed("    [")
-                                        + e.get_type().to_readable_type(&registry)
-                                        + m::dimmed("]")
-                                }
-                            } else {
-                                m::empty()
-                            }
-                        });
-
-                        let q_markup = m::whitespace("    ")
-                            + m::operator("=")
-                            + m::space()
-                            + value.pretty_print()
-                            + type_;
-                        println!("{}", ansi_format(&q_markup, false));
+                    InterpreterResult::Value(_) => {
                         println!();
-
                         ControlFlow::Continue(())
                     }
                     InterpreterResult::Continue => ControlFlow::Continue(()),

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -292,7 +292,7 @@ impl Cli {
                                     PrettyPrintMode::Auto => true,
                                 };
                                 let help = help_markup(pretty_print);
-                                print!("{}", ansi_format(&help, true));
+                                print!("{}", ansi_format(&help, false));
                             }
                             _ => {
                                 let result = self.parse_and_evaluate(

--- a/numbat-cli/tests/integration.rs
+++ b/numbat-cli/tests/integration.rs
@@ -92,3 +92,14 @@ fn without_prelude() {
         .success()
         .stdout(predicates::str::contains("5.2"));
 }
+
+#[test]
+fn help_text() {
+    numbat()
+        .write_stdin("help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "Energy of red photons: 1.87855 eV",
+        ));
+}

--- a/numbat-wasm/src/lib.rs
+++ b/numbat-wasm/src/lib.rs
@@ -13,6 +13,7 @@ use numbat::pretty_print::PrettyPrint;
 use numbat::resolver::CodeSource;
 use numbat::{markup as m, NameResolutionError, NumbatError, Type};
 use numbat::{Context, InterpreterResult, InterpreterSettings};
+use numbat::help::help_markup();
 
 use crate::jquery_terminal_formatter::JqueryTerminalWriter;
 
@@ -154,6 +155,12 @@ impl Numbat {
         let markup = self.ctx.print_environment();
         let fmt = JqueryTerminalFormatter {};
         fmt.format(&markup, false).into()
+    }
+
+    pub fn help(&self) -> JsValue {
+        let markup = help_markup();
+        let fmt = JqueryTerminalFormatter {};
+        fmt.format(&markup, true).into()
     }
 
     pub fn get_completions_for(&self, input: &str) -> Vec<JsValue> {

--- a/numbat-wasm/src/lib.rs
+++ b/numbat-wasm/src/lib.rs
@@ -99,46 +99,12 @@ impl Numbat {
                     output.push_str("\n");
                 }
 
-                match result {
-                    InterpreterResult::Value(value) => {
-                        if !to_be_printed.is_empty() {
-                            output.push_str("\n");
-                        }
-
-                        // TODO: the following statement is copied from numbat-cli. Move this to the numbat crate
-                        // to avoid duplication.
-                        let type_ = statements.last().map_or(m::empty(), |s| {
-                            if let numbat::Statement::Expression(e) = s {
-                                let type_ = e.get_type();
-
-                                if type_ == Type::scalar() {
-                                    m::empty()
-                                } else {
-                                    m::dimmed("    [")
-                                        + e.get_type().to_readable_type(&registry)
-                                        + m::dimmed("]")
-                                }
-                            } else {
-                                m::empty()
-                            }
-                        });
-
-                        let markup = m::whitespace("    ")
-                            + m::operator("=")
-                            + m::space()
-                            + value.pretty_print()
-                            + type_;
-                        output.push_str(&fmt.format(&markup, true));
-                    }
-                    InterpreterResult::Continue => {}
-                    InterpreterResult::Exit(_) => {
-                        output.push_str(&jt_format(Some("error"), "Error!".into()))
-                    }
-                }
+                let result_markup = result.to_markup(statements.last(), &registry);
+                output.push_str(&fmt.format(&markup, true));
 
                 InterpreterOutput {
                     output,
-                    is_error: false,
+                    is_error: !result.is_success()
                 }
             }
             Err(NumbatError::ResolverError(e)) => self.print_diagnostic(&e),

--- a/numbat-wasm/src/lib.rs
+++ b/numbat-wasm/src/lib.rs
@@ -6,14 +6,14 @@ use numbat::module_importer::BuiltinModuleImporter;
 use std::sync::{Arc, Mutex};
 use wasm_bindgen::prelude::*;
 
-use jquery_terminal_formatter::{jt_format, JqueryTerminalFormatter};
+use jquery_terminal_formatter::JqueryTerminalFormatter;
 
 use numbat::markup::Formatter;
 use numbat::pretty_print::PrettyPrint;
 use numbat::resolver::CodeSource;
-use numbat::{markup as m, NameResolutionError, NumbatError, Type};
-use numbat::{Context, InterpreterResult, InterpreterSettings};
-use numbat::help::help_markup();
+use numbat::{markup as m, NameResolutionError, NumbatError};
+use numbat::{Context, InterpreterSettings};
+use numbat::help::help_markup;
 
 use crate::jquery_terminal_formatter::JqueryTerminalWriter;
 
@@ -100,7 +100,7 @@ impl Numbat {
                 }
 
                 let result_markup = result.to_markup(statements.last(), &registry);
-                output.push_str(&fmt.format(&markup, true));
+                output.push_str(&fmt.format(&result_markup, true));
 
                 InterpreterOutput {
                     output,

--- a/numbat-wasm/src/lib.rs
+++ b/numbat-wasm/src/lib.rs
@@ -8,12 +8,12 @@ use wasm_bindgen::prelude::*;
 
 use jquery_terminal_formatter::JqueryTerminalFormatter;
 
+use numbat::help::help_markup;
 use numbat::markup::Formatter;
 use numbat::pretty_print::PrettyPrint;
 use numbat::resolver::CodeSource;
 use numbat::{markup as m, NameResolutionError, NumbatError};
 use numbat::{Context, InterpreterSettings};
-use numbat::help::help_markup;
 
 use crate::jquery_terminal_formatter::JqueryTerminalWriter;
 
@@ -104,7 +104,7 @@ impl Numbat {
 
                 InterpreterOutput {
                     output,
-                    is_error: !result.is_success()
+                    is_error: false,
                 }
             }
             Err(NumbatError::ResolverError(e)) => self.print_diagnostic(&e),

--- a/numbat-wasm/www/index.js
+++ b/numbat-wasm/www/index.js
@@ -53,6 +53,8 @@ function interpret(input) {
     this.clear();
   } else if (input_trimmed == "list" || input_trimmed == "ll" || input_trimmed == "ls") {
     output = numbat.print_environment();
+  } else if (input_trimmed == "help" || input_trimmed == "?") {
+    output = numbat.help();
   } else {
     var result = numbat.interpret(input);
     output = result.output;

--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numbat"
-description = " A statically typed programming language for scientific computations with first class support for physical dimensions and units"
+description = "A statically typed programming language for scientific computations with first class support for physical dimensions and units."
 authors = ["David Peter <mail@david-peter.de>"]
 categories = ["science", "mathematics", "compilers"]
 keywords = ["language", "compiler", "physics", "units", "calculation"]

--- a/numbat/examples/inspect.rs
+++ b/numbat/examples/inspect.rs
@@ -5,8 +5,7 @@ fn main() {
     let mut importer = FileSystemImporter::default();
     importer.add_path("numbat/modules");
     let mut ctx = Context::new(importer);
-    let result = ctx.interpret("use all", CodeSource::Internal).unwrap();
-    assert!(result.1.is_success());
+    let _result = ctx.interpret("use all", CodeSource::Internal).unwrap();
 
     println!("| Dimension | Unit name | Identifier(s) |");
     println!("| --- | --- | --- |");

--- a/numbat/examples/unit_graph.rs
+++ b/numbat/examples/unit_graph.rs
@@ -13,8 +13,7 @@ fn main() {
     let mut importer = FileSystemImporter::default();
     importer.add_path("numbat/modules");
     let mut ctx = Context::new(importer);
-    let result = ctx.interpret("use all", CodeSource::Internal).unwrap();
-    assert!(result.1.is_success());
+    let _ = ctx.interpret("use all", CodeSource::Internal).unwrap();
 
     println!("digraph G {{");
     println!("  layout=fdp;");

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -73,7 +73,7 @@ pub fn help_markup() -> m::Markup {
     let examples = [
         "8 km / (1 h + 25 min)",
         "atan2(30 cm, 1 m) -> deg",
-        "let ω = 2 π c / 660 cm",
+        "let ω = 2 π c / 660 nm",
         r#"print("Energy of red photons: {ℏ ω -> eV}")"#,
     ];
     let mut example_context = Context::new(BuiltinModuleImporter::default());

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -11,19 +11,12 @@ use crate::{InterpreterSettings, NameResolutionError, Type};
 
 use std::sync::{Arc, Mutex};
 
-fn evaluate_example(
-    context: &mut Context,
-    input: &str,
-    pretty_print: bool,
-) -> m::Markup {
-    let statement_output : Arc<Mutex<Vec<m::Markup>>> = Arc::new(Mutex::new(vec![]));
+fn evaluate_example(context: &mut Context, input: &str, pretty_print: bool) -> m::Markup {
+    let statement_output: Arc<Mutex<Vec<m::Markup>>> = Arc::new(Mutex::new(vec![]));
     let statement_output_c = statement_output.clone();
     let mut settings = InterpreterSettings {
         print_fn: Box::new(move |s: &m::Markup| {
-            statement_output_c
-                .lock()
-                .unwrap()
-                .push(s.clone());
+            statement_output_c.lock().unwrap().push(s.clone());
         }),
     };
 
@@ -40,16 +33,15 @@ fn evaluate_example(
     match result {
         Ok((statements, interpreter_result)) => {
             if pretty_print {
-                full_output +=
-                    statements
-                        .iter()
-                        .fold(m::empty(), |accumulated_mk, statement| {
-                            accumulated_mk
-                                + m::nl()
-                                + m::whitespace("  ")
-                                + statement.pretty_print()
-                                + m::nl()
-                        });
+                full_output += statements
+                    .iter()
+                    .fold(m::empty(), |accumulated_mk, statement| {
+                        accumulated_mk
+                            + m::nl()
+                            + m::whitespace("  ")
+                            + statement.pretty_print()
+                            + m::nl()
+                    });
             }
 
             match interpreter_result {
@@ -70,16 +62,16 @@ fn evaluate_example(
                         }
                     });
 
-                    full_output += 
-                        statement_output.lock().unwrap().iter().fold(
-                            m::empty(), |accumulated_mk, single_line| {
-                                accumulated_mk
-                                    + m::nl()
-                                    + m::whitespace("  ")
-                                    + single_line.clone()
-                                    + m::nl()
-                            })
-                        + m::nl()
+                    full_output += statement_output.lock().unwrap().iter().fold(
+                        m::empty(),
+                        |accumulated_mk, single_line| {
+                            accumulated_mk
+                                + m::nl()
+                                + m::whitespace("  ")
+                                + single_line.clone()
+                                + m::nl()
+                        },
+                    ) + m::nl()
                         + m::whitespace("    ")
                         + m::operator("=")
                         + m::space()
@@ -89,14 +81,16 @@ fn evaluate_example(
                 }
                 InterpreterResult::Continue => {
                     full_output += statement_output.lock().unwrap().iter().fold(
-                            m::empty(), |accumulated_mk, single_line| {
-                                accumulated_mk
-                                    + m::nl()
-                                    + m::whitespace("  ")
-                                    + single_line.clone()
-                                    + m::nl()
-                            });
-                },
+                        m::empty(),
+                        |accumulated_mk, single_line| {
+                            accumulated_mk
+                                + m::nl()
+                                + m::whitespace("  ")
+                                + single_line.clone()
+                                + m::nl()
+                        },
+                    );
+                }
                 InterpreterResult::Exit(_exit_status) => {
                     println!("Interpretation Error.");
                 }
@@ -124,12 +118,12 @@ fn evaluate_example(
 
 pub fn help_markup(pretty_print: bool) -> m::Markup {
     let mut output = m::nl()
-            + m::keyword("numbat")
-            + m::space()
-            + m::text(env!("CARGO_PKG_DESCRIPTION"))
-            + m::nl()
-            + m::text("You can start by trying one of the examples:")
-            + m::nl();
+        + m::keyword("numbat")
+        + m::space()
+        + m::text(env!("CARGO_PKG_DESCRIPTION"))
+        + m::nl()
+        + m::text("You can start by trying one of the examples:")
+        + m::nl();
 
     let examples = vec![
         "8 km / (1 h + 25 min)",
@@ -145,9 +139,8 @@ pub fn help_markup(pretty_print: bool) -> m::Markup {
         output += m::nl();
     }
     output += m::text("Full documentation:")
-            + m::space()
-            + m::keyword("https://numbat.dev/doc/")
-            + m::nl()
-            + m::nl();
+        + m::space()
+        + m::keyword("https://numbat.dev/doc/")
+        + m::nl();
     output
 }

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -60,9 +60,16 @@ pub fn help_markup() -> m::Markup {
     let mut output = m::nl()
         + m::keyword("numbat")
         + m::space()
-        + m::text(env!("CARGO_PKG_DESCRIPTION"))
+        + m::text("is a statically typed programming language for scientific computations")
         + m::nl()
-        + m::text("You can start by trying one of the examples:")
+        + m::text("with first class support for physical dimensions and units.")
+        + m::nl()
+        + m::text("You can read the full documentation online at")
+        + m::space()
+        + m::keyword("https://numbat.dev/doc/")
+        + m::nl()
+        + m::text("For now, you can start by trying one of these examples:")
+        + m::nl()
         + m::nl();
 
     let examples = vec![
@@ -76,11 +83,6 @@ pub fn help_markup() -> m::Markup {
     for example in examples.iter() {
         output += m::text(">>> ") + m::text(example) + m::nl();
         output += evaluate_example(&mut example_context, example);
-        output += m::nl();
     }
-    output += m::text("Full documentation:")
-        + m::space()
-        + m::keyword("https://numbat.dev/doc/")
-        + m::nl();
     output
 }

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -58,21 +58,19 @@ fn evaluate_example(context: &mut Context, input: &str) -> m::Markup {
 
 pub fn help_markup() -> m::Markup {
     let mut output = m::nl()
-        + m::keyword("numbat")
-        + m::space()
-        + m::text("is a statically typed programming language for scientific computations")
+        + m::text("Numbat is a statically typed programming language for scientific computations")
         + m::nl()
-        + m::text("with first class support for physical dimensions and units.")
+        + m::text("with first class support for physical dimensions and units. Please refer to")
         + m::nl()
-        + m::text("You can read the full documentation online at")
-        + m::space()
-        + m::keyword("https://numbat.dev/doc/")
+        + m::text("the full documentation online at ")
+        + m::string("https://numbat.dev/doc/")
+        + m::text(" or try one of these ")
         + m::nl()
-        + m::text("For now, you can start by trying one of these examples:")
+        + m::text("examples:")
         + m::nl()
         + m::nl();
 
-    let examples = vec![
+    let examples = [
         "8 km / (1 h + 25 min)",
         "atan2(30 cm, 1 m) -> deg",
         "let ω = 2 π c / 660 cm",
@@ -82,7 +80,7 @@ pub fn help_markup() -> m::Markup {
     let _use_prelude_output = evaluate_example(&mut example_context, "use prelude");
     for example in examples.iter() {
         output += m::text(">>> ") + m::text(example) + m::nl();
-        output += evaluate_example(&mut example_context, example);
+        output += evaluate_example(&mut example_context, example) + m::nl();
     }
     output
 }

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -1,7 +1,5 @@
-/**
- * Print a help, linking the documentation and live-running some examples
- * in an isolated context
- */
+/// Print a help, linking the documentation, and live-running some examples
+/// in an isolated context.
 use crate::markup as m;
 use crate::module_importer::BuiltinModuleImporter;
 use crate::pretty_print::PrettyPrint;

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -1,0 +1,151 @@
+/**
+ * Print a help, linking the documentation and live-running some examples
+ * in an isolated context
+ */
+use crate::markup as m;
+use crate::module_importer::BuiltinModuleImporter;
+use crate::pretty_print::PrettyPrint;
+use crate::resolver::CodeSource;
+use crate::{Context, InterpreterResult, NumbatError};
+use crate::{InterpreterSettings, NameResolutionError, Type};
+
+use std::sync::{Arc, Mutex};
+
+/**
+ * evaluate an example code in the input context
+ *
+ * Current limitations
+ * - We need the interpreted statement to get the pretty-printed statement,
+ *   but that only comes after interpretation. Thus we cannot show an example
+ *   where the statement itself prints (i.e. the `print` function) because it
+ *   will be printed _before_ the pretty-printed statement.
+ */
+fn evaluate_example(
+    context: &mut Context,
+    input: &str,
+    to_be_printed: Arc<Mutex<Vec<m::Markup>>>,
+    pretty_print: bool,
+) -> () {
+    let to_be_printed_c = to_be_printed.clone();
+    let mut settings = InterpreterSettings {
+        print_fn: Box::new(move |s: &m::Markup| {
+            to_be_printed_c
+                .lock()
+                .unwrap()
+                .push(m::nl() + m::whitespace("  ") + s.clone() + m::nl());
+        }),
+    };
+
+    let (result, registry) = {
+        let registry = context.dimension_registry().clone(); // TODO: get rid of this clone
+        (
+            context.interpret_with_settings(&mut settings, input, CodeSource::Internal),
+            registry,
+        )
+    };
+
+    match result {
+        Ok((statements, interpreter_result)) => {
+            if pretty_print {
+                let statements_markup =
+                    statements
+                        .iter()
+                        .fold(m::empty(), |accumulated_mk, statement| {
+                            accumulated_mk
+                                + m::nl()
+                                + m::whitespace("  ")
+                                + statement.pretty_print()
+                                + m::nl()
+                        });
+                to_be_printed.lock().unwrap().push(statements_markup);
+            }
+
+            match interpreter_result {
+                InterpreterResult::Value(value) => {
+                    let type_ = statements.last().map_or(m::empty(), |s| {
+                        if let crate::Statement::Expression(e) = s {
+                            let type_ = e.get_type();
+
+                            if type_ == Type::scalar() {
+                                m::empty()
+                            } else {
+                                m::dimmed("    [")
+                                    + e.get_type().to_readable_type(&registry)
+                                    + m::dimmed("]")
+                            }
+                        } else {
+                            m::empty()
+                        }
+                    });
+
+                    let q_markup = m::nl()
+                        + m::whitespace("    ")
+                        + m::operator("=")
+                        + m::space()
+                        + value.pretty_print()
+                        + type_
+                        + m::nl();
+                    to_be_printed.lock().unwrap().push(q_markup);
+                }
+                InterpreterResult::Continue => (),
+                InterpreterResult::Exit(_exit_status) => {
+                    println!("Interpretation Error.");
+                }
+            }
+        }
+        Err(NumbatError::ResolverError(e)) => {
+            context.print_diagnostic(e.clone());
+        }
+        Err(NumbatError::NameResolutionError(
+            e @ (NameResolutionError::IdentifierClash { .. }
+            | NameResolutionError::ReservedIdentifier(_)),
+        )) => {
+            context.print_diagnostic(e);
+        }
+        Err(NumbatError::TypeCheckError(e)) => {
+            context.print_diagnostic(e);
+        }
+        Err(NumbatError::RuntimeError(e)) => {
+            context.print_diagnostic(e);
+        }
+    }
+}
+
+pub fn help_markup(pretty_print: bool) -> m::Markup {
+    let output = Arc::new(Mutex::new(vec![
+        m::nl()
+            + m::keyword("numbat")
+            + m::space()
+            + m::text(env!("CARGO_PKG_DESCRIPTION"))
+            + m::nl()
+            + m::text("You can start by trying one of the examples:")
+            + m::nl(),
+    ]));
+
+    let examples = vec![
+        "8 km / (1 h + 25 min)",
+        "atan2(30 cm, 1 m) -> deg",
+        "let ω = 2 π c / 660 cm",
+        "# Energy of red photons",
+        "ℏ ω -> eV",
+    ];
+    let mut example_context = Context::new(BuiltinModuleImporter::default());
+    evaluate_example(&mut example_context, "use prelude", output.clone(), false);
+    for example in examples.iter() {
+        output
+            .lock()
+            .unwrap()
+            .push(m::text(">>> ") + m::text(example) + m::nl());
+        evaluate_example(&mut example_context, example, output.clone(), pretty_print);
+        output.lock().unwrap().push(m::nl());
+    }
+    output.lock().unwrap().push(
+        m::text("Full documentation:")
+            + m::space()
+            + m::keyword("https://numbat.dev/doc/")
+            + m::nl()
+            + m::nl(),
+    );
+    let markup = output.lock().unwrap().to_vec().into_iter().sum();
+    markup
+}

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -87,9 +87,8 @@ impl InterpreterResult {
                 };
                 m::whitespace("    ")
                     + m::operator("=")
-                    + m::operator("=")
                     + m::space()
-                    + value.clone().pretty_print()
+                    + value.pretty_print()
                     + type_markup
                     + m::nl()
             }

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -40,28 +40,13 @@ pub enum RuntimeError {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum ExitStatus {
-    Success,
-    Error,
-}
-
-#[derive(Debug, PartialEq, Eq)]
 #[must_use]
 pub enum InterpreterResult {
     Value(Value),
     Continue,
-    Exit(ExitStatus),
 }
 
 impl InterpreterResult {
-    pub fn is_success(&self) -> bool {
-        match self {
-            Self::Value(_) => true,
-            Self::Continue => true,
-            Self::Exit(_) => false,
-        }
-    }
-
     pub fn to_markup(
         &self,
         evaluated_statement: Option<&Statement>,
@@ -93,7 +78,6 @@ impl InterpreterResult {
                     + m::nl()
             }
             Self::Continue => m::empty(),
-            Self::Exit(_) => m::text("Interpreter Error") + m::nl(),
         }
     }
 }

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -7,6 +7,7 @@ pub mod diagnostic;
 mod dimension;
 mod ffi;
 mod gamma;
+pub mod help;
 mod interpreter;
 pub mod keywords;
 pub mod markup;

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -52,7 +52,6 @@ use thiserror::Error;
 use typechecker::{TypeCheckError, TypeChecker};
 
 pub use diagnostic::Diagnostic;
-pub use interpreter::ExitStatus;
 pub use interpreter::InterpreterResult;
 pub use interpreter::InterpreterSettings;
 pub use interpreter::RuntimeError;

--- a/numbat/tests/common.rs
+++ b/numbat/tests/common.rs
@@ -20,11 +20,9 @@ pub fn get_test_context() -> Context {
     static CONTEXT: Lazy<Context> = Lazy::new(|| {
         let mut context = get_test_context_without_prelude();
 
-        assert!(context
+        let _ = context
             .interpret("use prelude", CodeSource::Internal)
-            .expect("Error while running prelude")
-            .1
-            .is_success());
+            .expect("Error while running prelude");
         context
     });
 


### PR DESCRIPTION
This resolves #175 .

I implemented an `insect`-like `help` command for the REPL (with `?` as an alias) by writing the package description, running a few examples through the REPL itself and then printing the link to the online documentation. The examples are printed along with the prompt to show the user how it would look and then the result of the examples are printed just like any other user command to show the user how it would look on their computer.

I like this so that the output of the examples are automatically updated along with any output formatting changes in numbat, but this has the downside of potentially polluting the user namespace if any of the examples have `let` or `use` in them. For now, I just avoid using those commands in the examples.