### PR TITLE
Flatten main config fields into root config

### DIFF
--- a/book/src/cli-customization.md
+++ b/book/src/cli-customization.md
@@ -48,7 +48,6 @@ numbat --generate-config
 The most important fields are:
 
 ``` toml
-[main]
 # Controls the welcome message. Can be "long", "short", or "off".
 intro-banner = "long"
 

--- a/numbat-cli/src/config.rs
+++ b/numbat-cli/src/config.rs
@@ -24,7 +24,11 @@ pub struct MainConfig {
     pub intro_banner: IntroBanner,
     pub prompt: String,
     pub pretty_print: PrettyPrintMode,
+
+    #[serde(skip_serializing)]
     pub load_prelude: bool,
+
+    #[serde(skip_serializing)]
     pub load_user_init: bool,
 }
 
@@ -71,6 +75,7 @@ impl Default for ExchangeRateConfig {
 #[derive(Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
+    #[serde(flatten)]
     pub main: MainConfig,
     pub exchange_rates: ExchangeRateConfig,
 }


### PR DESCRIPTION
Also, hide `load_prelude` and `load_user_init` from the generated config for now. Not sure if they should stay (in this form).

closes #243 