### PR TITLE
Unflatten the Config/MainConfig struct

### DIFF
--- a/numbat-cli/src/config.rs
+++ b/numbat-cli/src/config.rs
@@ -18,32 +18,6 @@ pub enum PrettyPrintMode {
     Auto,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
-pub struct MainConfig {
-    pub intro_banner: IntroBanner,
-    pub prompt: String,
-    pub pretty_print: PrettyPrintMode,
-
-    #[serde(skip_serializing)]
-    pub load_prelude: bool,
-
-    #[serde(skip_serializing)]
-    pub load_user_init: bool,
-}
-
-impl Default for MainConfig {
-    fn default() -> Self {
-        Self {
-            prompt: ">>> ".to_owned(),
-            intro_banner: IntroBanner::default(),
-            pretty_print: PrettyPrintMode::Auto,
-            load_prelude: true,
-            load_user_init: true,
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExchangeRateFetchingPolicy {
@@ -72,10 +46,30 @@ impl Default for ExchangeRateConfig {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
-    #[serde(flatten)]
-    pub main: MainConfig,
+    pub intro_banner: IntroBanner,
+    pub prompt: String,
+    pub pretty_print: PrettyPrintMode,
+
+    #[serde(skip_serializing)]
+    pub load_prelude: bool,
+
+    #[serde(skip_serializing)]
+    pub load_user_init: bool,
     pub exchange_rates: ExchangeRateConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            prompt: ">>> ".to_owned(),
+            intro_banner: IntroBanner::default(),
+            pretty_print: PrettyPrintMode::Auto,
+            load_prelude: true,
+            load_user_init: true,
+            exchange_rates: Default::default(),
+        }
+    }
 }

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -133,11 +133,11 @@ impl Cli {
             Config::default()
         };
 
-        config.main.load_prelude &= !args.no_prelude;
-        config.main.load_user_init &= !(args.no_prelude || args.no_init);
+        config.load_prelude &= !args.no_prelude;
+        config.load_user_init &= !(args.no_prelude || args.no_init);
 
-        config.main.intro_banner = args.intro_banner.unwrap_or(config.main.intro_banner);
-        config.main.pretty_print = args.pretty_print.unwrap_or(config.main.pretty_print);
+        config.intro_banner = args.intro_banner.unwrap_or(config.intro_banner);
+        config.pretty_print = args.pretty_print.unwrap_or(config.pretty_print);
 
         let mut fs_importer = FileSystemImporter::default();
         for path in Self::get_modules_paths() {
@@ -165,7 +165,7 @@ impl Cli {
     }
 
     fn run(&mut self) -> Result<()> {
-        if self.config.main.load_prelude {
+        if self.config.load_prelude {
             let result = self.parse_and_evaluate(
                 "use prelude",
                 CodeSource::Internal,
@@ -177,7 +177,7 @@ impl Cli {
             }
         }
 
-        if self.config.main.load_user_init {
+        if self.config.load_user_init {
             let user_init_path = Self::get_config_path().join("init.nbt");
 
             if let Ok(user_init_code) = fs::read_to_string(&user_init_path) {
@@ -193,7 +193,7 @@ impl Cli {
             }
         }
 
-        if self.config.main.load_prelude
+        if self.config.load_prelude
             && self.config.exchange_rates.fetching_policy != ExchangeRateFetchingPolicy::Never
         {
             self.context
@@ -221,7 +221,7 @@ impl Cli {
                 &code,
                 code_source,
                 ExecutionMode::Normal,
-                self.config.main.pretty_print,
+                self.config.pretty_print,
             );
 
             match result {
@@ -232,7 +232,7 @@ impl Cli {
                 }
             }
         } else {
-            let mut currency_fetch_thread = if self.config.main.load_prelude
+            let mut currency_fetch_thread = if self.config.load_prelude
                 && self.config.exchange_rates.fetching_policy
                     == ExchangeRateFetchingPolicy::OnStartup
             {
@@ -275,7 +275,7 @@ impl Cli {
         rl.load_history(&history_path).ok();
 
         if interactive {
-            match self.config.main.intro_banner {
+            match self.config.intro_banner {
                 IntroBanner::Long => {
                     println!();
                     println!(
@@ -313,7 +313,7 @@ impl Cli {
         interactive: bool,
     ) -> Result<()> {
         loop {
-            let readline = rl.readline(&self.config.main.prompt);
+            let readline = rl.readline(&self.config.prompt);
             match readline {
                 Ok(line) => {
                     if !line.trim().is_empty() {
@@ -394,7 +394,7 @@ impl Cli {
                                     } else {
                                         ExecutionMode::Normal
                                     },
-                                    self.config.main.pretty_print,
+                                    self.config.pretty_print,
                                 );
 
                                 match result {


### PR DESCRIPTION
This works around a known serde problem when wrong error messages are generated with flattened fields (by implementing the suggestion from @sharkdp in https://github.com/sharkdp/numbat/issues/295#issuecomment-1913349841)

Closes #295