### PR TITLE
Better "suggested fix" messages

### DIFF
--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -54,6 +54,17 @@ fn suggested_fix(
     actual_type: &BaseRepresentation,
     actual_name: &str,
 ) -> Option<String> {
+    let actual_name = actual_name.trim();
+
+    // Heuristic 1: if actual_type == 1 / expected_type, suggest
+    // to invert the 'actual' expression:
+    if actual_type == &expected_type.clone().invert() {
+        return Some(format!("invert the {actual_name}"));
+    }
+
+    // Heuristic 2: compute the "missing" factor between the expected
+    // and the actual type. Suggest to multiply / divide with the
+    // appropriate delta.
     let delta_type = expected_type.clone() / actual_type.clone();
 
     let exponent_sum: Rational = delta_type.iter().map(|a| a.1).sum();
@@ -65,8 +76,7 @@ fn suggested_fix(
     };
 
     Some(format!(
-        "{action} the {name} by a factor of dimension {delta_type}",
-        name = actual_name.trim_start(),
+        "{action} the {actual_name} by a factor of dimension {delta_type}"
     ))
 }
 

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -65,6 +65,11 @@ fn suggested_fix(
     // appropriate delta.
     let delta_type = expected_type.clone() / actual_type.clone();
 
+    let num_factors = delta_type.iter().count();
+    if num_factors > 2 {
+        return None; // Do not suggest fixes with complicated dimensions
+    }
+
     let exponent_sum: Rational = delta_type.iter().map(|a| a.1).sum();
 
     let (action, delta_type) = if exponent_sum >= Rational::zero() {

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -79,7 +79,7 @@ fn suggested_fix(
     };
 
     Some(format!(
-        "{action} the {expression_to_change} by a factor of dimension {delta_type}"
+        "{action} the {expression_to_change} by a `{delta_type}` factor"
     ))
 }
 

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -257,8 +257,6 @@ fn test_incompatible_dimension_errors() {
         @r###"
      left hand side: Length / Time            [= Velocity]
     right hand side: Current × Temperature
-
-    Suggested fix: divide the expression on the right hand side by a factor of dimension Current × Temperature × Time / Length
     "###
     );
 

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -238,7 +238,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length  × Mass × Time⁻²    [= Force]
     right hand side: Length² × Mass             [= MomentOfInertia]
 
-    Suggested fix: divide the right hand side by a factor of dimension Length × Time²
+    Suggested fix: divide the expression on the right hand side by a factor of dimension Length × Time²
     "###
     );
 
@@ -248,7 +248,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Scalar    [= Angle, Scalar, SolidAngle]
     right hand side: Length
 
-    Suggested fix: divide the right hand side by a factor of dimension Length
+    Suggested fix: divide the expression on the right hand side by a factor of dimension Length
     "###
     );
 
@@ -258,7 +258,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length / Time            [= Velocity]
     right hand side: Current × Temperature
 
-    Suggested fix: divide the right hand side by a factor of dimension Current × Temperature × Time / Length
+    Suggested fix: divide the expression on the right hand side by a factor of dimension Current × Temperature × Time / Length
     "###
     );
 
@@ -268,7 +268,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length
     right hand side: Length⁻¹    [= Wavenumber]
 
-    Suggested fix: invert the right hand side
+    Suggested fix: invert the expression on the right hand side
     "###
     );
 
@@ -278,7 +278,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length² × Mass × Time⁻³    [= Power]
     right hand side: Length² × Mass × Time⁻²    [= Energy, Torque]
 
-    Suggested fix: divide the right hand side by a factor of dimension Time
+    Suggested fix: divide the expression on the right hand side by a factor of dimension Time
     "###
     );
 
@@ -288,7 +288,7 @@ fn test_incompatible_dimension_errors() {
     parameter type: Scalar    [= Angle, Scalar, SolidAngle]
      argument type: Length
 
-    Suggested fix: divide the argument type by a factor of dimension Length
+    Suggested fix: divide the function argument by a factor of dimension Length
     "###
     );
 
@@ -298,7 +298,7 @@ fn test_incompatible_dimension_errors() {
     specified dimension: Length × Time⁻²    [= Acceleration]
        actual dimension: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the actual dimension by a factor of dimension Time
+    Suggested fix: divide the right hand side expression by a factor of dimension Time
     "###
     );
 
@@ -308,7 +308,7 @@ fn test_incompatible_dimension_errors() {
     specified dimension: Length × Time⁻²    [= Acceleration]
        actual dimension: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the actual dimension by a factor of dimension Time
+    Suggested fix: divide the right hand side expression by a factor of dimension Time
     "###
     );
 
@@ -318,7 +318,7 @@ fn test_incompatible_dimension_errors() {
     specified return type: Length × Time⁻²    [= Acceleration]
        actual return type: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the actual return type by a factor of dimension Time
+    Suggested fix: divide the expression in the function body by a factor of dimension Time
     "###
     );
 }

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -238,7 +238,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length  × Mass × Time⁻²    [= Force]
     right hand side: Length² × Mass             [= MomentOfInertia]
 
