### PR TITLE
Add only existing modules to imported_modules list

### DIFF
--- a/numbat/src/resolver.rs
+++ b/numbat/src/resolver.rs
@@ -98,8 +98,8 @@ impl Resolver {
             match statement {
                 Statement::ModuleImport(span, module_path) => {
                     if !self.imported_modules.contains(module_path) {
-                        self.imported_modules.push(module_path.clone());
                         if let Some((code, filesystem_path)) = self.importer.import(module_path) {
+                            self.imported_modules.push(module_path.clone());
                             let code_source_id = self.add_code_source(
                                 CodeSource::Module(module_path.clone(), filesystem_path),
                                 &code,


### PR DESCRIPTION
Should fix #254.

Modules were previously always added to the `imported_modules` list, this pull request changes this to only add them if the module can be read without error.

