### PR TITLE
Add unit meta information, auto-generate list of units

### DIFF
--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -5,145 +5,159 @@ See also: [Unit notation](./unit-notation.md).
 All SI-accepted units support [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix) (`mm`, `cm`, `km`, ... or `millimeter`, `centimeter`, `kilometer`, ...)
 and — where sensible — units allow for [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) (`MiB`, `GiB`, ... or `mebibyte`, `gibibyte`, ...).
 
-| Unit | Syntax |
-| ---- | ------ |
-| [Acre](https://en.wikipedia.org/wiki/Acre) | `acre`, `acres` |
-| [Ampere](https://en.wikipedia.org/wiki/Ampere) | `amperes`, `ampere`, `A` |
-| [Ångström](https://en.wikipedia.org/wiki/Ångström) | `angstroms`, `angstrom`, `Å` |
-| [Arcminute](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcminute`, `arcminutes`, `arcmin` |
-| [Arcsecond](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcsecond`, `arcseconds`, `arcsec` |
-| [Are](https://en.wikipedia.org/wiki/Hectare#Are) | `are` |
-| [Astronomical unit](https://en.wikipedia.org/wiki/Astronomical_unit) | `AU`, `au`, `astronomicalunits`, `astronomicalunit` |
-| [Atmosphere](https://en.wikipedia.org/wiki/Atmosphere_(unit)) | `atmosphere`, `atm` |
-| [Australian dollar](https://en.wikipedia.org/wiki/Australian_dollar) | `australian_dollar`, `australian_dollars`, `AUD`, `A$` |
-| [Bar](https://en.wikipedia.org/wiki/Bar_(unit)) | `bars`, `bar` |
-| [Barn](https://en.wikipedia.org/wiki/Barn_(unit)) | `barns`, `barn` |
-| [Becquerel](https://en.wikipedia.org/wiki/Becquerel) | `becquerels`, `becquerel`, `Bq` |
-| [Bel](https://en.wikipedia.org/wiki/Decibel) | `bels`, `bel` |
-| [Bit](https://en.wikipedia.org/wiki/Bit) | `bits`, `bit` |
-| [Bits per second](https://en.wikipedia.org/wiki/Data_rate_units) | `bps` |
-| [Bohr](https://en.wikipedia.org/wiki/Hartree_atomic_units) | `bohr` |
-| [British pound](https://en.wikipedia.org/wiki/Pound_sterling) | `british_pound`, `pound_sterling`, `GBP`, `£` |
-| [British thermal unit](https://en.wikipedia.org/wiki/British_thermal_unit) | `BTU` |
-| [Byte](https://en.wikipedia.org/wiki/Byte) | `Bytes`, `bytes`, `Byte`, `byte`, `B`, `Octets`, `octets`, `Octet`, `octet`|
-| [Calorie](https://en.wikipedia.org/wiki/Calorie) | `calories`, `calorie`, `cal` |
-| [Canadian dollar](https://en.wikipedia.org/wiki/Canadian_dollar) | `canadian_dollar`, `canadian_dollars`, `CAD`, `C$` |
-| [Candela](https://en.wikipedia.org/wiki/Candela) | `candelas`, `candela`, `cd` |
-| [Century](https://en.wikipedia.org/wiki/Century) | `century`, `centuries` |
-| [Coulomb](https://en.wikipedia.org/wiki/Coulomb) | `coulombs`, `coulomb`, `C` |
-| [Cubic centimetre](https://en.wikipedia.org/wiki/Cubic_centimetre) | `cc` |
-| [Cup](https://en.wikipedia.org/wiki/Cup_(unit)) | `cups`, `cup` |
-| [DPI](https://en.wikipedia.org/wiki/Dots_per_inch) | `dpi` |
-| [Dalton](https://en.wikipedia.org/wiki/Dalton_(unit)) | `dalton` |
-| [Day](https://en.wikipedia.org/wiki/Day) | `days`, `day`, `d` |
-| [Decade](https://en.wikipedia.org/wiki/Decade) | `decade`, `decades` |
-| [Degree](https://en.wikipedia.org/wiki/Degree_(angle)) | `degrees`, `degree`, `deg`, `°` |
-| [Dot](https://en.wikipedia.org/wiki/Dots_per_inch) | `dots`, `dot` |
-| [Dyne](https://en.wikipedia.org/wiki/Dyne) | `dyne`, `dyn` |
-| [Electronvolt](https://en.wikipedia.org/wiki/Electronvolt) | `electronvolts`, `electronvolt`, `eV` |
-| [Erg](https://en.wikipedia.org/wiki/Erg) | `erg`, `ergs` |
-| [Euro](https://en.wikipedia.org/wiki/Euro) | `euros`, `euro`, `EUR`, `€` |
-| [Farad](https://en.wikipedia.org/wiki/Farad) | `farads`, `farad`, `F` |
-| [Fathom](https://en.wikipedia.org/wiki/Fathom) | `fathom`, `fathoms` |
-| [Fermi](https://en.wikipedia.org/wiki/Femtometre) | `fermi` |
-| [Firkin](https://en.wikipedia.org/wiki/Firkin_(unit)) | `firkin`, `firkins` |
-| [Fluid ounce](https://en.wikipedia.org/wiki/Fluid_ounce) | `fluidounces`, `fluidounce`, `floz` |
-| [Foot](https://en.wikipedia.org/wiki/Foot_(unit)) | `feet`, `foot`, `ft` |
-| Football field | `footballfield` |
-| [Fortnight](https://en.wikipedia.org/wiki/Fortnight) | `fortnights`, `fortnight` |
-| [Frame](https://en.wikipedia.org/wiki/Film_frame) | `frames`, `frame` |
-| [Frames per second](https://en.wikipedia.org/wiki/Frame_rate) | `fps` |
-| [Furlong](https://en.wikipedia.org/wiki/Furlong) | `furlongs`, `furlong` |
-| [Gallon](https://en.wikipedia.org/wiki/Gallon) | `gallons`, `gallon`, `gal` |
-| [Gauss](https://en.wikipedia.org/wiki/Gauss_(unit)) | `gauss` |
-| [Gon](https://en.wikipedia.org/wiki/Gradian) | `gon` |
-| [Gram](https://en.wikipedia.org/wiki/Gram) | `grams`, `gram`, `grammes`, `gramme`, `g` |
-| [Gray](https://en.wikipedia.org/wiki/Gray_(unit)) | `grays`, `gray`, `Gy` |
-| [Gregorian year](https://en.wikipedia.org/wiki/Gregorian_year) | `years`, `year` |
-| [Hartree](https://en.wikipedia.org/wiki/Hartree_atomic_units) | `hartree`, `hartrees` |
-| [Hectare](https://en.wikipedia.org/wiki/Hectare) | `hectares`, `hectare`, `ha` |
-| [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `henrys`, `henries`, `henry`, `H` |
-| [Hertz](https://en.wikipedia.org/wiki/Hertz) | `hertz`, `Hz` |
-| [Hogshead](https://en.wikipedia.org/wiki/Hogshead) | `hogsheads`, `hogshead` |
-| [Horsepower](https://en.wikipedia.org/wiki/Horsepower#Metric_horsepower) | `horsepower`, `hp` |
-| [Hour](https://en.wikipedia.org/wiki/Hour) | `hours`, `hour`, `hr`, `h` |
-| [Inch of mercury](https://en.wikipedia.org/wiki/Inch_of_mercury) | `inHg` |
-| [Inch](https://en.wikipedia.org/wiki/Inch) | `inches`, `inch`, `in` |
-| [Joule](https://en.wikipedia.org/wiki/Joule) | `joules`, `joule`, `J` |
-| [Julian year](https://en.wikipedia.org/wiki/Julian_year_(astronomy)) | `julian_years`, `julian_year` |
-| [Katal](https://en.wikipedia.org/wiki/Katal) | `katals`, `katal`, `kat` |
-| [Kelvin](https://en.wikipedia.org/wiki/Kelvin) | `kelvins`, `kelvin`, `K` |
-| [Kilogram-force](https://en.wikipedia.org/wiki/Kilogram-force) | `kilogram_force`, `kgf` |
-| [Kilometres per hour](https://en.wikipedia.org/wiki/Kilometres_per_hour) | `kph` |
-| [Knot](https://en.wikipedia.org/wiki/Knot_(unit)) | `knots`, `knot`, `kn`, `kt` |
-| [League](https://en.wikipedia.org/wiki/League_(unit)) | `league`, `leagues` |
-| [Light-year](https://en.wikipedia.org/wiki/Light-year) | `lightyears`, `lightyear`, `ly` |
-| [Liter](https://en.wikipedia.org/wiki/Liter) | `liters`, `liter`, `litres`, `litre`, `L`, `l` |
-| [Lumen](https://en.wikipedia.org/wiki/Lumen_(unit)) | `lumens`, `lumen`, `lm` |
-| [Lux](https://en.wikipedia.org/wiki/Lux) | `lux`, `lx` |
-| [Maxwell](https://en.wikipedia.org/wiki/Maxwell_(unit)) | `maxwell`, `Mx` |
-| [Meter](https://en.wikipedia.org/wiki/Meter) | `meters`, `meter`, `metres`, `metre`, `m` |
-| [Micron](https://en.wikipedia.org/wiki/Micrometre) | `micron` |
-| [Mile](https://en.wikipedia.org/wiki/Mile) | `miles`, `mile` |
-| [Mileage](https://en.wikipedia.org/wiki/Mileage) | `mpg` |
-| [Miles per hour](https://en.wikipedia.org/wiki/Miles_per_hour) | `mph` |
-| [Millennium](https://en.wikipedia.org/wiki/Millennium) | `millennium`, `millennia` |
-| [Millimeter of mercury](https://en.wikipedia.org/wiki/Millimeter_of_mercury) | `mmHg` |
-| [Minute](https://en.wikipedia.org/wiki/Minute) | `minutes`, `minute`, `min` |
-| [Molal](https://en.wikipedia.org/wiki/Molality) | `molal` |
-| [Molar](https://en.wikipedia.org/wiki/Molar_concentration) | `molar` |
-| [Mole](https://en.wikipedia.org/wiki/Mole_(unit)) | `moles`, `mole`, `mol` |
-| [Month](https://en.wikipedia.org/wiki/Month) | `months`, `month` |
-| [Nautical mile](https://en.wikipedia.org/wiki/Nautical_mile) | `M`, `NM`, `nmi` |
-| [Newton](https://en.wikipedia.org/wiki/Newton_(unit)) | `newtons`, `newton`, `N` |
-| [Oersted](https://en.wikipedia.org/wiki/Oersted) | `oersted`, `Oe` |
-| [Ohm](https://en.wikipedia.org/wiki/Ohm) | `ohms`, `ohm`, `Ω` |
-| [Ounce-force](https://en.wikipedia.org/wiki/Ounce#Ounce-force) | `ounce_force`, `ozf` |
-| [Ounce](https://en.wikipedia.org/wiki/Ounce) | `ounces`, `ounce`, `oz` |
-| [PPI](https://en.wikipedia.org/wiki/Pixels_per_inch) | `ppi` |
-| [Parsec](https://en.wikipedia.org/wiki/Parsec) | `parsecs`, `parsec`, `pc` |
-| [Parts-per-billion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppb` |
-| [Parts-per-million](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppm` |
-| [Parts-per-quadrillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppq` |
-| [Parts-per-trillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppt` |
-| [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit)) | `pascals`, `pascal`, `Pa` |
-| [Percent](https://en.wikipedia.org/wiki/Parts-per_notation) | `percent`, `%`, `pct` |
-| [Person](https://en.wiktionary.org/wiki/person) | `persons`, `person`, `people`, `capita` |
-| [Piece](https://en.wiktionary.org/wiki/piece) | `pieces`, `piece` |
-| [Pint](https://en.wikipedia.org/wiki/Pint) | `pints`, `pint` |
-| [Pixel](https://en.wikipedia.org/wiki/Pixel) | `pixels`, `pixel`, `px` |
-| [Poise](https://en.wikipedia.org/wiki/Poise_(unit)) | `poise` |
-| [Pound-force](https://en.wikipedia.org/wiki/Pound_%28force%29) | `pound_force`, `lbf` |
-| [Pound](https://en.wikipedia.org/wiki/Pound_(mass)) | `pounds`, `pound`, `lb` |
-| [Psi](https://en.wikipedia.org/wiki/Pounds_per_square_inch) | `psi` |
-| [RPM](https://en.wikipedia.org/wiki/RPM) | `RPM`, `rpm` |
-| [Radian](https://en.wikipedia.org/wiki/Radian) | `radians`, `radian`, `rad` |
-| [Renminbi](https://en.wikipedia.org/wiki/Renminbi) | `renminbi`, `CNY`, `元` |
-| [Rod](https://en.wikipedia.org/wiki/Rod_(unit)) | `rods`, `rod` |
-| [Second](https://en.wikipedia.org/wiki/Second) | `seconds`, `second`, `sec`, `s` |
-| [Sidereal day](https://en.wikipedia.org/wiki/Sidereal_time#Sidereal_day) | `sidereal_day`, `sidereal_days` |
-| [Siemens](https://en.wikipedia.org/wiki/Siemens_(unit)) | `siemens`, `S` |
-| [Sievert](https://en.wikipedia.org/wiki/Sievert) | `sieverts`, `sievert`, `Sv` |
-| [Smoot](https://en.wikipedia.org/wiki/Smoot) | `smoots`, `smoot` |
-| [Steradian](https://en.wikipedia.org/wiki/Steradian) | `steradian`, `steradians`, `sr` |
-| [Stokes](https://en.wikipedia.org/wiki/Viscosity#Units) | `stokes`, `St` |
-| [Stoney length](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_length` |
-| [Stoney mass](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_mass` |
-| [Stoney time](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_time` |
-| Swimming pool | `swimmingpool` |
-| [Swiss franc](https://en.wikipedia.org/wiki/Swiss_franc) | `swiss_franc`, `CHF` |
-| [Tablespoon](https://en.wikipedia.org/wiki/Tablespoon) | `tablespoons`, `tablespoon`, `tbsp` |
-| [Teaspoon](https://en.wikipedia.org/wiki/Teaspoon) | `teaspoons`, `teaspoon`, `tsp` |
-| [Tesla](https://en.wikipedia.org/wiki/Tesla_(unit)) | `teslas`, `tesla`, `T` |
-| [Thou](https://en.wikipedia.org/wiki/Thousandth_of_an_inch) | `thou`, `mils`, `mil` |
-| [Tonne](https://en.wikipedia.org/wiki/Tonne) | `tonnes`, `tonne`, `tons`, `ton` |
-| [Torr](https://en.wikipedia.org/wiki/Torr) | `torr` |
-| [Turn](https://en.wikipedia.org/wiki/Turn_(angle)) | `turn`, `turns` |
-| [US Dollar](https://en.wikipedia.org/wiki/USD) | `dollars`, `dollar`, `USD`, `$` |
-| [Volt](https://en.wikipedia.org/wiki/Volt) | `volts`, `volt`, `V` |
-| [Watt-hour](https://en.wikipedia.org/wiki/Kilowatt_hour) | `Wh` |
-| [Watt](https://en.wikipedia.org/wiki/Watt) | `watts`, `watt`, `W` |
-| [Weber](https://en.wikipedia.org/wiki/Weber_(unit)) | `webers`, `weber`, `Wb` |
-| [Week](https://en.wikipedia.org/wiki/Week) | `weeks`, `week` |
-| [Yard](https://en.wikipedia.org/wiki/Yard) | `yards`, `yard`, `yd` |
-| [Yen](https://en.wikipedia.org/wiki/Yen) | `yen`, `JPY`, `¥`, `円` |
+| Dimension | Unit name | Identifier(s) |
+| --- | --- | --- |
+| `AbsorbedDose` | [Gray](https://en.wikipedia.org/wiki/Gray_(unit)) | `Gy`, `gray`, `grays` |
+| `Activity` | [Becquerel](https://en.wikipedia.org/wiki/Becquerel) | `Bq`, `becquerel`, `becquerels` |
+| `AmountOfSubstance` | [Mole](https://en.wikipedia.org/wiki/Mole_(unit)) | `mol`, `mole`, `moles` |
+| `Angle` | [Minute of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcmin`, `arcminute`, `arcminutes` |
+| `Angle` | [Second of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcsec`, `arcsecond`, `arcseconds` |
+| `Angle` | [Degree](https://en.wikipedia.org/wiki/Degree_(angle)) | `deg`, `degree`, `degrees`, `°` |
+| `Angle` | [Gradian](https://en.wikipedia.org/wiki/Gradian) | `gon` |
+| `Angle` | [Radian](https://en.wikipedia.org/wiki/Radian) | `rad`, `radian`, `radians` |
+| `Angle` | [Revolution](https://en.wikipedia.org/wiki/Revolution_(unit)) | `rev`, `revolution`, `revolutions` |
+| `Angle` | [Turn](https://en.wikipedia.org/wiki/Turn_(geometry)) | `turn`, `turns` |
+| `Area` | [Acre](https://en.wikipedia.org/wiki/Acre) | `acre`, `acres` |
+| `Area` | [Are](https://en.wikipedia.org/wiki/Are_(unit)) | `are` |
+| `Area` | [Barn](https://en.wikipedia.org/wiki/Barn_(unit)) | `barn`, `barns` |
+| `Area` | [Football field](https://en.wikipedia.org/wiki/Football_pitch) | `footballfield` |
+| `Area` | [Hectare](https://en.wikipedia.org/wiki/Hectare) | `ha`, `hectare`, `hectares` |
+| `Capacitance` | [Farad](https://en.wikipedia.org/wiki/Farad) | `F`, `farad`, `farads` |
+| `CatalyticActivity` | [Katal](https://en.wikipedia.org/wiki/Katal) | `kat`, `katal`, `katals` |
+| `Current` | [Ampere](https://en.wikipedia.org/wiki/Ampere) | `A`, `ampere`, `amperes` |
+| `DigitalInformation` | [Bit](https://en.wikipedia.org/wiki/Bit) | `bit`, `bits` |
+| `DigitalInformation` | [Byte](https://en.wikipedia.org/wiki/Byte) | `B`, `Byte`, `Bytes`, `Octet`, `Octets`, `byte`, `bytes`, `octet`, `octets` |
+| `DigitalInformation / Time` | [Bits per second](https://en.wikipedia.org/wiki/Bit_per_second) | `bps` |
+| `Dot` | [Dot](https://en.wikipedia.org/wiki/Dots_per_inch) | `dot`, `dots` |
+| `Dot / Length` | [Dots per inch](https://en.wikipedia.org/wiki/Dots_per_inch) | `dpi` |
+| `DynamicViscosity` | [Poise](https://en.wikipedia.org/wiki/Poise_(unit)) | `poise` |
+| `ElectricCharge` | [Coulomb](https://en.wikipedia.org/wiki/Coulomb) | `C`, `coulomb`, `coulombs` |
+| `ElectricConductance` | [Siemens](https://en.wikipedia.org/wiki/Siemens_(unit)) | `S`, `siemens` |
+| `ElectricResistance` | [Ohm](https://en.wikipedia.org/wiki/Ohm) | `ohm`, `ohms`, `Ω` |
+| `Energy` | [British thermal unit](https://en.wikipedia.org/wiki/British_thermal_unit) | `BTU`, `Btu` |
+| `Energy` | [Calorie](https://en.wikipedia.org/wiki/Calorie) | `cal`, `calorie`, `calories` |
+| `Energy` | [Electronvolt](https://en.wikipedia.org/wiki/Electronvolt) | `eV`, `electronvolt`, `electronvolts` |
+| `Energy` | [Erg](https://en.wikipedia.org/wiki/Erg) | `erg`, `ergs` |
+| `Energy` | [Hartree](https://en.wikipedia.org/wiki/Hartree) | `hartree`, `hartrees` |
+| `Energy` | [Joule](https://en.wikipedia.org/wiki/Joule) | `J`, `joule`, `joules` |
+| `Energy` | [Planck energy](https://en.wikipedia.org/wiki/Planck_energy) | `planck_energy` |
+| `Energy` | [Watt-hour](https://en.wikipedia.org/wiki/Watt_hour) | `Wh`, `watthour` |
+| `EquivalentDose` | [Sievert](https://en.wikipedia.org/wiki/Sievert) | `Sv`, `sievert`, `sieverts` |
+| `Force` | [Dyne](https://en.wikipedia.org/wiki/Dyne) | `dyn`, `dyne` |
+| `Force` | [Kilogram-force](https://en.wikipedia.org/wiki/Kilogram-force) | `kgf`, `kilogram_force` |
+| `Force` | [Newton](https://en.wikipedia.org/wiki/Newton_(unit)) | `N`, `newton`, `newtons` |
+| `Force` | [Ounce-force](https://en.wikipedia.org/wiki/Ounce-force) | `ounce_force`, `ozf` |
+| `Force` | [Pound-force](https://en.wikipedia.org/wiki/Pound_(force)) | `lbf`, `pound_force` |
+| `Force / Volume` | [Mercury](https://en.wikipedia.org/wiki/Mercury_(element)) | `Hg` |
+| `Frame` | [Frame](https://en.wikipedia.org/wiki/Frame_rate) | `frame`, `frames` |
+| `Frame / Time` | [Frames per second](https://en.wikipedia.org/wiki/Frame_rate) | `fps` |
+| `Frequency` | [Hertz](https://en.wikipedia.org/wiki/Hertz) | `Hz`, `hertz` |
+| `Frequency` | [Revolutions per minute](https://en.wikipedia.org/wiki/Revolutions_per_minute) | `RPM`, `rpm` |
+| `Illuminance` | [Lux](https://en.wikipedia.org/wiki/Lux) | `lux`, `lx` |
+| `Inductance` | [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `H`, `henries`, `henry`, `henrys` |
+| `KinematicViscosity` | [Stokes](https://en.wikipedia.org/wiki/Stokes_(unit)) | `St`, `stokes` |
+| `Length` | [Ångström](https://en.wikipedia.org/wiki/Angstrom) | `angstrom`, `angstroms`, `Å` |
+| `Length` | [Astronomical unit](https://en.wikipedia.org/wiki/Astronomical_unit) | `AU`, `astronomicalunit`, `astronomicalunits`, `au` |
+| `Length` | [Bohr](https://en.wikipedia.org/wiki/Hartree_atomic_units) | `bohr` |
+| `Length` | [Fathom](https://en.wikipedia.org/wiki/Fathom) | `fathom`, `fathoms` |
+| `Length` | [Fermi](https://en.wikipedia.org/wiki/Femtometre) | `fermi` |
+| `Length` | [Foot](https://en.wikipedia.org/wiki/Foot_(unit)) | `feet`, `foot`, `ft` |
+| `Length` | [Furlong](https://en.wikipedia.org/wiki/Furlong) | `furlong`, `furlongs` |
+| `Length` | [Inch](https://en.wikipedia.org/wiki/Inch) | `in`, `inch`, `inches` |
+| `Length` | [League](https://en.wikipedia.org/wiki/League_(unit)) | `league`, `leagues` |
+| `Length` | [Light-year](https://en.wikipedia.org/wiki/Light-year) | `lightyear`, `lightyears`, `ly` |
+| `Length` | [Metre](https://en.wikipedia.org/wiki/Metre) | `m`, `meter`, `meters`, `metre`, `metres` |
+| `Length` | [Micron](https://en.wikipedia.org/wiki/Micrometre) | `micron` |
+| `Length` | [Mile](https://en.wikipedia.org/wiki/Mile) | `mi`, `mile`, `miles` |
+| `Length` | [Nautical Mile](https://en.wikipedia.org/wiki/Nautical_mile) | `NM`, `nautical_mile`, `nautical_miles`, `nmi` |
+| `Length` | [Parsec](https://en.wikipedia.org/wiki/Parsec) | `parsec`, `parsecs`, `pc` |
+| `Length` | [Planck length](https://en.wikipedia.org/wiki/Planck_length) | `planck_length` |
+| `Length` | [US rod](https://en.wikipedia.org/wiki/Rod_(unit)) | `perch`, `rod`, `rods` |
+| `Length` | [Smoot](https://en.wikipedia.org/wiki/Smoot) | `smoot` |
+| `Length` | [Stoney length](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_length` |
+| `Length` | [Thousandth of an inch](https://en.wikipedia.org/wiki/Thousandth_of_an_inch) | `mil`, `mils`, `thou` |
+| `Length` | [Yard](https://en.wikipedia.org/wiki/Yard) | `yard`, `yards`, `yd` |
+| `Length / Volume` | [Miles per gallon](https://en.wikipedia.org/wiki/Fuel_economy_in_automobiles) | `mpg` |
+| `LuminousFlux` | [Lumen](https://en.wikipedia.org/wiki/Lumen_(unit)) | `lm`, `lumen`, `lumens` |
+| `LuminousIntensity` | [Candela](https://en.wikipedia.org/wiki/Candela) | `candela`, `candelas`, `cd` |
+| `MagneticFieldStrength` | [Oersted](https://en.wikipedia.org/wiki/Oersted) | `Oe`, `oersted` |
+| `MagneticFlux` | [Maxwell](https://en.wikipedia.org/wiki/Maxwell_(unit)) | `Mx`, `maxwell` |
+| `MagneticFlux` | [Weber](https://en.wikipedia.org/wiki/Weber_(unit)) | `Wb`, `weber`, `webers` |
+| `MagneticFluxDensity` | [Gauss](https://en.wikipedia.org/wiki/Gauss_(unit)) | `gauss` |
+| `MagneticFluxDensity` | [Tesla](https://en.wikipedia.org/wiki/Tesla_(unit)) | `T`, `tesla`, `teslas` |
+| `Mass` | [Dalton](https://en.wikipedia.org/wiki/Dalton) | `Da`, `dalton`, `daltons` |
+| `Mass` | [Firkin](https://en.wikipedia.org/wiki/Firkin_(unit)) | `firkin`, `firkins` |
+| `Mass` | [Gram](https://en.wikipedia.org/wiki/Gram) | `g`, `gram`, `gramme`, `grammes`, `grams` |
+| `Mass` | [Ounce](https://en.wikipedia.org/wiki/Ounce) | `ounce`, `ounces`, `oz` |
+| `Mass` | [Planck mass](https://en.wikipedia.org/wiki/Planck_mass) | `planck_mass` |
+| `Mass` | [Pound](https://en.wikipedia.org/wiki/Pound_(mass)) | `lb`, `lbs`, `pound`, `pounds` |
+| `Mass` | [Stoney mass](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_mass` |
+| `Mass` | [Tonne](https://en.wikipedia.org/wiki/Tonne) | `metricton`, `ton`, `tonne`, `tonnes`, `tons` |
+| `Molality` | [Molal](https://en.wikipedia.org/wiki/Molality) | `molal` |
+| `Molarity` | [Molar](https://en.wikipedia.org/wiki/Molar_concentration) | `molar` |
+| `Money` | [Australian dollar](https://en.wikipedia.org/wiki/Australian_dollar) | `A$`, `AUD`, `australian_dollar`, `australian_dollars` |
+| `Money` | [Pound sterling](https://en.wikipedia.org/wiki/Pound_sterling) | `GBP`, `british_pound`, `pound_sterling`, `£` |
+| `Money` | [Canadian dollar](https://en.wikipedia.org/wiki/Canadian_dollar) | `C$`, `CAD`, `canadian_dollar`, `canadian_dollars` |
+| `Money` | [US dollar](https://en.wikipedia.org/wiki/United_States_dollar) | `$`, `USD`, `dollar`, `dollars` |
+| `Money` | [Euro](https://en.wikipedia.org/wiki/Euro) | `EUR`, `euro`, `euros`, `€` |
+| `Money` | [Chinese yuan](https://en.wikipedia.org/wiki/Renminbi) | `CNY`, `renminbi`, `元` |
+| `Money` | [Swiss franc](https://en.wikipedia.org/wiki/Swiss_franc) | `CHF`, `swiss_franc`, `swiss_francs` |
+| `Money` | [Japanese yen](https://en.wikipedia.org/wiki/Japanese_yen) | `JPY`, `yen`, `yens`, `¥`, `円` |
+| `Person` | Person | `capita`, `people`, `person`, `persons` |
+| `Piece` | Piece | `piece`, `pieces` |
+| `Pixel` | [Pixel](https://en.wikipedia.org/wiki/Pixel) | `pixel`, `pixels`, `px` |
+| `Pixel / Length` | [Pixels per inch](https://en.wikipedia.org/wiki/Pixels_per_inch) | `ppi` |
+| `Power` | [Metric horsepower](https://en.wikipedia.org/wiki/Horsepower) | `horsepower`, `hp` |
+| `Power` | [Watt](https://en.wikipedia.org/wiki/Watt) | `W`, `watt`, `watts` |
+| `Pressure` | [Standard atmosphere](https://en.wikipedia.org/wiki/Standard_atmosphere_(unit)) | `atm`, `atmosphere`, `atmospheres` |
+| `Pressure` | [Bar](https://en.wikipedia.org/wiki/Bar_(unit)) | `bar`, `bars` |
+| `Pressure` | [Inch of mercury](https://en.wikipedia.org/wiki/Inch_of_mercury) | `inHg` |
+| `Pressure` | [Millimeter of mercury](https://en.wikipedia.org/wiki/Millimeter_of_mercury) | `mmHg` |
+| `Pressure` | [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit)) | `Pa`, `pascal`, `pascals` |
+| `Pressure` | [Pound-force per square inch](https://en.wikipedia.org/wiki/Pounds_per_square_inch) | `PSI`, `psi` |
+| `Pressure` | [Torr](https://en.wikipedia.org/wiki/Torr) | `torr` |
+| `Scalar` | [Billion](https://en.wikipedia.org/wiki/Billion) | `billion` |
+| `Scalar` | dozen | `dozen` |
+| `Scalar` | [Hundred](https://en.wikipedia.org/wiki/100_(number)) | `hundred` |
+| `Scalar` | [Million](https://en.wikipedia.org/wiki/Million) | `million` |
+| `Scalar` | [Parts per billion](https://en.wikipedia.org/wiki/Parts-per_notation) | `partsperbillion`, `ppb` |
+| `Scalar` | [Parts per million](https://en.wikipedia.org/wiki/Parts-per_notation) | `partspermillion`, `ppm` |
+| `Scalar` | [Parts per quadrillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `partsperquadrillion`, `ppq` |
+| `Scalar` | [Parts per trillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `partspertrillion`, `ppt` |
+| `Scalar` | [Percent](https://en.wikipedia.org/wiki/Percentage) | `%`, `pct`, `percent` |
+| `Scalar` | [Quadrillion](https://en.wikipedia.org/wiki/Quadrillion) | `quadrillion` |
+| `Scalar` | [Quintillion](https://en.wikipedia.org/wiki/Quintillion) | `quintillion` |
+| `Scalar` | [Thousand](https://en.wikipedia.org/wiki/1000_(number)) | `thousand` |
+| `Scalar` | [Trillion](https://en.wikipedia.org/wiki/Trillion) | `trillion` |
+| `SolidAngle` | [Steradian](https://en.wikipedia.org/wiki/Steradian) | `sr`, `steradian`, `steradians` |
+| `Temperature` | [Kelvin](https://en.wikipedia.org/wiki/Kelvin) | `K`, `kelvin`, `kelvins` |
+| `Temperature` | [Planck temperature](https://en.wikipedia.org/wiki/Planck_temperature) | `planck_temperature` |
+| `Time` | [Century](https://en.wikipedia.org/wiki/Century) | `centuries`, `century` |
+| `Time` | [Day](https://en.wikipedia.org/wiki/Day) | `d`, `day`, `days` |
+| `Time` | [Decade](https://en.wikipedia.org/wiki/Decade) | `decade`, `decades` |
+| `Time` | [Fortnight](https://en.wikipedia.org/wiki/Fortnight) | `fortnight`, `fortnights` |
+| `Time` | [Hour](https://en.wikipedia.org/wiki/Hour) | `h`, `hour`, `hours`, `hr` |
+| `Time` | [Julian year](https://en.wikipedia.org/wiki/Julian_year_(astronomy)) | `julian_year`, `julian_years` |
+| `Time` | [Millennium](https://en.wikipedia.org/wiki/Millennium) | `millennia`, `millennium` |
+| `Time` | [Minute](https://en.wikipedia.org/wiki/Minute) | `min`, `minute`, `minutes` |
+| `Time` | [Month](https://en.wikipedia.org/wiki/Month) | `month`, `months` |
+| `Time` | [Planck time](https://en.wikipedia.org/wiki/Planck_time) | `planck_time` |
+| `Time` | [Second](https://en.wikipedia.org/wiki/Second) | `s`, `sec`, `second`, `seconds` |
+| `Time` | [Sidereal day](https://en.wikipedia.org/wiki/Sidereal_time#Sidereal_day) | `sidereal_day`, `sidereal_days` |
+| `Time` | [Stoney time](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_time` |
+| `Time` | [Week](https://en.wikipedia.org/wiki/Week) | `week`, `weeks` |
+| `Time` | [Gregorian year](https://en.wikipedia.org/wiki/Gregorian_year) | `year`, `years`, `yr` |
+| `Velocity` | [Knot](https://en.wikipedia.org/wiki/Knot_(unit)) | `kn`, `knot`, `knots`, `kt` |
+| `Velocity` | [Kilometres per hour](https://en.wikipedia.org/wiki/Kilometres_per_hour) | `kph` |
+| `Velocity` | [Miles per hour](https://en.wikipedia.org/wiki/Miles_per_hour) | `mph` |
+| `Voltage` | [Volt](https://en.wikipedia.org/wiki/Volt) | `V`, `volt`, `volts` |
+| `Volume` | [Cubic centimetre](https://en.wikipedia.org/wiki/Cubic_centimetre) | `cc`, `ccm` |
+| `Volume` | [US cup](https://en.wikipedia.org/wiki/Cup_(unit)) | `cup`, `cups` |
+| `Volume` | [US fluid ounce](https://en.wikipedia.org/wiki/Fluid_ounce) | `floz`, `fluidounce`, `fluidounces` |
+| `Volume` | [US liquid gallon](https://en.wikipedia.org/wiki/Gallon) | `gal`, `gallon`, `gallons` |
+| `Volume` | [US hogshead](https://en.wikipedia.org/wiki/Hogshead) | `hogshead`, `hogsheads` |
+| `Volume` | [Litre](https://en.wikipedia.org/wiki/Litre) | `L`, `l`, `liter`, `liters`, `litre`, `litres` |
+| `Volume` | [US liquid pint](https://en.wikipedia.org/wiki/Pint) | `pint`, `pints` |
+| `Volume` | [Swimming pool](https://en.wikipedia.org/wiki/Olympic-size_swimming_pool) | `swimmingpool` |
+| `Volume` | [US tablespoon](https://en.wikipedia.org/wiki/Tablespoon) | `tablespoon`, `tablespoons`, `tbsp` |
+| `Volume` | [US teaspoon](https://en.wikipedia.org/wiki/Teaspoon) | `teaspoon`, `teaspoons`, `tsp` |

--- a/numbat/examples/inspect.rs
+++ b/numbat/examples/inspect.rs
@@ -1,0 +1,35 @@
+use itertools::Itertools;
+use numbat::{module_importer::FileSystemImporter, resolver::CodeSource, Context};
+
+fn main() {
+    let mut importer = FileSystemImporter::default();
+    importer.add_path("numbat/modules");
+    let mut ctx = Context::new(importer);
+    let result = ctx.interpret("use all", CodeSource::Internal).unwrap();
+    assert!(result.1.is_success());
+
+    println!("| Dimension | Unit name | Identifier(s) |");
+    println!("| --- | --- | --- |");
+    for (ref unit_name, (_base_representation, unit_metadata)) in ctx
+        .unit_representations()
+        .sorted_by_key(|(u, (_, m))| (m.readable_type.to_string(), u.to_lowercase()))
+    {
+        let mut names = unit_metadata.aliases;
+        names.sort_by_key(|n| n.to_lowercase());
+        names.sort();
+        let names = names.join("`, `");
+
+        let url = unit_metadata.url;
+        let name = unit_metadata.name.unwrap_or(unit_name.clone());
+
+        let name_with_url = if let Some(url) = url {
+            format!("[{name}]({url})")
+        } else {
+            name.clone()
+        };
+
+        let readable_type = unit_metadata.readable_type;
+
+        println!("| `{readable_type}` | {name_with_url} | `{names}` |");
+    }
+}

--- a/numbat/examples/unit_graph.rs
+++ b/numbat/examples/unit_graph.rs
@@ -5,15 +5,15 @@
 //
 
 use itertools::Itertools;
-use numbat::{module_importer::FileSystemImporter, resolver::CodeSource, Context};
+use numbat::{
+    module_importer::FileSystemImporter, resolver::CodeSource, BaseRepresentationFactor, Context,
+};
 
 fn main() {
     let mut importer = FileSystemImporter::default();
     importer.add_path("numbat/modules");
     let mut ctx = Context::new(importer);
-    let result = ctx
-        .interpret("use prelude\nuse units::currencies", CodeSource::Internal)
-        .unwrap();
+    let result = ctx.interpret("use all", CodeSource::Internal).unwrap();
     assert!(result.1.is_success());
 
     println!("digraph G {{");
@@ -26,8 +26,15 @@ fn main() {
         println!("  {unit_name} [color=\"#eaea5e\",style=filled,shape=doublecircle]");
     }
 
-    for (ref unit_name, base_representation) in
-        ctx.unit_representations().sorted_by_key(|(_, b)| b.clone())
+    for (ref unit_name, base_representation) in ctx.unit_representations().map(|(u, b)| {
+        (
+            u,
+            b.0.iter()
+                .map(|BaseRepresentationFactor(name, exp)| (name.clone(), exp.to_integer()))
+                .collect::<Vec<_>>(),
+        )
+    })
+    // TODO: check if to_integer can fail here.sorted_by_key(|(_, b)| b.clone())
     {
         let is_base = base_representation == vec![(unit_name.into(), 1i128)];
 

--- a/numbat/modules/all.nbt
+++ b/numbat/modules/all.nbt
@@ -1,0 +1,4 @@
+use prelude
+use units::currencies
+use units::stoney
+use units::hartree

--- a/numbat/modules/math/constants.nbt
+++ b/numbat/modules/math/constants.nbt
@@ -13,13 +13,33 @@ let golden_ratio = φ
 
 #### Large numbers
 
-unit hundred =  100
-unit thousand =  1_000
-unit million =  1_000_000
-unit billion =  10^9
-unit trillion =  10^12
-unit quadrillion =  10^15
-unit quintillion =  10^18
+@name("Hundred")
+@url("https://en.wikipedia.org/wiki/100_(number)")
+unit hundred = 100
+
+@name("Thousand")
+@url("https://en.wikipedia.org/wiki/1000_(number)")
+unit thousand = 1_000
+
+@name("Million")
+@url("https://en.wikipedia.org/wiki/Million")
+unit million = 1_000_000
+
+@name("Billion")
+@url("https://en.wikipedia.org/wiki/Billion")
+unit billion = 10^9
+
+@name("Trillion")
+@url("https://en.wikipedia.org/wiki/Trillion")
+unit trillion = 10^12
+
+@name("Quadrillion")
+@url("https://en.wikipedia.org/wiki/Quadrillion")
+unit quadrillion = 10^15
+
+@name("Quintillion")
+@url("https://en.wikipedia.org/wiki/Quintillion")
+unit quintillion = 10^18
 
 let googol =  10^100
 

--- a/numbat/modules/units/astronomical.nbt
+++ b/numbat/modules/units/astronomical.nbt
@@ -1,12 +1,18 @@
 use units::si
 
+@name("Parsec")
+@url("https://en.wikipedia.org/wiki/Parsec")
 @metric_prefixes
 @aliases(parsecs, pc: short)
 unit parsec: Length = 648_000 / π × au
 
+@name("Light-year")
+@url("https://en.wikipedia.org/wiki/Light-year")
 @metric_prefixes
 @aliases(lightyears, ly: short)
 unit lightyear: Length = 9_460_730_472_580_800 m
 
+@name("Sidereal day")
+@url("https://en.wikipedia.org/wiki/Sidereal_time#Sidereal_day")
 @aliases(sidereal_days)
 unit sidereal_day: Time = 86164.0905 s

--- a/numbat/modules/units/bit.nbt
+++ b/numbat/modules/units/bit.nbt
@@ -2,16 +2,22 @@ use units::si
 
 dimension DigitalInformation
 
+@name("Bit")
+@url("https://en.wikipedia.org/wiki/Bit")
 @metric_prefixes
 @binary_prefixes
 @aliases(bit: both, bits: both)
 unit bit: DigitalInformation
 
+@name("Byte")
+@url("https://en.wikipedia.org/wiki/Byte")
 @metric_prefixes
 @binary_prefixes
 @aliases(B: short, byte: both, bytes: both, Byte: both, Bytes: both, octet, octets, Octet, Octets)
 unit byte: DigitalInformation = 8 bit
 
+@name("Bits per second")
+@url("https://en.wikipedia.org/wiki/Bit_per_second")
 @metric_prefixes
 @aliases(bps: short)
 unit bps: DigitalInformation / Time = bit / second

--- a/numbat/modules/units/cgs.nbt
+++ b/numbat/modules/units/cgs.nbt
@@ -2,24 +2,38 @@ use units::si
 
 ### Centimetre–gram–second system of units
 
+@name("Dyne")
+@url("https://en.wikipedia.org/wiki/Dyne")
 @aliases(dyn)
 unit dyne: Force = 1e-5 N
 
+@name("Erg")
+@url("https://en.wikipedia.org/wiki/Erg")
 @aliases(ergs)
 unit erg: Energy = 1 dyn cm
 
+@name("Gauss")
+@url("https://en.wikipedia.org/wiki/Gauss_(unit)")
 unit gauss: MagneticFluxDensity = 100 µT
 
+@name("Maxwell")
+@url("https://en.wikipedia.org/wiki/Maxwell_(unit)")
 @aliases(Mx)
 unit maxwell: MagneticFlux = 1 gauss × cm^2
 
+@name("Oersted")
+@url("https://en.wikipedia.org/wiki/Oersted")
 @metric_prefixes
 @aliases(Oe: short)
 unit oersted: MagneticFieldStrength = 1 / (4 pi) * dyne / maxwell
 
+@name("Poise")
+@url("https://en.wikipedia.org/wiki/Poise_(unit)")
 @metric_prefixes
 unit poise: DynamicViscosity = 1 dyn × s / cm^2
 
+@name("Stokes")
+@url("https://en.wikipedia.org/wiki/Stokes_(unit)")
 @metric_prefixes
 @aliases(St: short)
 unit stokes: KinematicViscosity = cm^2 / s

--- a/numbat/modules/units/currencies.nbt
+++ b/numbat/modules/units/currencies.nbt
@@ -8,23 +8,37 @@ use units::currency
 
 fn exchange_rate(currency: String) -> Scalar
 
+@name("US dollar")
+@url("https://en.wikipedia.org/wiki/United_States_dollar")
 @aliases(dollars, USD, $: short)
 unit dollar: Money = EUR / exchange_rate("USD")
 
+@name("Japanese yen")
+@url("https://en.wikipedia.org/wiki/Japanese_yen")
 @aliases(yens, JPY, ¥: short, 円)
 unit yen: Money = EUR / exchange_rate("JPY")
 
+@name("Pound sterling")
+@url("https://en.wikipedia.org/wiki/Pound_sterling")
 @aliases(pound_sterling, GBP, £: short)
 unit british_pound: Money = EUR / exchange_rate("GBP")
 
+@name("Chinese yuan")
+@url("https://en.wikipedia.org/wiki/Renminbi")
 @aliases(CNY: short, 元)
 unit renminbi: Money = EUR / exchange_rate("CNY")
 
+@name("Australian dollar")
+@url("https://en.wikipedia.org/wiki/Australian_dollar")
 @aliases(australian_dollars, AUD: short, A$)
 unit australian_dollar: Money = EUR / exchange_rate("AUD")
 
+@name("Canadian dollar")
+@url("https://en.wikipedia.org/wiki/Canadian_dollar")
 @aliases(canadian_dollars, CAD: short, C$)
 unit canadian_dollar: Money = EUR / exchange_rate("CAD")
 
+@name("Swiss franc")
+@url("https://en.wikipedia.org/wiki/Swiss_franc")
 @aliases(swiss_francs, CHF: short)
 unit swiss_franc: Money = EUR / exchange_rate("CHF")

--- a/numbat/modules/units/currency.nbt
+++ b/numbat/modules/units/currency.nbt
@@ -1,5 +1,8 @@
 dimension Money
 
+
+@name("Euro")
+@url("https://en.wikipedia.org/wiki/Euro")
 @aliases(euros, EUR, €: short)
 unit euro: Money
 

--- a/numbat/modules/units/fff.nbt
+++ b/numbat/modules/units/fff.nbt
@@ -3,14 +3,20 @@ use units::imperial
 # The furlong–firkin–fortnight system
 # https://en.wikipedia.org/wiki/FFF_system
 
+@name("Furlong")
+@url("https://en.wikipedia.org/wiki/Furlong")
 @metric_prefixes
 @aliases(furlongs)
 unit furlong: Length = 220 yard
 
+@name("Firkin")
+@url("https://en.wikipedia.org/wiki/Firkin_(unit)")
 @metric_prefixes
 @aliases(firkins)
 unit firkin: Mass = 90 lb
 
+@name("Fortnight")
+@url("https://en.wikipedia.org/wiki/Fortnight")
 @metric_prefixes
 @aliases(fortnights)
 unit fortnight: Time = 14 days

--- a/numbat/modules/units/hartree.nbt
+++ b/numbat/modules/units/hartree.nbt
@@ -1,6 +1,10 @@
 use physics::constants
 
+@name("Hartree")
+@url("https://en.wikipedia.org/wiki/Hartree")
 @aliases(hartrees)
 unit hartree: Energy = ℏ^2 / (electron_mass a0^2)
 
+@name("Bohr")
+@url("https://en.wikipedia.org/wiki/Hartree_atomic_units")
 unit bohr: Length = a0

--- a/numbat/modules/units/humorous.nbt
+++ b/numbat/modules/units/humorous.nbt
@@ -1,6 +1,6 @@
 use units::si
 use units::imperial
 
-# https://en.wikipedia.org/wiki/Smoot
+@name("Smoot")
+@url("https://en.wikipedia.org/wiki/Smoot")
 unit smoot: Length = 5 feet + 7 inch
-

--- a/numbat/modules/units/imperial.nbt
+++ b/numbat/modules/units/imperial.nbt
@@ -3,33 +3,55 @@ use units::misc
 
 ### Imperial unit system
 
+@name("Inch")
+@url("https://en.wikipedia.org/wiki/Inch")
 @aliases(inches, in: short)
 unit inch: Length = 0.0254 meter
 
+@name("Foot")
+@url("https://en.wikipedia.org/wiki/Foot_(unit)")
 @aliases(feet, ft: short)
 unit foot: Length = 12 inch
 
+@name("Yard")
+@url("https://en.wikipedia.org/wiki/Yard")
 @aliases(yards, yd: short)
 unit yard: Length = 3 feet
 
+@name("Mile")
+@url("https://en.wikipedia.org/wiki/Mile")
 @aliases(miles, mi: short)
 unit mile: Length = 1760 yard
 
+@name("Ounce")
+@url("https://en.wikipedia.org/wiki/Ounce")
 @aliases(ounces, oz: short)
 unit ounce: Mass = 28.35 gram
 
+@name("Pound")
+@url("https://en.wikipedia.org/wiki/Pound_(mass)")
 @aliases(pounds, lb: short, lbs)
 unit pound: Mass = 16 ounces
 
+@name("Thousandth of an inch")
+@url("https://en.wikipedia.org/wiki/Thousandth_of_an_inch")
 @aliases(mils, mil: short)
 unit thou: Length = inch / 1000
 
+@name("Fathom")
+@url("https://en.wikipedia.org/wiki/Fathom")
 @aliases(fathoms)
 unit fathom: Length = 2 yard
 
+@name("League")
+@url("https://en.wikipedia.org/wiki/League_(unit)")
 @aliases(leagues)
 unit league: Length = 3 mile
 
+@name("Miles per hour")
+@url("https://en.wikipedia.org/wiki/Miles_per_hour")
 unit mph: Velocity = miles per hour
 
+@name("Inch of mercury")
+@url("https://en.wikipedia.org/wiki/Inch_of_mercury")
 unit inHg: Pressure = in Hg

--- a/numbat/modules/units/misc.nbt
+++ b/numbat/modules/units/misc.nbt
@@ -2,85 +2,136 @@ use units::si
 
 ### Other units
 
+@name("Bar")
+@url("https://en.wikipedia.org/wiki/Bar_(unit)")
 @metric_prefixes
 @aliases(bar: both, bars: both)
 unit bar: Pressure = 100 kPa
 
+@name("Ångström")
+@url("https://en.wikipedia.org/wiki/Angstrom")
 @aliases(angstroms, Å: short)
 unit angstrom: Length = 1e-10 meter
 
+@name("Barn")
+@url("https://en.wikipedia.org/wiki/Barn_(unit)")
 @metric_prefixes
 @aliases(barns)
 unit barn: Area = 1e-28 meter^2
 
+@name("Calorie")
+@url("https://en.wikipedia.org/wiki/Calorie")
 @metric_prefixes
 @aliases(calories, cal: both)
 unit calorie: Energy = 4.184 joule
 
+@name("British thermal unit")
+@url("https://en.wikipedia.org/wiki/British_thermal_unit")
 @aliases(Btu)
 unit BTU: Energy = 1055.05585262 joule
 
+@name("Pound-force")
+@url("https://en.wikipedia.org/wiki/Pound_(force)")
 @aliases(lbf: short)
 unit pound_force: Force = 4.448222 newton
 
+@name("Ounce-force")
+@url("https://en.wikipedia.org/wiki/Ounce-force")
 @aliases(ozf: short)
 unit ounce_force: Force = 1 / 16 * lbf
 
+@name("Kilogram-force")
+@url("https://en.wikipedia.org/wiki/Kilogram-force")
 @aliases(kgf: short)
 unit kilogram_force: Force = 9.80665 newton
 
-# Metric horsepower
+@name("Metric horsepower")
+@url("https://en.wikipedia.org/wiki/Horsepower")
 @aliases(hp: short)
 unit horsepower: Power = 735.49875 W
 
+@name("Revolution")
+@url("https://en.wikipedia.org/wiki/Revolution_(unit)")
 @aliases(revolutions, rev: short)
 unit revolution: Angle = 360°
 
+@name("Revolutions per minute")
+@url("https://en.wikipedia.org/wiki/Revolutions_per_minute")
 @aliases(RPM: short)
 unit rpm: Frequency = 1 / minute
 
+@name("Millimeter of mercury")
+@url("https://en.wikipedia.org/wiki/Millimeter_of_mercury")
 unit mmHg: Pressure = 133.322387415 pascal
 
+@name("Mercury")
+@url("https://en.wikipedia.org/wiki/Mercury_(element)")
 unit Hg: Force / Volume = mmHg / mm
 
+@name("Torr")
+@url("https://en.wikipedia.org/wiki/Torr")
 unit torr: Pressure = 101325 / 760 × pascal
 
+@name("Pound-force per square inch")
+@url("https://en.wikipedia.org/wiki/Pounds_per_square_inch")
 @aliases(PSI: short)
 unit psi: Pressure = 6.894757 kPa
 
+@name("Standard atmosphere")
+@url("https://en.wikipedia.org/wiki/Standard_atmosphere_(unit)")
 @aliases(atmospheres, atm: short)
 unit atmosphere: Pressure = 101_325 pascal
 
+@name("Molar")
+@url("https://en.wikipedia.org/wiki/Molar_concentration")
 @metric_prefixes
 unit molar: Molarity = 1 mol / litre
 
+@name("Molal")
+@url("https://en.wikipedia.org/wiki/Molality")
 @metric_prefixes
 unit molal: Molality = 1 mole / kilogram
 
-# Standard FIFA football pitch
-unit footballfield: Area = 105 m × 68 m
+@name("Football field")
+@url("https://en.wikipedia.org/wiki/Football_pitch")
+unit footballfield: Area = 105 m × 68 m # Standard FIFA football pitch
 
-# Olympic-size swimming pool (FR3)
-unit swimmingpool: Volume = 50 m × 25 m × 2 m
+@name("Swimming pool")
+@url("https://en.wikipedia.org/wiki/Olympic-size_swimming_pool")
+unit swimmingpool: Volume = 50 m × 25 m × 2 m # Olympic-size swimming pool (FR3)
 
 # Angles
 
+@name("Turn")
+@url("https://en.wikipedia.org/wiki/Turn_(geometry)")
 @aliases(turns)
 unit turn: Angle = 2 π rad
 
+@name("Gradian")
+@url("https://en.wikipedia.org/wiki/Gradian")
 unit gon: Angle = 90° / 100
 
 ### Abbreviations
 
+@name("Watt-hour")
+@url("https://en.wikipedia.org/wiki/Watt_hour")
 @metric_prefixes
 @aliases(Wh: short)
 unit watthour: Energy = W h
 
+@name("Kilometres per hour")
+@url("https://en.wikipedia.org/wiki/Kilometres_per_hour")
 unit kph: Velocity = kilometer per hour
 
+@name("Micron")
+@url("https://en.wikipedia.org/wiki/Micrometre")
 unit micron: Length = µm
 
+@name("Cubic centimetre")
+@url("https://en.wikipedia.org/wiki/Cubic_centimetre")
 @aliases(ccm)
 unit cc: Volume = cm^3
 
+@name("Fermi")
+@url("https://en.wikipedia.org/wiki/Femtometre")
 unit fermi: Length = 1 fm

--- a/numbat/modules/units/nautical.nbt
+++ b/numbat/modules/units/nautical.nbt
@@ -1,7 +1,11 @@
 use units::si
 
+@name("Knot")
+@url("https://en.wikipedia.org/wiki/Knot_(unit)")
 @aliases(knots, kn: short, kt: short)
 unit knot: Velocity = 463 m / 900 s
 
+@name("Nautical Mile")
+@url("https://en.wikipedia.org/wiki/Nautical_mile")
 @aliases(nautical_miles, NM: short, nmi: short)
 unit nautical_mile: Length = 1852 m

--- a/numbat/modules/units/partsperx.nbt
+++ b/numbat/modules/units/partsperx.nbt
@@ -1,14 +1,24 @@
+@name("Percent")
+@url("https://en.wikipedia.org/wiki/Percentage")
 @aliases(%: short, pct)
 unit percent = 1e-02
 
+@name("Parts per million")
+@url("https://en.wikipedia.org/wiki/Parts-per_notation")
 @aliases(ppm)
 unit partspermillion = 1e-06
 
+@name("Parts per billion")
+@url("https://en.wikipedia.org/wiki/Parts-per_notation")
 @aliases(ppb)
 unit partsperbillion = 1e-09
 
+@name("Parts per trillion")
+@url("https://en.wikipedia.org/wiki/Parts-per_notation")
 @aliases(ppt)
 unit partspertrillion = 1e-12
 
+@name("Parts per quadrillion")
+@url("https://en.wikipedia.org/wiki/Parts-per_notation")
 @aliases(ppq)
 unit partsperquadrillion = 1e-15

--- a/numbat/modules/units/placeholder.nbt
+++ b/numbat/modules/units/placeholder.nbt
@@ -3,34 +3,47 @@ use units::imperial
 # Smallest addressable element on a digital display
 dimension Pixel
 
+@name("Pixel")
+@url("https://en.wikipedia.org/wiki/Pixel")
 @metric_prefixes
 @aliases(pixels, px: short)
 unit pixel: Pixel
 
+@name("Pixels per inch")
+@url("https://en.wikipedia.org/wiki/Pixels_per_inch")
 unit ppi: Pixel / Length = pixel / inch
 
 
 # Smallest possible output resolution on a printing device
 dimension Dot
 
+@name("Dot")
+@url("https://en.wikipedia.org/wiki/Dots_per_inch")
 @aliases(dots)
 unit dot: Dot
 
+@name("Dots per inch")
+@url("https://en.wikipedia.org/wiki/Dots_per_inch")
 unit dpi: Dot / Length = dots / inch
 
 
 # A single image in a (video) sequence
 dimension Frame
 
+@name("Frame")
+@url("https://en.wikipedia.org/wiki/Frame_rate")
 @aliases(frames)
 unit frame: Frame
 
+@name("Frames per second")
+@url("https://en.wikipedia.org/wiki/Frame_rate")
 unit fps: Frame / Time = frame / second
 
 
 # A separate or limited portion or quantity of something
 dimension Piece
 
+@name("Piece")
 @aliases(pieces)
 unit piece: Piece
 
@@ -38,5 +51,6 @@ unit piece: Piece
 # A human being
 dimension Person
 
+@name("Person")
 @aliases(persons, people, capita)
 unit person: Person

--- a/numbat/modules/units/planck.nbt
+++ b/numbat/modules/units/planck.nbt
@@ -2,17 +2,22 @@
 
 use physics::constants
 
-# Planck length
+@name("Planck length")
+@url("https://en.wikipedia.org/wiki/Planck_length")
 unit planck_length: Length = sqrt(ℏ G / c^3) -> m
 
-# Planck mass
+@name("Planck mass")
+@url("https://en.wikipedia.org/wiki/Planck_mass")
 unit planck_mass: Mass = sqrt(ℏ c / G) -> kg
 
-# Planck time
+@name("Planck time")
+@url("https://en.wikipedia.org/wiki/Planck_time")
 unit planck_time: Time = sqrt(ℏ G / c^5) -> s
 
-# Planck temperature
+@name("Planck temperature")
+@url("https://en.wikipedia.org/wiki/Planck_temperature")
 unit planck_temperature: Temperature = sqrt(ℏ c^5 / (G k_B^2)) -> K
 
-# Planck energy
+@name("Planck energy")
+@url("https://en.wikipedia.org/wiki/Planck_energy")
 unit planck_energy: Energy = sqrt(ℏ c^5 / G) -> J

--- a/numbat/modules/units/si.nbt
+++ b/numbat/modules/units/si.nbt
@@ -3,159 +3,241 @@ use math::constants
 
 ### SI base units
 
+@name("Metre")
+@url("https://en.wikipedia.org/wiki/Metre")
 @metric_prefixes
-@aliases(meters, metre, metres, m: short)
-unit meter: Length
+@aliases(metres, meter, meters, m: short)
+unit metre: Length
 
+@name("Second")
+@url("https://en.wikipedia.org/wiki/Second")
 @metric_prefixes
 @aliases(seconds, s: short, sec: none)
 unit second: Time
 
+@name("Gram")
+@url("https://en.wikipedia.org/wiki/Gram")
 @metric_prefixes
 @aliases(grams, gramme, grammes, g: short)
 unit gram: Mass
 
+@name("Ampere")
+@url("https://en.wikipedia.org/wiki/Ampere")
 @metric_prefixes
 @aliases(amperes, A: short)
 unit ampere: Current
 
+@name("Kelvin")
+@url("https://en.wikipedia.org/wiki/Kelvin")
 @metric_prefixes
 @aliases(kelvins, K: short)
 unit kelvin: Temperature
 
+@name("Mole")
+@url("https://en.wikipedia.org/wiki/Mole_(unit)")
 @metric_prefixes
 @aliases(moles, mol: short)
 unit mole: AmountOfSubstance
 
+@name("Candela")
+@url("https://en.wikipedia.org/wiki/Candela")
 @metric_prefixes
 @aliases(candelas, cd: short)
 unit candela: LuminousIntensity
 
 ### SI derived units
 
+@name("Radian")
+@url("https://en.wikipedia.org/wiki/Radian")
 @metric_prefixes
 @aliases(radians, rad: short)
 unit radian: Angle = meter / meter
 
+@name("Steradian")
+@url("https://en.wikipedia.org/wiki/Steradian")
 @metric_prefixes
 @aliases(steradians, sr: short)
 unit steradian: SolidAngle = radian^2
 
+@name("Hertz")
+@url("https://en.wikipedia.org/wiki/Hertz")
 @metric_prefixes
 @aliases(Hz: short)
 unit hertz: Frequency = 1 / second
 
+@name("Newton")
+@url("https://en.wikipedia.org/wiki/Newton_(unit)")
 @metric_prefixes
 @aliases(newtons, N: short)
 unit newton: Force = kilogram meter / second^2
 
+@name("Pascal")
+@url("https://en.wikipedia.org/wiki/Pascal_(unit)")
 @metric_prefixes
 @aliases(pascals, Pa: short)
 unit pascal: Pressure = newton / meter^2
 
+@name("Joule")
+@url("https://en.wikipedia.org/wiki/Joule")
 @metric_prefixes
 @aliases(joules, J: short)
 unit joule: Energy = newton meter
 
+@name("Watt")
+@url("https://en.wikipedia.org/wiki/Watt")
 @metric_prefixes
 @aliases(watts, W: short)
 unit watt: Power = joule / second
 
+@name("Coulomb")
+@url("https://en.wikipedia.org/wiki/Coulomb")
 @metric_prefixes
 @aliases(coulombs, C: short)
 unit coulomb: ElectricCharge = ampere second
 
+@name("Volt")
+@url("https://en.wikipedia.org/wiki/Volt")
 @metric_prefixes
 @aliases(volts, V: short)
 unit volt: Voltage = kilogram meter^2 / (second^3 ampere)
 
+@name("Farad")
+@url("https://en.wikipedia.org/wiki/Farad")
 @metric_prefixes
 @aliases(farads, F: short)
 unit farad: Capacitance = coulomb / volt
 
+@name("Ohm")
+@url("https://en.wikipedia.org/wiki/Ohm")
 @metric_prefixes
 @aliases(ohms, Ω: short)
 unit ohm: ElectricResistance = volt / ampere
 
+@name("Siemens")
+@url("https://en.wikipedia.org/wiki/Siemens_(unit)")
 @metric_prefixes
 @aliases(S: short)
 unit siemens: ElectricConductance = 1 / ohm
 
+@name("Weber")
+@url("https://en.wikipedia.org/wiki/Weber_(unit)")
 @metric_prefixes
 @aliases(webers, Wb: short)
 unit weber: MagneticFlux = volt second
 
+@name("Tesla")
+@url("https://en.wikipedia.org/wiki/Tesla_(unit)")
 @metric_prefixes
 @aliases(teslas, T: short)
 unit tesla: MagneticFluxDensity = weber / meter^2
 
+@name("Henry")
+@url("https://en.wikipedia.org/wiki/Henry_(unit)")
 @metric_prefixes
 @aliases(henrys, henries, H: short)
 unit henry: Inductance = weber / ampere
 
+@name("Lumen")
+@url("https://en.wikipedia.org/wiki/Lumen_(unit)")
 @metric_prefixes
 @aliases(lumens, lm: short)
 unit lumen: LuminousFlux = candela steradian
 
+@name("Lux")
+@url("https://en.wikipedia.org/wiki/Lux")
 @metric_prefixes
 @aliases(lx: short)
 unit lux: Illuminance = lumen / meter^2
 
+@name("Becquerel")
+@url("https://en.wikipedia.org/wiki/Becquerel")
 @metric_prefixes
 @aliases(becquerels, Bq: short)
 unit becquerel: Activity = 1 / second
 
+@name("Gray")
+@url("https://en.wikipedia.org/wiki/Gray_(unit)")
 @metric_prefixes
 @aliases(grays, Gy: short)
 unit gray: AbsorbedDose = joule / kilogram
 
+@name("Sievert")
+@url("https://en.wikipedia.org/wiki/Sievert")
 @metric_prefixes
 @aliases(sieverts, Sv: short)
 unit sievert: EquivalentDose = joule / kilogram
 
+@name("Katal")
+@url("https://en.wikipedia.org/wiki/Katal")
 @metric_prefixes
 @aliases(katals, kat: short)
 unit katal: CatalyticActivity = mole / second
 
 ### SI accepted units
 
+@name("Minute")
+@url("https://en.wikipedia.org/wiki/Minute")
 @aliases(minutes, min: short)
 unit minute: Time = 60 seconds
 
+@name("Hour")
+@url("https://en.wikipedia.org/wiki/Hour")
 @aliases(hours, hr, h: short)
 unit hour: Time = 60 minutes
 
+@name("Day")
+@url("https://en.wikipedia.org/wiki/Day")
 @aliases(days, day: short, d: short)
 unit day: Time = 24 hours
 
+@name("Astronomical unit")
+@url("https://en.wikipedia.org/wiki/Astronomical_unit")
 @aliases(astronomicalunits, au: short, AU: short)
 unit astronomicalunit: Length = 149_597_870_700 meter
 
+@name("Degree")
+@url("https://en.wikipedia.org/wiki/Degree_(angle)")
 @aliases(degrees, deg, °: short)
 unit degree: Angle = π / 180 × radian
 
+@name("Minute of arc")
+@url("https://en.wikipedia.org/wiki/Minute_and_second_of_arc")
 @aliases(arcminutes, arcmin)
 unit arcminute: Angle = 1 / 60 × degree
 
+@name("Second of arc")
+@url("https://en.wikipedia.org/wiki/Minute_and_second_of_arc")
 @aliases(arcseconds, arcsec)
 unit arcsecond: Angle = 1 / 60 × arcminute
 
+@name("Are")
+@url("https://en.wikipedia.org/wiki/Are_(unit)")
 unit are: Area = (10 m)^2
 
+@name("Hectare")
+@url("https://en.wikipedia.org/wiki/Hectare")
 @aliases(hectares, ha: short)
 unit hectare: Area = 100 are
 
+@name("Litre")
+@url("https://en.wikipedia.org/wiki/Litre")
 @metric_prefixes
 @aliases(litres, liter, liters, l: short, L: short)
 unit litre: Volume = decimeter^3
 
+@name("Tonne")
+@url("https://en.wikipedia.org/wiki/Tonne")
 @metric_prefixes
 @aliases(tonnes, ton: both, tons: both, metricton: none)
 unit tonne: Mass = 10^3 kilogram
 
+@name("Dalton")
+@url("https://en.wikipedia.org/wiki/Dalton")
 @aliases(daltons, Da: short)
 unit dalton: Mass = 1.660539040e-27 kilogram
 
+@name("Electronvolt")
+@url("https://en.wikipedia.org/wiki/Electronvolt")
 @metric_prefixes
 @aliases(electronvolts, eV: short)
 unit electronvolt: Energy = 1.602176634e-19 joule

--- a/numbat/modules/units/stoney.nbt
+++ b/numbat/modules/units/stoney.nbt
@@ -1,7 +1,13 @@
-# See https://en.wikipedia.org/wiki/Stoney_units
-
 use physics::constants
 
+@name("Stoney length")
+@url("https://en.wikipedia.org/wiki/Stoney_units")
 unit stoney_length: Length = sqrt(G × electron_charge^2 / 4 π ε0 c^4)
+
+@name("Stoney mass")
+@url("https://en.wikipedia.org/wiki/Stoney_units")
 unit stoney_mass: Mass = sqrt(electron_charge^2 / 4 π ε0 G)
+
+@name("Stoney time")
+@url("https://en.wikipedia.org/wiki/Stoney_units")
 unit stoney_time: Time = sqrt(G × electron_charge^2 / 4 π ε0 c^6)

--- a/numbat/modules/units/time.nbt
+++ b/numbat/modules/units/time.nbt
@@ -2,25 +2,38 @@ use units::si
 
 ### Time units
 
+@name("Week")
+@url("https://en.wikipedia.org/wiki/Week")
 @aliases(weeks)
 unit week: Time = 7 days
 
-# Gregorian year
+@name("Gregorian year")
+@url("https://en.wikipedia.org/wiki/Gregorian_year")
 @metric_prefixes
 @aliases(year: both, years, yr: short)
 unit year: Time = 365.2425 days
 
+@name("Month")
+@url("https://en.wikipedia.org/wiki/Month")
 @aliases(months)
 unit month: Time = year / 12
 
+@name("Julian year")
+@url("https://en.wikipedia.org/wiki/Julian_year_(astronomy)")
 @aliases(julian_years)
 unit julian_year: Time = 365.25 days
 
+@name("Decade")
+@url("https://en.wikipedia.org/wiki/Decade")
 @aliases(decades)
 unit decade: Time = 10 years
 
+@name("Century")
+@url("https://en.wikipedia.org/wiki/Century")
 @aliases(centuries)
 unit century: Time = 100 years
 
+@name("Millennium")
+@url("https://en.wikipedia.org/wiki/Millennium")
 @aliases(millennia)
 unit millennium: Time = 1000 years

--- a/numbat/modules/units/us_customary.nbt
+++ b/numbat/modules/units/us_customary.nbt
@@ -1,40 +1,51 @@
 use units::si
 use units::imperial
 
-# US liquid gallon
+@name("US liquid gallon")
+@url("https://en.wikipedia.org/wiki/Gallon")
 @aliases(gallons, gal: short)
 unit gallon: Volume = 231 in^3
 
-# US liquid pint
+@name("US liquid pint")
+@url("https://en.wikipedia.org/wiki/Pint")
 @aliases(pints)
 unit pint: Volume = 1/8 × gallon
 
-# US cup
+@name("US cup")
+@url("https://en.wikipedia.org/wiki/Cup_(unit)")
 @aliases(cups)
 unit cup: Volume = 1/2 × pint
 
-# US tablespoon
+@name("US tablespoon")
+@url("https://en.wikipedia.org/wiki/Tablespoon")
 @aliases(tablespoons, tbsp)
 unit tablespoon: Volume = 1/16 × cup
 
-# US teaspoon
+@name("US teaspoon")
+@url("https://en.wikipedia.org/wiki/Teaspoon")
 @aliases(teaspoons, tsp)
 unit teaspoon: Volume = 1/3 × tablespoon
 
-# US fluid ounce
+@name("US fluid ounce")
+@url("https://en.wikipedia.org/wiki/Fluid_ounce")
 @aliases(fluidounces, floz: short)
 unit fluidounce: Volume = 2 tablespoon
 
-# US hogshead
+@name("US hogshead")
+@url("https://en.wikipedia.org/wiki/Hogshead")
 @aliases(hogsheads)
 unit hogshead: Volume = 63 gallon
 
-# US rod
+@name("US rod")
+@url("https://en.wikipedia.org/wiki/Rod_(unit)")
 @aliases(rods, perch)
 unit rod: Length = 16.5 ft
 
+@name("Acre")
+@url("https://en.wikipedia.org/wiki/Acre")
 @aliases(acres)
 unit acre: Area = 4840 yard^2
 
-# Mileage, miles per gallon
+@name("Miles per gallon")
+@url("https://en.wikipedia.org/wiki/Fuel_economy_in_automobiles")
 unit mpg: Length / Volume = miles per gallon

--- a/numbat/src/decorator.rs
+++ b/numbat/src/decorator.rs
@@ -5,6 +5,8 @@ pub enum Decorator {
     MetricPrefixes,
     BinaryPrefixes,
     Aliases(Vec<(String, Option<AcceptsPrefix>)>),
+    Url(String),
+    Name(String),
 }
 
 pub fn name_and_aliases<'a>(
@@ -45,4 +47,22 @@ pub fn get_canonical_unit_name(unit_name: &str, decorators: &[Decorator]) -> Str
         }
     }
     unit_name.into()
+}
+
+pub fn name(decorators: &[Decorator]) -> Option<String> {
+    for decorator in decorators {
+        if let Decorator::Name(name) = decorator {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+pub fn url(decorators: &[Decorator]) -> Option<String> {
+    for decorator in decorators {
+        if let Decorator::Url(url) = decorator {
+            return Some(url.clone());
+        }
+    }
+    None
 }

--- a/numbat/src/dimension.rs
+++ b/numbat/src/dimension.rs
@@ -14,9 +14,10 @@ impl DimensionRegistry {
     ) -> Result<BaseRepresentation> {
         match expression {
             DimensionExpression::Unity(_) => Ok(BaseRepresentation::unity()),
-            DimensionExpression::Dimension(_, name) => {
-                self.registry.get_base_representation_for_name(name)
-            }
+            DimensionExpression::Dimension(_, name) => self
+                .registry
+                .get_base_representation_for_name(name)
+                .map(|r| r.0),
             DimensionExpression::Multiply(_, lhs, rhs) => {
                 let lhs = self.get_base_representation(lhs)?;
                 let rhs = self.get_base_representation(rhs)?;
@@ -36,7 +37,9 @@ impl DimensionRegistry {
     }
 
     pub fn get_base_representation_for_name(&self, name: &str) -> Result<BaseRepresentation> {
-        self.registry.get_base_representation_for_name(name)
+        self.registry
+            .get_base_representation_for_name(name)
+            .map(|t| t.0)
     }
 
     pub fn get_derived_entry_names_for(
@@ -52,6 +55,7 @@ impl DimensionRegistry {
         Ok(self
             .registry
             .get_base_representation_for_name(name)
+            .map(|t| t.0)
             .unwrap())
     }
 
@@ -61,10 +65,12 @@ impl DimensionRegistry {
         expression: &DimensionExpression,
     ) -> Result<BaseRepresentation> {
         let base_representation = self.get_base_representation(expression)?;
-        self.registry.add_derived_entry(name, base_representation)?;
+        self.registry
+            .add_derived_entry(name, base_representation, ())?;
         Ok(self
             .registry
             .get_base_representation_for_name(name)
+            .map(|t| t.0)
             .unwrap())
     }
 

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -546,9 +546,11 @@ impl<'a> Parser<'a> {
                                 ));
                             }
 
+                            let content = token.lexeme.trim_matches('"');
+
                             match decorator.lexeme.as_str() {
-                                "url" => Decorator::Url(token.lexeme.clone()),
-                                "name" => Decorator::Name(token.lexeme.clone()),
+                                "url" => Decorator::Url(content.into()),
+                                "name" => Decorator::Name(content.into()),
                                 _ => unreachable!(),
                             }
                         } else {

--- a/numbat/src/registry.rs
+++ b/numbat/src/registry.rs
@@ -85,7 +85,7 @@ impl PrettyPrint for BaseRepresentation {
 #[derive(Debug, Clone)]
 pub struct Registry<Metadata> {
     base_entries: Vec<(String, Metadata)>,
-    derived_entries: HashMap<String, BaseRepresentation>,
+    derived_entries: HashMap<String, (BaseRepresentation, Metadata)>,
 }
 
 impl<T> Default for Registry<T> {
@@ -97,7 +97,7 @@ impl<T> Default for Registry<T> {
     }
 }
 
-impl<Metadata> Registry<Metadata> {
+impl<Metadata: Clone> Registry<Metadata> {
     pub fn add_base_entry(&mut self, name: &str, metadata: Metadata) -> Result<()> {
         if self.contains(name) {
             return Err(RegistryError::EntryExists(name.to_owned()));
@@ -113,27 +113,24 @@ impl<Metadata> Registry<Metadata> {
     ) -> Vec<String> {
         self.derived_entries
             .iter()
-            .filter(|(_, br)| *br == base_representation)
+            .filter(|(_, (br, _))| br == base_representation)
             .map(|(name, _)| name.clone())
             .sorted_unstable()
             .collect()
-    }
-
-    pub fn is_base_entry(&self, name: &str) -> bool {
-        self.base_entries.iter().any(|(n, _)| n == name)
     }
 
     pub fn add_derived_entry(
         &mut self,
         name: &str,
         base_representation: BaseRepresentation,
+        metadata: Metadata,
     ) -> Result<()> {
         if self.contains(name) {
             return Err(RegistryError::EntryExists(name.to_owned()));
         }
 
         self.derived_entries
-            .insert(name.to_owned(), base_representation);
+            .insert(name.to_owned(), (base_representation, metadata));
 
         Ok(())
     }
@@ -143,12 +140,23 @@ impl<Metadata> Registry<Metadata> {
             || self.derived_entries.contains_key(name)
     }
 
-    pub fn get_base_representation_for_name(&self, name: &str) -> Result<BaseRepresentation> {
-        if self.is_base_entry(name) {
-            Ok(BaseRepresentation::from_factor(BaseRepresentationFactor(
-                name.to_owned(),
-                Rational::from_integer(1),
-            )))
+    pub fn get_base_representation_for_name(
+        &self,
+        name: &str,
+    ) -> Result<(BaseRepresentation, Metadata)> {
+        if let Some(metadata) = self
+            .base_entries
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, m)| m)
+        {
+            Ok((
+                BaseRepresentation::from_factor(BaseRepresentationFactor(
+                    name.to_owned(),
+                    Rational::from_integer(1),
+                )),
+                metadata.clone(),
+            ))
         } else {
             self.derived_entries
                 .get(name)

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -973,6 +973,7 @@ impl TypeChecker {
                         .as_ref()
                         .map(|d| d.pretty_print())
                         .unwrap_or_else(|| type_deduced.to_readable_type(&self.registry)),
+                    Type::Dimension(type_deduced),
                 )
             }
             ast::Statement::DefineFunction {

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -171,7 +171,7 @@ pub enum Statement {
     ),
     DefineDimension(String, Vec<DimensionExpression>),
     DefineBaseUnit(String, Vec<Decorator>, Markup, Type),
-    DefineDerivedUnit(String, Expression, Vec<Decorator>, Markup),
+    DefineDerivedUnit(String, Expression, Vec<Decorator>, Markup, Type),
     ProcedureCall(crate::ast::ProcedureKind, Vec<Expression>),
 }
 
@@ -236,6 +236,12 @@ fn decorator_markup(decorators: &Vec<Decorator>) -> Markup {
                         )
                         .sum()
                         + m::operator(")")
+                }
+                Decorator::Url(url) => {
+                    m::decorator("@url") + m::operator("(") + m::string(url) + m::operator(")")
+                }
+                Decorator::Name(name) => {
+                    m::decorator("@name") + m::operator("(") + m::string(name) + m::operator(")")
                 }
             }
             + m::nl();
@@ -338,7 +344,7 @@ impl PrettyPrint for Statement {
                     + m::space()
                     + readable_type.clone()
             }
-            Statement::DefineDerivedUnit(identifier, expr, decorators, readable_type) => {
+            Statement::DefineDerivedUnit(identifier, expr, decorators, readable_type, _type) => {
                 decorator_markup(decorators)
                     + m::keyword("unit")
                     + m::space()

--- a/numbat/src/unit_registry.rs
+++ b/numbat/src/unit_registry.rs
@@ -1,3 +1,4 @@
+use crate::markup::Markup;
 use crate::registry::{BaseRepresentation, BaseRepresentationFactor, Registry, RegistryError};
 use crate::typed_ast::Type;
 use crate::unit::Unit;
@@ -12,31 +13,45 @@ pub enum UnitRegistryError {
 
 pub type Result<T> = std::result::Result<T, UnitRegistryError>;
 
+#[derive(Debug, Clone)]
+pub struct UnitMetadata {
+    pub type_: Type,
+    pub readable_type: Markup,
+    pub aliases: Vec<String>,
+    pub name: Option<String>,
+    pub url: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct UnitRegistry {
-    pub inner: Registry<Type>,
+    pub inner: Registry<UnitMetadata>,
 }
 
 impl UnitRegistry {
     pub fn new() -> Self {
         Self {
-            inner: Registry::<Type>::default(),
+            inner: Registry::<UnitMetadata>::default(),
         }
     }
 
-    pub fn add_base_unit(&mut self, name: &str, type_: Type) -> Result<()> {
+    pub fn add_base_unit(&mut self, name: &str, metadata: UnitMetadata) -> Result<()> {
         self.inner
-            .add_base_entry(name, type_)
+            .add_base_entry(name, metadata)
             .map_err(UnitRegistryError::RegistryError)
     }
 
-    pub fn add_derived_unit(&mut self, name: &str, base_representation: &Unit) -> Result<()> {
+    pub fn add_derived_unit(
+        &mut self,
+        name: &str,
+        base_representation: &Unit,
+        metadata: UnitMetadata,
+    ) -> Result<()> {
         let base_representation_factors = base_representation
             .iter()
             .map(|factor| BaseRepresentationFactor(factor.unit_id.name.clone(), factor.exponent));
         let base_representation = BaseRepresentation::from_factors(base_representation_factors);
         self.inner
-            .add_derived_entry(name, base_representation)
+            .add_derived_entry(name, base_representation, metadata)
             .map_err(UnitRegistryError::RegistryError)?;
 
         Ok(())


### PR DESCRIPTION
The list of units can now be autogenerated using
```
cargo run --example=inspect
```
This could be further automated later on.

See https://numbat.dev/doc/list-units.html for the rendered output which also includes the physical dimensions now.