### PR TITLE
Default to `--pretty-print=never` for `-e` and stdin input

### DIFF
--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -29,7 +29,7 @@ fn evaluate_example(context: &mut Context, input: &str) -> m::Markup {
             .fold(m::empty(), |accumulated_mk, single_line| {
                 accumulated_mk + m::nl() + m::whitespace("  ") + single_line.clone() + m::nl()
             })
-            + interpreter_result.to_markup(statements.last(), context.dimension_registry());
+            + interpreter_result.to_markup(statements.last(), context.dimension_registry(), true);
 
     markup
 }

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -174,6 +174,16 @@ pub enum Statement {
     ProcedureCall(crate::ast::ProcedureKind, Vec<Expression>),
 }
 
+impl Statement {
+    pub fn as_expression(&self) -> Option<&Expression> {
+        if let Self::Expression(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 impl Expression {
     pub fn get_type(&self) -> Type {
         match self {


### PR DESCRIPTION
see #237

Pretty sure this is a breaking change since I added a parameter to `InterpreterResult::to_markup()`