### PR TITLE
Add ampere-hours to `misc` module

### DIFF
--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -32,6 +32,7 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Dot / Length` | [Dots per inch](https://en.wikipedia.org/wiki/Dots_per_inch) | `dpi` |
 | `DynamicViscosity` | [Poise](https://en.wikipedia.org/wiki/Poise_(unit)) | `poise` |
 | `ElectricCharge` | [Coulomb](https://en.wikipedia.org/wiki/Coulomb) | `C`, `coulomb`, `coulombs` |
+| `ElectricCharge` | [Ampere-Hour](https://en.wikipedia.org/wiki/Ampere_hour) | `Ah`, `amperehour`, `amperehours` |
 | `ElectricConductance` | [Siemens](https://en.wikipedia.org/wiki/Siemens_(unit)) | `S`, `siemens` |
 | `ElectricResistance` | [Ohm](https://en.wikipedia.org/wiki/Ohm) | `ohm`, `ohms`, `Ω` |
 | `Energy` | [British thermal unit](https://en.wikipedia.org/wiki/British_thermal_unit) | `BTU`, `Btu` |

--- a/numbat/modules/units/misc.nbt
+++ b/numbat/modules/units/misc.nbt
@@ -119,6 +119,12 @@ unit gon: Angle = 90° / 100
 @aliases(Wh: short)
 unit watthour: Energy = W h
 
+@name("Ampere-hour")
+@url("https://en.wikipedia.org/wiki/Ampere_hour")
+@metric_prefixes
+@aliases(Ah: short)
+unit amperehour: ElectricCharge = A h
+
 @name("Kilometres per hour")
 @url("https://en.wikipedia.org/wiki/Kilometres_per_hour")
 unit kph: Velocity = kilometer per hour


### PR DESCRIPTION
Adds ampere-hours which is a widely used unit for batteries.