### PR TITLE
Better formatting of large numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +819,7 @@ dependencies = [
  "insta",
  "itertools 0.11.0",
  "libc",
+ "num-format",
  "num-integer",
  "num-rational",
  "num-traits",

--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -27,6 +27,7 @@ unicode-ident = "1.0.11"
 unicode-width = "0.1.10"
 libc = "0.2.147"
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path"] }
+num-format = "0.4.4"
 
 [dev-dependencies]
 approx = "0.5"

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -386,8 +386,8 @@ impl PrettyPrint for Statement {
     }
 }
 
-fn pretty_scalar(Number(n): Number) -> Markup {
-    m::value(format!("{n}"))
+fn pretty_scalar(n: Number) -> Markup {
+    m::value(format!("{}", n.pretty_print()))
 }
 
 fn with_parens(expr: &Expression) -> Markup {

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -71,7 +71,7 @@ fn simple_value() {
     expect_failure("0b0.0", "Expected base-2 digit");
 
     expect_output("0o0", "0");
-    expect_output("0o01234567", 0o01234567.to_string());
+    expect_output("0o01234567", "342_391");
     expect_output("0o0_0", "0");
     expect_failure("0o012345678", "Expected base-8 digit");
     expect_failure("0o", "Expected base-8 digit");
@@ -81,7 +81,7 @@ fn simple_value() {
     expect_failure("0o0.0", "Expected base-8 digit");
 
     expect_output("0x0", "0");
-    expect_output("0x0123456789abcdef", "8.19855e16");
+    expect_output("0x0123456789abcdef", "8.19855e+16");
     expect_output("0x0_0", "0");
     expect_failure("0x0123456789abcdefg", "Expected base-16 digit");
     expect_failure("0x", "Expected base-16 digit");
@@ -361,12 +361,12 @@ fn test_last_result_identifier() {
 #[test]
 fn test_misc_examples() {
     expect_output("1920/16*9", "1080");
-    expect_output("2^32", "4294967296");
+    expect_output("2^32", "4_294_967_296");
     expect_output("sqrt(1.4^2 + 1.5^2) * cos(pi/3)^2", "0.512957");
 
     expect_output("2min + 30s", "2.5 min");
     expect_output("2min + 30s -> sec", "150 s");
-    expect_output("4/3 * pi * (6000km)³", "9.04779e11 km³");
+    expect_output("4/3 * pi * (6000km)³", "9.04779e+11 km³");
     expect_output("40kg * 9.8m/s^2 * 150cm", "588 kg·m²/s²");
     expect_output("sin(30°)", "0.5");
 


### PR DESCRIPTION
- Thousands separator for large inters
- Always use '+' in scientific notation (1e+3)

closes #152