### PR TITLE
Enhance the help command to print info about a given unit

### DIFF
--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -370,12 +370,12 @@ impl Cli {
                                 println!();
                             }
                             _ => {
-                                if let Some(keyword) = line.strip_prefix("help") {
+                                if let Some(keyword) = line.strip_prefix("info") {
                                     let help = self
                                         .context
                                         .lock()
                                         .unwrap()
-                                        .print_help_for_keyword(keyword.trim());
+                                        .print_info_for_keyword(keyword.trim());
                                     println!("{}", ansi_format(&help, true));
                                     continue;
                                 }

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -370,6 +370,15 @@ impl Cli {
                                 println!();
                             }
                             _ => {
+                                if let Some(keyword) = line.strip_prefix("help") {
+                                    let help = self
+                                        .context
+                                        .lock()
+                                        .unwrap()
+                                        .print_help_for_keyword(keyword.trim());
+                                    println!("{}", ansi_format(&help, true));
+                                    continue;
+                                }
                                 let result = self.parse_and_evaluate(
                                     &line,
                                     CodeSource::Text,

--- a/numbat-cli/tests/integration.rs
+++ b/numbat-cli/tests/integration.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use assert_cmd::Command;
+use predicates::boolean::PredicateBooleanExt;
 
 fn numbat() -> Command {
     let module_path = Path::new(&std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("modules");
@@ -124,4 +125,16 @@ fn help_text() {
         .stdout(predicates::str::contains(
             "Energy of red photons: 1.87855 eV",
         ));
+}
+
+#[test]
+fn info_text() {
+    numbat().write_stdin("info g0").assert().success().stdout(
+        predicates::str::contains("Standard acceleration of gravity on earth")
+            .and(predicates::str::contains("9.80665 m/s²")),
+    );
+
+    numbat().write_stdin("info C").assert().success().stdout(
+        predicates::str::contains("Coulomb").and(predicates::str::contains("1 coulomb = ")),
+    );
 }

--- a/numbat-wasm/src/lib.rs
+++ b/numbat-wasm/src/lib.rs
@@ -175,6 +175,11 @@ impl Numbat {
         self.format(&help_markup(), true).into()
     }
 
+    pub fn print_info(&mut self, keyword: &str) -> JsValue {
+        let output = self.ctx.print_info_for_keyword(keyword);
+        self.format(&output, false).into()
+    }
+
     pub fn get_completions_for(&self, input: &str) -> Vec<JsValue> {
         self.ctx
             .get_completions_for(input, false)

--- a/numbat-wasm/www/index.js
+++ b/numbat-wasm/www/index.js
@@ -68,8 +68,14 @@ function interpret(input) {
   } else if (input_trimmed == "help" || input_trimmed == "?") {
     output = numbat.help();
   } else {
-    var result = numbat.interpret(input);
-    output = result.output;
+    var result = {is_error: false};
+    if (input_trimmed.startsWith("info")) {
+      var keyword = input_trimmed.substring(4).trim();
+      output = numbat.print_info(keyword);
+    } else {
+      result = numbat.interpret(input);
+      output = result.output;
+    }
 
     if (!result.is_error) {
         combined_input += input.trim() + "⏎";

--- a/numbat/modules/math/constants.nbt
+++ b/numbat/modules/math/constants.nbt
@@ -2,12 +2,19 @@ use core::scalar
 
 ### Mathematical
 
-let pi = 3.14159265358979323846264338327950288
-let π = pi
+@url("https://en.wikipedia.org/wiki/Pi")
+@aliases(pi)
+let π = 3.14159265358979323846264338327950288
+
+@url("https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals")
 let τ = 2 π
+
+@url("https://en.wikipedia.org/wiki/E_(mathematical_constant)")
 let e = 2.71828182845904523536028747135266250
+
+@url("https://en.wikipedia.org/wiki/Golden_ratio")
+@aliases(golden_ratio)
 let φ = 1.61803398874989484820458683436563811
-let golden_ratio = φ
 
 ### Named numbers
 
@@ -41,16 +48,23 @@ unit quadrillion = 10^15
 @url("https://en.wikipedia.org/wiki/Quintillion")
 unit quintillion = 10^18
 
+@name("Googol")
+@url("https://en.wikipedia.org/wiki/Googol")
 let googol =  10^100
 
 ### Unicode fractions
 
+@name("One half")
+@url("https://en.wikipedia.org/wiki/One_half")
+@aliases(half, semi)
 let ½ = 1 / 2
 
 let ⅓ = 1 / 3
 let ⅔ = 2 / 3
 
+@aliases(quarter)
 let ¼ = 1 / 4
+
 let ¾ = 3 / 4
 
 let ⅕ = 1 / 5
@@ -74,9 +88,16 @@ let ⅒ = 1 / 10
 
 #### Colloquial
 
-let quarter = 1 / 4
-let half = 1 / 2
-let semi = 1 / 2
-let double = 2
-let triple = 3
+@name("Two")
+@url("https://en.wikipedia.org/wiki/2")
+@aliases(double)
+let two = 2
+
+@name("Three")
+@url("https://en.wikipedia.org/wiki/3")
+@aliases(triple)
+let three = 3
+
+@name("Dozen")
+@url("https://en.wikipedia.org/wiki/Dozen")
 unit dozen = 12

--- a/numbat/modules/math/constants.nbt
+++ b/numbat/modules/math/constants.nbt
@@ -2,16 +2,20 @@ use core::scalar
 
 ### Mathematical
 
+@name("Pi")
 @url("https://en.wikipedia.org/wiki/Pi")
 @aliases(pi)
 let π = 3.14159265358979323846264338327950288
 
+@name("Tau")
 @url("https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals")
 let τ = 2 π
 
+@name("Euler's number")
 @url("https://en.wikipedia.org/wiki/E_(mathematical_constant)")
 let e = 2.71828182845904523536028747135266250
 
+@name("Golden ratio")
 @url("https://en.wikipedia.org/wiki/Golden_ratio")
 @aliases(golden_ratio)
 let φ = 1.61803398874989484820458683436563811
@@ -86,7 +90,11 @@ let ⅑ = 1 / 9
 
 let ⅒ = 1 / 10
 
-#### Colloquial
+#### Integers and colloquial names
+
+@name("One")
+@url("https://en.wikipedia.org/wiki/1")
+let one = 1
 
 @name("Two")
 @url("https://en.wikipedia.org/wiki/2")
@@ -97,6 +105,43 @@ let two = 2
 @url("https://en.wikipedia.org/wiki/3")
 @aliases(triple)
 let three = 3
+
+@name("Four")
+@url("https://en.wikipedia.org/wiki/4")
+@aliases(quadruple)
+let four = 4
+
+@name("Five")
+@url("https://en.wikipedia.org/wiki/5")
+let five = 5
+
+@name("Six")
+@url("https://en.wikipedia.org/wiki/6")
+let six = 6
+
+@name("Seven")
+@url("https://en.wikipedia.org/wiki/7")
+let seven = 7
+
+@name("Eight")
+@url("https://en.wikipedia.org/wiki/8")
+let eight = 8
+
+@name("Nine")
+@url("https://en.wikipedia.org/wiki/9")
+let nine = 9
+
+@name("Ten")
+@url("https://en.wikipedia.org/wiki/10")
+let ten = 10
+
+@name("Eleven")
+@url("https://en.wikipedia.org/wiki/11")
+let eleven = 11
+
+@name("Twelve")
+@url("https://en.wikipedia.org/wiki/12")
+let twelve = 12
 
 @name("Dozen")
 @url("https://en.wikipedia.org/wiki/Dozen")

--- a/numbat/modules/physics/constants.nbt
+++ b/numbat/modules/physics/constants.nbt
@@ -3,78 +3,95 @@ use units::si
 
 ### Physics constants
 
-# The speed of light in vacuum
+@name("Speed of light in vacuum")
+@url("https://en.wikipedia.org/wiki/Speed_of_light")
+@aliases(c)
 let speed_of_light: Velocity = 299_792_458 m / s
-let c = speed_of_light
 
-# The Newtonian constant of gravitation
+@name("Newtonian constant of gravitation")
+@url("https://en.wikipedia.org/wiki/Gravitational_constant")
+@aliases(G)
 let gravitational_constant: Force × Length^2 / Mass^2 =  6.67430e-11 m³ / (kg s²)
-let G = gravitational_constant
 
 # Standard acceleration of gravity on earth
+@url("https://en.wikipedia.org/wiki/Gravity_of_Earth")
+@aliases(g0)
 let gravity: Acceleration = 9.80665 m / s²
-let g0 = gravity
 
 # The Planck constant
+@name("Planck constant")
+@url("https://en.wikipedia.org/wiki/Planck_constant")
+@aliases(ℎ)
 let planck_constant: Action = 6.62607015e-34 J / Hz
-let ℎ = planck_constant
 
 # The reduced Planck constant
+@name("Reduced Planck constant")
+@url("https://en.wikipedia.org/wiki/Planck_constant#Reduced_Planck_constant_%E2%84%8F")
+@aliases(h_bar)
 let ℏ: AngularMomentum = planck_constant / 2π
-let h_bar = ℏ
 
 # Mass of the electron
+@url("https://en.wikipedia.org/wiki/Electron_mass")
 let electron_mass: Mass = 9.1093837015e-31 kg
 
 # Elementary charge (charge of the electron)
+@url("https://en.wikipedia.org/wiki/Elementary_charge")
+@aliases(electron_charge)
 let elementary_charge: ElectricCharge =  1.602176634e-19 C
-let electron_charge: ElectricCharge = elementary_charge
 
 # Magnetic constant (vacuum magnetic permeability)
+@url("https://en.wikipedia.org/wiki/Vacuum_permeability")
+@aliases(µ0,mu0)
 let magnetic_constant: MagneticPermeability =  1.25663706212e-6 N / A²
-let µ0 = magnetic_constant
-let mu0 = magnetic_constant
 
 # Electric constant ( vacuum electric permittivity)
+@url("https://en.wikiversity.org/wiki/Electric_constant")
+@aliases(ε0,eps0)
 let electric_constant: ElectricPermittivity = 8.8541878128e-12 F / m
-let ε0 = electric_constant
-let eps0 = electric_constant
 
 # Bohr magneton
+@aliases(µ_B)
+@url("https://en.wikipedia.org/wiki/Bohr_magneton")
 let bohr_magneton: Energy / MagneticFluxDensity = 9.2740100783e-24 J / T
-let µ_B = bohr_magneton
 
 # Fine structure constant
+@aliases(α, alpha)
+@url("https://en.wikipedia.org/wiki/Fine-structure_constant")
 let fine_structure_constant: Scalar = 7.2973525693e-3
-let α = fine_structure_constant
-let alpha = fine_structure_constant
 
 # Proton mass
+@url("https://en.wikipedia.org/wiki/Proton")
 let proton_mass: Mass =  1.67262192369e-27 kg
 
 # Neutron mass
+@url("https://en.wikipedia.org/wiki/Neutron")
 let neutron_mass: Mass = 1.67492749804e-27 kg
 
 # Avogadro constant
+@url("https://en.wikipedia.org/wiki/Avogadro_constant")
+@aliases(N_A)
 let avogadro_constant: 1 / AmountOfSubstance = 6.02214076e23 / mol
-let N_A = avogadro_constant
 
 # Boltzmann constant
+@aliases(k_B)
 let boltzmann_constant: Energy / Temperature = 1.380649e-23 J / K
-let k_B = boltzmann_constant
 
 # Stefan-Boltzmann constant
+@url("https://en.wikipedia.org/wiki/Boltzmann_constant")
 let stefan_boltzmann_constant: Power / (Area × Temperature^4) = 2 π^5 k_B^4 / (15 planck_constant^3 c^2)
 
 # Ideal gas constant
+@aliases(R)
+@url("https://en.wikipedia.org/wiki/Gas_constant")
 let gas_constant: Energy / (AmountOfSubstance × Temperature) = 8.31446261815324 J / (K mol)
-let R = gas_constant
 
 # Bohr radius
+@url("https://en.wikipedia.org/wiki/Bohr_radius")
+@aliases(a0)
 let bohr_radius: Length = 4 pi ε0 ℏ^2 / (electron_charge^2 electron_mass)
-let a0 = bohr_radius
 
 # Rydberg constant
+@url("https://en.wikipedia.org/wiki/Rydberg_constant")
 let rydberg_constant: Wavenumber = (electron_mass electron_charge^4) / (8 ε0^2 ℎ^3 c)
 
 @name("Rydberg unit of energy")

--- a/numbat/modules/physics/constants.nbt
+++ b/numbat/modules/physics/constants.nbt
@@ -1,8 +1,6 @@
 use math::functions
 use units::si
 
-### Physics constants
-
 @name("Speed of light in vacuum")
 @url("https://en.wikipedia.org/wiki/Speed_of_light")
 @aliases(c)
@@ -13,84 +11,83 @@ let speed_of_light: Velocity = 299_792_458 m / s
 @aliases(G)
 let gravitational_constant: Force × Length^2 / Mass^2 =  6.67430e-11 m³ / (kg s²)
 
-# Standard acceleration of gravity on earth
+@name("Standard acceleration of gravity on earth")
 @url("https://en.wikipedia.org/wiki/Gravity_of_Earth")
 @aliases(g0)
 let gravity: Acceleration = 9.80665 m / s²
 
-# The Planck constant
 @name("Planck constant")
 @url("https://en.wikipedia.org/wiki/Planck_constant")
 @aliases(ℎ)
 let planck_constant: Action = 6.62607015e-34 J / Hz
 
-# The reduced Planck constant
 @name("Reduced Planck constant")
 @url("https://en.wikipedia.org/wiki/Planck_constant#Reduced_Planck_constant_%E2%84%8F")
 @aliases(h_bar)
 let ℏ: AngularMomentum = planck_constant / 2π
 
-# Mass of the electron
+@name("Electron mass")
 @url("https://en.wikipedia.org/wiki/Electron_mass")
 let electron_mass: Mass = 9.1093837015e-31 kg
 
-# Elementary charge (charge of the electron)
+@name("Elementary charge")
 @url("https://en.wikipedia.org/wiki/Elementary_charge")
 @aliases(electron_charge)
 let elementary_charge: ElectricCharge =  1.602176634e-19 C
 
-# Magnetic constant (vacuum magnetic permeability)
+@name("Vacuum permeability / magnetic constant")
 @url("https://en.wikipedia.org/wiki/Vacuum_permeability")
 @aliases(µ0,mu0)
 let magnetic_constant: MagneticPermeability =  1.25663706212e-6 N / A²
 
-# Electric constant ( vacuum electric permittivity)
+@name("Vacuum electric permittivity / electric constant")
 @url("https://en.wikiversity.org/wiki/Electric_constant")
 @aliases(ε0,eps0)
 let electric_constant: ElectricPermittivity = 8.8541878128e-12 F / m
 
-# Bohr magneton
+@name("Bohr magneton")
 @aliases(µ_B)
 @url("https://en.wikipedia.org/wiki/Bohr_magneton")
 let bohr_magneton: Energy / MagneticFluxDensity = 9.2740100783e-24 J / T
 
-# Fine structure constant
-@aliases(α, alpha)
+@name("Fine structure constant")
 @url("https://en.wikipedia.org/wiki/Fine-structure_constant")
+@aliases(α, alpha)
 let fine_structure_constant: Scalar = 7.2973525693e-3
 
-# Proton mass
+@name("Proton mass")
 @url("https://en.wikipedia.org/wiki/Proton")
 let proton_mass: Mass =  1.67262192369e-27 kg
 
-# Neutron mass
+@name("Neutron mass")
 @url("https://en.wikipedia.org/wiki/Neutron")
 let neutron_mass: Mass = 1.67492749804e-27 kg
 
-# Avogadro constant
+@name("Avogadro constant")
 @url("https://en.wikipedia.org/wiki/Avogadro_constant")
 @aliases(N_A)
 let avogadro_constant: 1 / AmountOfSubstance = 6.02214076e23 / mol
 
-# Boltzmann constant
+@name("Boltzmann constant")
+@url("https://en.wikipedia.org/wiki/Boltzmann_constant")
 @aliases(k_B)
 let boltzmann_constant: Energy / Temperature = 1.380649e-23 J / K
 
-# Stefan-Boltzmann constant
-@url("https://en.wikipedia.org/wiki/Boltzmann_constant")
+@name("Stefan-Boltzmann constant")
+@url("https://en.wikipedia.org/wiki/Stefan%E2%80%93Boltzmann_law")
 let stefan_boltzmann_constant: Power / (Area × Temperature^4) = 2 π^5 k_B^4 / (15 planck_constant^3 c^2)
 
-# Ideal gas constant
-@aliases(R)
+@name("Ideal gas constant")
 @url("https://en.wikipedia.org/wiki/Gas_constant")
+@aliases(R)
 let gas_constant: Energy / (AmountOfSubstance × Temperature) = 8.31446261815324 J / (K mol)
 
-# Bohr radius
+@name("Bohr radius")
 @url("https://en.wikipedia.org/wiki/Bohr_radius")
 @aliases(a0)
 let bohr_radius: Length = 4 pi ε0 ℏ^2 / (electron_charge^2 electron_mass)
 
-# Rydberg constant
+@name("Rydberg constant")
 @url("https://en.wikipedia.org/wiki/Rydberg_constant")
 let rydberg_constant: Wavenumber = (electron_mass electron_charge^4) / (8 ε0^2 ℎ^3 c)
 

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -295,6 +295,7 @@ pub enum Statement {
         identifier: String,
         expr: Expression,
         type_annotation: Option<TypeAnnotation>,
+        decorators: Vec<Decorator>,
     },
     DefineFunction {
         function_name_span: Span,
@@ -440,11 +441,13 @@ impl ReplaceSpans for Statement {
                 identifier,
                 expr,
                 type_annotation,
+                decorators,
             } => Statement::DefineVariable {
                 identifier_span: Span::dummy(),
                 identifier: identifier.clone(),
                 expr: expr.replace_spans(),
                 type_annotation: type_annotation.as_ref().map(|t| t.replace_spans()),
+                decorators: decorators.clone(),
             },
             Statement::DefineFunction {
                 function_name_span: _,

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -359,6 +359,16 @@ impl BytecodeInterpreter {
     fn current_depth(&self) -> usize {
         self.locals.len() - 1
     }
+
+    pub fn get_defining_unit(&self, unit_name: &str) -> Option<&Unit> {
+        self.unit_name_to_constant_index
+            .get(unit_name)
+            .and_then(|idx| self.vm.constants.get(*idx as usize))
+            .and_then(|constant| match constant {
+                Constant::Unit(u) => Some(u),
+                _ => None,
+            })
+    }
 }
 
 impl Interpreter for BytecodeInterpreter {

--- a/numbat/src/decorator.rs
+++ b/numbat/src/decorator.rs
@@ -66,3 +66,15 @@ pub fn url(decorators: &[Decorator]) -> Option<String> {
     }
     None
 }
+
+pub fn contains_aliases_with_prefixes(decorates: &[Decorator]) -> bool {
+    for decorator in decorates {
+        if let Decorator::Aliases(aliases) = decorator {
+            if aliases.iter().any(|(_, prefixes)| prefixes.is_some()) {
+                return true;
+            }
+        }
+    }
+
+    false
+}

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -256,7 +256,10 @@ impl Context {
         words.into_iter().filter(move |w| w.starts_with(word_part))
     }
 
-    pub fn print_help_for_keyword(&mut self, keyword: &str) -> Markup {
+    pub fn print_info_for_keyword(&mut self, keyword: &str) -> Markup {
+        if keyword.is_empty() {
+            return m::text("Usage: info <unit or variable>");
+        }
         let reg = self.interpreter.get_unit_registry();
 
         if let PrefixParserResult::UnitIdentifier(_span, prefix, _, full_name) =

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -271,11 +271,11 @@ impl Context {
                 .ok()
                 .map(|(_, md)| md)
             {
-                let mut help =
-                    m::text("Unit: ") + m::unit(md.name.as_deref().unwrap_or(keyword)) + m::nl();
+                let mut help = m::text("Unit: ") + m::unit(md.name.as_deref().unwrap_or(keyword));
                 if let Some(url) = &md.url {
-                    help += m::string(url) + m::nl();
+                    help += m::text(" (") + m::string(url) + m::text(")");
                 }
+                help += m::nl();
                 if md.aliases.len() > 1 {
                     help += m::text("Aliases: ")
                         + m::text(
@@ -300,24 +300,29 @@ impl Context {
                     if !prefix.is_none() {
                         help += m::nl()
                             + m::value("1 ")
-                            + m::type_identifier(keyword)
+                            + m::unit(keyword)
                             + m::text(" = ")
                             + m::value(prefix.factor().pretty_print())
                             + m::space()
-                            + m::type_identifier(&full_name);
+                            + m::unit(&full_name);
                     }
 
                     if let Some(BaseUnitAndFactor(prod, num)) = x {
                         help += m::nl()
                             + m::value("1 ")
-                            + m::type_identifier(&full_name)
+                            + m::unit(&full_name)
                             + m::text(" = ")
                             + m::value(num.pretty_print())
                             + m::space()
-                            + prod.pretty_print_with(|f| f.exponent, 'x', '/', true);
+                            + prod.pretty_print_with(
+                                |f| f.exponent,
+                                'x',
+                                '/',
+                                true,
+                                Some(m::FormatType::Unit),
+                            );
                     } else {
-                        help +=
-                            m::nl() + m::type_identifier(&full_name) + m::text(" is a base unit");
+                        help += m::nl() + m::unit(&full_name) + m::text(" is a base unit");
                     }
                 };
 
@@ -326,12 +331,13 @@ impl Context {
         };
 
         if let Some(l) = self.interpreter.lookup_global(keyword) {
-            let mut help = m::text("Variable: ") + m::identifier(keyword) + m::nl();
+            let mut help = m::text("Variable: ") + m::identifier(keyword);
+            if let Some(url) = &l.metadata.url {
+                help += m::text(" (") + m::string(url) + m::text(")");
+            }
+            help += m::nl();
             if let Some(name) = &l.metadata.name {
                 help += m::text(name) + m::nl();
-            }
-            if let Some(url) = &l.metadata.url {
-                help += m::string(url) + m::nl();
             }
             if l.metadata.aliases.len() > 1 {
                 help += m::text("Aliases: ")

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -288,7 +288,14 @@ impl Context {
                         + m::nl();
                 }
 
-                help += m::text("A unit of [") + md.readable_type + m::text("]") + m::nl();
+                if matches!(md.type_, Type::Dimension(d) if d.is_scalar()) {
+                    help += m::text("A dimensionless unit ([")
+                        + md.readable_type
+                        + m::text("])")
+                        + m::nl();
+                } else {
+                    help += m::text("A unit of [") + md.readable_type + m::text("]") + m::nl();
+                }
 
                 if let Some(defining_info) = self.interpreter.get_defining_unit(&full_name) {
                     let x = defining_info

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -338,14 +338,17 @@ impl Context {
         };
 
         if let Some(l) = self.interpreter.lookup_global(keyword) {
-            let mut help = m::text("Variable: ") + m::identifier(keyword);
+            let mut help = m::text("Variable: ");
+            if let Some(name) = &l.metadata.name {
+                help += m::text(name);
+            } else {
+                help += m::identifier(keyword);
+            }
             if let Some(url) = &l.metadata.url {
                 help += m::text(" (") + m::string(url) + m::text(")");
             }
             help += m::nl();
-            if let Some(name) = &l.metadata.name {
-                help += m::text(name) + m::nl();
-            }
+
             if l.metadata.aliases.len() > 1 {
                 help += m::text("Aliases: ")
                     + m::text(

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -268,7 +268,8 @@ impl Context {
                 .ok()
                 .map(|(_, md)| md)
             {
-                let mut help = m::unit(md.name.as_deref().unwrap_or(keyword)) + m::nl();
+                let mut help =
+                    m::text("Unit: ") + m::unit(md.name.as_deref().unwrap_or(keyword)) + m::nl();
                 if let Some(url) = &md.url {
                     help += m::string(url) + m::nl();
                 }
@@ -320,6 +321,34 @@ impl Context {
                 return help;
             }
         };
+
+        if let Some(l) = self.interpreter.lookup_global(keyword) {
+            let mut help = m::text("Variable: ") + m::identifier(keyword) + m::nl();
+            if let Some(name) = &l.metadata.name {
+                help += m::text(name) + m::nl();
+            }
+            if let Some(url) = &l.metadata.url {
+                help += m::string(url) + m::nl();
+            }
+            if l.metadata.aliases.len() > 1 {
+                help += m::text("Aliases: ")
+                    + m::text(
+                        l.metadata
+                            .aliases
+                            .iter()
+                            .map(|x| x.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    )
+                    + m::nl();
+            }
+
+            if let Ok((_, results)) = self.interpret(keyword, CodeSource::Internal) {
+                help += m::nl() + results.to_markup(None, self.dimension_registry(), true);
+            }
+
+            return help;
+        }
 
         m::text("Not found")
     }

--- a/numbat/src/markup.rs
+++ b/numbat/src/markup.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FormatType {
     Whitespace,
     Emphasized,

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -156,8 +156,11 @@ impl Transformer {
                 identifier,
                 expr,
                 type_annotation,
+                decorators,
             } => {
-                self.variable_names.push(identifier.clone());
+                for (name, _) in decorator::name_and_aliases(&identifier, &decorators) {
+                    self.variable_names.push(name.clone());
+                }
                 self.prefix_parser
                     .add_other_identifier(&identifier, identifier_span)?;
                 Statement::DefineVariable {
@@ -165,6 +168,7 @@ impl Transformer {
                     identifier,
                     expr: self.transform_expression(expr),
                     type_annotation,
+                    decorators,
                 }
             }
             Statement::DefineFunction {

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -10,7 +10,7 @@ type Result<T> = std::result::Result<T, NameResolutionError>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Transformer {
-    prefix_parser: PrefixParser,
+    pub prefix_parser: PrefixParser,
 
     pub variable_names: Vec<String>,
     pub function_names: Vec<String>,

--- a/numbat/src/product.rs
+++ b/numbat/src/product.rs
@@ -25,16 +25,21 @@ pub struct Product<Factor, const CANONICALIZE: bool = false> {
 impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: bool>
     Product<Factor, CANONICALIZE>
 {
+    /// The last argument controls how the factor is formated.
+    ///
+    /// By default it is with `TypeIdentifier`, but `Unit` can be used too.
     pub fn pretty_print_with<GetExponent>(
         &self,
         get_exponent: GetExponent,
         times_separator: char,
         over_separator: char,
         separator_padding: bool,
+        format_type: Option<m::FormatType>,
     ) -> m::Markup
     where
         GetExponent: Fn(&Factor) -> Exponent,
     {
+        let format_type = format_type.unwrap_or(m::FormatType::TypeIdentifier);
         let separator_padding = if separator_padding {
             m::space()
         } else {
@@ -46,7 +51,11 @@ impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: b
             let num_factors = fs.len();
             for (i, factor) in fs.iter().enumerate() {
                 result = result
-                    + m::type_identifier(&factor.to_string()) // TODO: for units, this should be m::unit. This is not a problem so far, since we only plain-text format units
+                    + m::Markup::from(m::FormattedString(
+                        m::OutputType::Normal,
+                        format_type,
+                        factor.to_string(),
+                    ))
                     + if i == num_factors - 1 {
                         m::empty()
                     } else {
@@ -108,6 +117,7 @@ impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: b
                 times_separator,
                 over_separator,
                 separator_padding,
+                None,
             ),
             false,
         )

--- a/numbat/src/registry.rs
+++ b/numbat/src/registry.rs
@@ -77,7 +77,7 @@ impl PrettyPrint for BaseRepresentation {
         if self.iter().count() == 0 {
             crate::markup::type_identifier("Scalar")
         } else {
-            self.pretty_print_with(|f| f.1, '×', '/', true)
+            self.pretty_print_with(|f| f.1, '×', '/', true, None)
         }
     }
 }

--- a/numbat/src/resolver.rs
+++ b/numbat/src/resolver.rs
@@ -187,7 +187,8 @@ mod tests {
                     identifier_span: Span::dummy(),
                     identifier: "a".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
-                    type_annotation: None
+                    type_annotation: None,
+                    decorators: Vec::new(),
                 },
                 Statement::Expression(Expression::Identifier(Span::dummy(), "a".into()))
             ]
@@ -216,7 +217,8 @@ mod tests {
                     identifier_span: Span::dummy(),
                     identifier: "a".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
-                    type_annotation: None
+                    type_annotation: None,
+                    decorators: Vec::new(),
                 },
                 Statement::Expression(Expression::Identifier(Span::dummy(), "a".into()))
             ]
@@ -244,13 +246,15 @@ mod tests {
                     identifier_span: Span::dummy(),
                     identifier: "y".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
-                    type_annotation: None
+                    type_annotation: None,
+                    decorators: Vec::new(),
                 },
                 Statement::DefineVariable {
                     identifier_span: Span::dummy(),
                     identifier: "x".into(),
                     expr: Expression::Identifier(Span::dummy(), "y".into()),
-                    type_annotation: None
+                    type_annotation: None,
+                    decorators: Vec::new(),
                 },
             ]
         );

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -457,7 +457,7 @@ impl TypeChecker {
 
                 match *op {
                     ast::UnaryOperator::Factorial => {
-                        if dtype != DType::unity() {
+                        if !dtype.is_scalar() {
                             return Err(TypeCheckError::NonScalarFactorialArgument(
                                 expr.full_span(),
                                 dtype,
@@ -539,7 +539,7 @@ impl TypeChecker {
                     }
                     typed_ast::BinaryOperator::Power => {
                         let exponent_type = dtype(&rhs_checked)?;
-                        if exponent_type != DType::unity() {
+                        if !exponent_type.is_scalar() {
                             return Err(TypeCheckError::NonScalarExponent(
                                 rhs.full_span(),
                                 exponent_type,
@@ -547,7 +547,7 @@ impl TypeChecker {
                         }
 
                         let base_type = dtype(&lhs_checked)?;
-                        if base_type == DType::unity() {
+                        if base_type.is_scalar() {
                             // Skip evaluating the exponent if the lhs is a scalar. This allows
                             // for arbitrary (decimal) exponents, if the base is a scalar.
 

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -851,6 +851,7 @@ impl TypeChecker {
                 identifier,
                 expr,
                 type_annotation,
+                decorators,
             } => {
                 // Make sure that identifier does not clash with a function name. We do not
                 // check for clashes with unit names, as this is handled by the prefix parser.
@@ -907,13 +908,14 @@ impl TypeChecker {
                     }
                 }
 
-                self.identifiers.insert(
-                    identifier.clone(),
-                    (type_deduced.clone(), Some(*identifier_span)),
-                );
+                for (name, _) in decorator::name_and_aliases(identifier, decorators) {
+                    self.identifiers
+                        .insert(name.clone(), (type_deduced.clone(), Some(*identifier_span)));
+                }
 
                 typed_ast::Statement::DefineVariable(
                     identifier.clone(),
+                    decorators.clone(),
                     expr_checked,
                     type_annotation
                         .as_ref()

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -15,8 +15,11 @@ use crate::{
 pub type DType = BaseRepresentation;
 
 impl DType {
+    pub fn is_scalar(&self) -> bool {
+        self == &DType::unity()
+    }
     pub fn to_readable_type(&self, registry: &DimensionRegistry) -> m::Markup {
-        if self == &DType::unity() {
+        if self.is_scalar() {
             return m::type_identifier("Scalar");
         }
 

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -152,7 +152,7 @@ impl Expression {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     Expression(Expression),
-    DefineVariable(String, Expression, Markup, Type),
+    DefineVariable(String, Vec<Decorator>, Expression, Markup, Type),
     DefineFunction(
         String,
         Vec<String>, // type parameters
@@ -261,7 +261,7 @@ fn decorator_markup(decorators: &Vec<Decorator>) -> Markup {
 impl PrettyPrint for Statement {
     fn pretty_print(&self) -> Markup {
         match self {
-            Statement::DefineVariable(identifier, expr, readable_type, _type) => {
+            Statement::DefineVariable(identifier, _decs, expr, readable_type, _type) => {
                 m::keyword("let")
                     + m::space()
                     + m::identifier(identifier)

--- a/numbat/src/unit.rs
+++ b/numbat/src/unit.rs
@@ -27,7 +27,7 @@ pub struct UnitIdentifier {
     kind: UnitKind,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseUnitAndFactor(pub Unit, pub Number);
 
 impl std::iter::Product for BaseUnitAndFactor {
@@ -40,6 +40,18 @@ impl std::iter::Product for BaseUnitAndFactor {
 impl UnitIdentifier {
     pub fn is_base(&self) -> bool {
         matches!(self.kind, UnitKind::Base)
+    }
+
+    pub fn unit_and_factor(&self) -> BaseUnitAndFactor {
+        match &self.kind {
+            UnitKind::Base => BaseUnitAndFactor(
+                Unit::new_base(&self.name, &self.canonical_name),
+                Number::from_f64(1.0),
+            ),
+            UnitKind::Derived(factor, defining_unit) => {
+                BaseUnitAndFactor(defining_unit.clone(), *factor)
+            }
+        }
     }
 
     pub fn base_unit_and_factor(&self) -> BaseUnitAndFactor {


### PR DESCRIPTION
This PR starts to implement the enhanced help suggestion in #238.

At the moment, it looks like this:

```
>>> help megabyte
  Byte
  https://en.wikipedia.org/wiki/Byte
  Aliases: B, byte, bytes, Byte, Bytes, octet, octets, Octet, Octets
  A unit of [DigitalInformation]
  
  1 megabyte = 1_000_000 byte
  1 byte = 8 bit
```

```
>>> help m
  Metre
  https://en.wikipedia.org/wiki/Metre
  Aliases: metre, metres, meter, meters, m
  A unit of [Length]
  
  metre is a base unit
```


CC #238