### PR TITLE
Add foot-candles unit

### DIFF
--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -53,6 +53,7 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Frame / Time` | [Frames per second](https://en.wikipedia.org/wiki/Frame_rate) | `fps` |
 | `Frequency` | [Hertz](https://en.wikipedia.org/wiki/Hertz) | `Hz`, `hertz` |
 | `Frequency` | [Revolutions per minute](https://en.wikipedia.org/wiki/Revolutions_per_minute) | `RPM`, `rpm` |
+| `Illuminance` | [Foot-candle](https://en.wikipedia.org/wiki/Foot-candle) | `footcandle`, `footcandles`, `fc` |
 | `Illuminance` | [Lux](https://en.wikipedia.org/wiki/Lux) | `lux`, `lx` |
 | `Inductance` | [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `H`, `henries`, `henry`, `henrys` |
 | `KinematicViscosity` | [Stokes](https://en.wikipedia.org/wiki/Stokes_(unit)) | `St`, `stokes` |

--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -53,7 +53,7 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Frame / Time` | [Frames per second](https://en.wikipedia.org/wiki/Frame_rate) | `fps` |
 | `Frequency` | [Hertz](https://en.wikipedia.org/wiki/Hertz) | `Hz`, `hertz` |
 | `Frequency` | [Revolutions per minute](https://en.wikipedia.org/wiki/Revolutions_per_minute) | `RPM`, `rpm` |
-| `Illuminance` | [Foot-candle](https://en.wikipedia.org/wiki/Foot-candle) | `footcandle`, `footcandles`, `fc` |
+| `Illuminance` | [Foot-candle](https://en.wikipedia.org/wiki/Foot-candle) | `fc`, `footcandle`, `footcandles` |
 | `Illuminance` | [Lux](https://en.wikipedia.org/wiki/Lux) | `lux`, `lx` |
 | `Inductance` | [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `H`, `henries`, `henry`, `henrys` |
 | `KinematicViscosity` | [Stokes](https://en.wikipedia.org/wiki/Stokes_(unit)) | `St`, `stokes` |

--- a/numbat/modules/units/us_customary.nbt
+++ b/numbat/modules/units/us_customary.nbt
@@ -49,3 +49,8 @@ unit acre: Area = 4840 yard^2
 @name("Miles per gallon")
 @url("https://en.wikipedia.org/wiki/Fuel_economy_in_automobiles")
 unit mpg: Length / Volume = miles per gallon
+
+@name("Foot-candle")
+@url("https://en.wikipedia.org/wiki/Foot-candle")
+@aliases(footcandles, fc: short)
+unit footcandle: Illuminance = lumen / foot^2


### PR DESCRIPTION
Adds support for foot-candles, analogous to lux: https://en.wikipedia.org/wiki/Foot-candle

Unsure of the `us_customary` location.