### PR TITLE
Wait for background currency fetch thread to finish before exiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-apple-darwin         , os: macos-12                      }
           #- { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
-          # - { target: x86_64-pc-windows-msvc      , os: windows-2019                  } -- currently disabled because of a flaky unit test
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
     env:


### PR DESCRIPTION
When numbat is run with a quick-running --expression, it can finish evaluating the expression before the background currency fetch thread has finished.

On Windows, this is problematic because the main thread does some post-main winsock shutdown tasks, which conflict with the background task that's still trying to fetch exchange rate info from the network.

This commit keeps a reference to the currency fetching thread and joins on it before exiting.