-    Suggested fix: divide the expression on the right hand side by a factor of dimension Length × Time²
+    Suggested fix: divide the expression on the right hand side by a `Length × Time²` factor
     "###
     );
 
@@ -248,7 +248,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Scalar    [= Angle, Scalar, SolidAngle]
     right hand side: Length
 
-    Suggested fix: divide the expression on the right hand side by a factor of dimension Length
+    Suggested fix: divide the expression on the right hand side by a `Length` factor
     "###
     );
 
@@ -276,7 +276,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length² × Mass × Time⁻³    [= Power]
     right hand side: Length² × Mass × Time⁻²    [= Energy, Torque]
 
-    Suggested fix: divide the expression on the right hand side by a factor of dimension Time
+    Suggested fix: divide the expression on the right hand side by a `Time` factor
     "###
     );
 
@@ -286,7 +286,7 @@ fn test_incompatible_dimension_errors() {
     parameter type: Scalar    [= Angle, Scalar, SolidAngle]
      argument type: Length
 
-    Suggested fix: divide the function argument by a factor of dimension Length
+    Suggested fix: divide the function argument by a `Length` factor
     "###
     );
 
@@ -296,7 +296,7 @@ fn test_incompatible_dimension_errors() {
     specified dimension: Length × Time⁻²    [= Acceleration]
        actual dimension: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the right hand side expression by a factor of dimension Time
+    Suggested fix: divide the right hand side expression by a `Time` factor
     "###
     );
 
@@ -306,7 +306,7 @@ fn test_incompatible_dimension_errors() {
     specified dimension: Length × Time⁻²    [= Acceleration]
        actual dimension: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the right hand side expression by a factor of dimension Time
+    Suggested fix: divide the right hand side expression by a `Time` factor
     "###
     );
 
@@ -316,7 +316,7 @@ fn test_incompatible_dimension_errors() {
     specified return type: Length × Time⁻²    [= Acceleration]
        actual return type: Length × Time⁻¹    [= Velocity]
 
-    Suggested fix: divide the expression in the function body by a factor of dimension Time
+    Suggested fix: divide the expression in the function body by a `Time` factor
     "###
     );
 }

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -235,31 +235,31 @@ fn test_incompatible_dimension_errors() {
         "kg m / s^2 + kg m^2",
         " left hand side: Length  × Mass × Time⁻²    [= Force]\n\
          right hand side: Length² × Mass             [= MomentOfInertia]\n\n\
-         Suggested fix: multiply left hand side by Length × Time²",
+         Suggested fix: multiply the left hand side by: Length × Time²",
     );
     expect_exact_failure(
         "1 + m",
         " left hand side: Scalar    [= Angle, Scalar, SolidAngle]\n\
          right hand side: Length\n\n\
-         Suggested fix: multiply left hand side by Length",
+         Suggested fix: multiply the left hand side by: Length",
     );
     expect_exact_failure(
         "m / s + K A",
         " left hand side: Length / Time            [= Velocity]\n\
          right hand side: Current × Temperature\n\n\
-         Suggested fix: multiply left hand side by Current × Temperature × Time / Length",
+         Suggested fix: multiply the left hand side by: Current × Temperature × Time / Length",
     );
     expect_exact_failure(
         "m + 1 / m",
         " left hand side: Length\n\
          right hand side: Length⁻¹    [= Wavenumber]\n\n\
-         Suggested fix: multiply right hand side by Length²",
+         Suggested fix: multiply the right hand side by: Length²",
     );
     expect_exact_failure(
         "kW -> J",
         " left hand side: Length² × Mass × Time⁻³    [= Power]\n\
          right hand side: Length² × Mass × Time⁻²    [= Energy, Torque]\n\n\
-         Suggested fix: multiply left hand side by Time",
+         Suggested fix: multiply the left hand side by: Time",
     );
 }
 

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -268,7 +268,7 @@ fn test_incompatible_dimension_errors() {
      left hand side: Length
     right hand side: Length⁻¹    [= Wavenumber]
 
-    Suggested fix: multiply the right hand side by a factor of dimension Length²
+    Suggested fix: invert the right hand side
     "###
     );
 


### PR DESCRIPTION
- [x] Only show suggestions if the X factor in "multiply the rhs/lhs by X" is not too complicated. For example: only if X=D^alpha with a single dimension `D` (base or derived). Something like *"multiply left hand side by Current × Temperature × Time / Length"* is not very helpful.
- [x] For some types of errors, only one thing can be changed by the user. For example: if a function has been defined already, you can only modify the argument type, not the parameter type. In those cases, never show suggestions to change the parameter type. And similar for other types of `IncompatibleDimensionsError`s.
- [x] Think of more sophisticated heuristics for providing even better suggestions. For example: in the `X` vs `1/X` case, do not show a suggestion to multiply the rhs by `X²`, but rather suggest that one side should be inverted?

closes #138