### PR TITLE
Extended number formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "pretty_dtoa",
  "rand",
  "rust-embed",
+ "strfmt",
  "strsim 0.11.0",
  "termcolor",
  "thiserror",
@@ -1434,6 +1435,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strfmt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
 
 [[package]]
 name = "strsim"

--- a/book/src/example-numbat_syntax.md
+++ b/book/src/example-numbat_syntax.md
@@ -103,6 +103,7 @@ print(2 kilowarhol)              # Print the value of an expression
 print("hello world")             # Print a message
 print("value of pi = {pi}")      # String interpolation
 print("sqrt(10) = {sqrt(10)}")   # Expressions in string interpolation
+print("value of π ≈ {π:.3}")     # Format specifiers
 
 assert(1 yard < 1 meter)         # Assertion
 

--- a/book/src/procedures.md
+++ b/book/src/procedures.md
@@ -26,6 +26,15 @@ let speed = 25 km/h
 print("Speed of the bicycle: {speed} ({speed -> mph})")
 ```
 
+Format specifiers are also supported in interpolations. For instance:
+
+```nbt
+print("{pi:0.2f}") // Prints "3.14"
+```
+
+For more information on supported format specifiers, please see
+[this page](https://doc.rust-lang.org/std/fmt/#formatting-parameters).
+
 ## Testing
 
 The `assert_eq` procedure can be used to test for (approximate) equality of two quantities.

--- a/examples/numbat_syntax.nbt
+++ b/examples/numbat_syntax.nbt
@@ -98,6 +98,7 @@ print(2 kilowarhol)              # Print the value of an expression
 print("hello world")             # Print a message
 print("value of pi = {pi}")      # String interpolation
 print("sqrt(10) = {sqrt(10)}")   # Expressions in string interpolation
+print("value of π ≈ {π:.3}")     # Format specifiers
 
 assert(1 yard < 1 meter)         # Assertion
 

--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -35,6 +35,7 @@ iana-time-zone = "0.1"
 termcolor = { version = "1.4.1", optional = true }
 html-escape = { version = "0.2.13", optional = true }
 rand = "0.8.5"
+strfmt = "0.2.4"
 
 [features]
 default = ["fetch-exchangerates"]

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -58,7 +58,11 @@ impl PrettyPrint for BinaryOperator {
 #[derive(Debug, Clone, PartialEq)]
 pub enum StringPart {
     Fixed(String),
-    Interpolation(Span, Box<Expression>),
+    Interpolation {
+        span: Span,
+        expr: Box<Expression>,
+        format_specifiers: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -426,9 +430,15 @@ impl ReplaceSpans for StringPart {
     fn replace_spans(&self) -> Self {
         match self {
             f @ StringPart::Fixed(_) => f.clone(),
-            StringPart::Interpolation(_, expr) => {
-                StringPart::Interpolation(Span::dummy(), Box::new(expr.replace_spans()))
-            }
+            StringPart::Interpolation {
+                expr,
+                format_specifiers,
+                span: _,
+            } => StringPart::Interpolation {
+                span: Span::dummy(),
+                expr: Box::new(expr.replace_spans()),
+                format_specifiers: format_specifiers.clone(),
+            },
         }
     }
 }

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -187,8 +187,16 @@ impl BytecodeInterpreter {
                             let index = self.vm.add_constant(Constant::String(s.clone()));
                             self.vm.add_op1(Op::LoadConstant, index)
                         }
-                        StringPart::Interpolation(_, expr) => {
+                        StringPart::Interpolation {
+                            expr,
+                            span: _,
+                            format_specifiers,
+                        } => {
                             self.compile_expression_with_simplify(expr)?;
+                            let index = self.vm.add_constant(Constant::FormatSpecifiers(
+                                format_specifiers.clone(),
+                            ));
+                            self.vm.add_op1(Op::LoadConstant, index)
                         }
                     }
                 }

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -47,6 +47,12 @@ pub enum RuntimeError {
     DateTimeOutOfRange,
     #[error("Error in datetime format. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for possible format specifiers.")]
     DateFormattingError,
+
+    #[error("Invalid format specifiers: {0}")]
+    InvalidFormatSpecifiers(String),
+
+    #[error("Incorrect type for format specifiers: {0}")]
+    InvalidTypeForFormatSpecifiers(String),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -85,10 +85,15 @@ impl Transformer {
                     .into_iter()
                     .map(|p| match p {
                         f @ StringPart::Fixed(_) => f,
-                        StringPart::Interpolation(span, expr) => StringPart::Interpolation(
+                        StringPart::Interpolation {
                             span,
-                            Box::new(self.transform_expression(*expr)),
-                        ),
+                            expr,
+                            format_specifiers,
+                        } => StringPart::Interpolation {
+                            span,
+                            expr: Box::new(self.transform_expression(*expr)),
+                            format_specifiers,
+                        },
                     })
                     .collect(),
             ),

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -1022,12 +1022,15 @@ impl TypeChecker {
                     .iter()
                     .map(|p| match p {
                         StringPart::Fixed(s) => Ok(typed_ast::StringPart::Fixed(s.clone())),
-                        StringPart::Interpolation(span, expr) => {
-                            Ok(typed_ast::StringPart::Interpolation(
-                                *span,
-                                Box::new(self.check_expression(expr)?),
-                            ))
-                        }
+                        StringPart::Interpolation {
+                            span,
+                            expr,
+                            format_specifiers,
+                        } => Ok(typed_ast::StringPart::Interpolation {
+                            span: *span,
+                            format_specifiers: format_specifiers.clone(),
+                            expr: Box::new(self.check_expression(expr)?),
+                        }),
                     })
                     .collect::<Result<_>>()?,
             ),

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -129,15 +129,31 @@ impl Type {
 #[derive(Debug, Clone, PartialEq)]
 pub enum StringPart {
     Fixed(String),
-    Interpolation(Span, Box<Expression>),
+    Interpolation {
+        span: Span,
+        expr: Box<Expression>,
+        format_specifiers: Option<String>,
+    },
 }
 
 impl PrettyPrint for StringPart {
     fn pretty_print(&self) -> Markup {
         match self {
             StringPart::Fixed(s) => s.pretty_print(),
-            StringPart::Interpolation(_, expr) => {
-                m::operator("{") + expr.pretty_print() + m::operator("}")
+            StringPart::Interpolation {
+                span: _,
+                expr,
+                format_specifiers,
+            } => {
+                let mut markup = m::operator("{") + expr.pretty_print();
+
+                if let Some(format_specifiers) = format_specifiers {
+                    markup += m::text(format_specifiers);
+                }
+
+                markup += m::operator("}");
+
+                markup
             }
         }
     }

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -28,6 +28,7 @@ pub enum Value {
     /// A DateTime with an associated offset used when pretty printing
     DateTime(chrono::DateTime<chrono::FixedOffset>),
     FunctionReference(FunctionReference),
+    FormatSpecifiers(Option<String>),
 }
 
 impl Value {
@@ -85,6 +86,7 @@ impl std::fmt::Display for Value {
             Value::String(s) => write!(f, "\"{}\"", s),
             Value::DateTime(dt) => write!(f, "datetime(\"{}\")", dt),
             Value::FunctionReference(r) => write!(f, "{}", r),
+            Value::FormatSpecifiers(_) => write!(f, "<format specfiers>"),
         }
     }
 }
@@ -97,6 +99,8 @@ impl PrettyPrint for Value {
             Value::String(s) => s.pretty_print(),
             Value::DateTime(dt) => crate::markup::string(crate::datetime::to_rfc2822_save(dt)),
             Value::FunctionReference(r) => crate::markup::string(r.to_string()),
+            Value::FormatSpecifiers(Some(s)) => crate::markup::string(s.to_string()),
+            Value::FormatSpecifiers(None) => crate::markup::empty(),
         }
     }
 }

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -544,6 +544,51 @@ fn test_conditionals() {
 fn test_string_interpolation() {
     expect_output("\"pi = {pi}!\"", "pi = 3.14159!");
     expect_output("\"1 + 2 = {1 + 2}\"", "1 + 2 = 3");
+
+    expect_output("\"{0.2:0.5}\"", "0.20000");
+    expect_output("\"pi ~= {pi:.3}\"", "pi ~= 3.142");
+    expect_output(
+        "\"both {pi:.3} and {e} are irrational and transcendental numbers\"",
+        "both 3.142 and 2.71828 are irrational and transcendental numbers",
+    );
+    expect_output(
+        "
+        let str = \"1234\"
+        \"{str:0.2}\"
+        ",
+        "12",
+    );
+
+    expect_output("\"{1_000_300:+.3}\"", "+1000300.000");
+
+    expect_output(
+        "
+        let str = \"1234\"
+        \"a {str:^10} b\"
+        ",
+        "a    1234    b",
+    );
+
+    // Doesn't work at the moment, as `strfmt` expects `i64`'s for `#x`, but Numbat deals with `f64`'s
+    // internally
+    //expect_output("\"{31:#x}\"", "0x1f")
+
+    expect_failure(
+        "\"{200:x}\"",
+        "Incorrect type for format specifiers: Unknown format code 'x' for type",
+    );
+    expect_failure(
+        "\"{200:.}\"",
+        "Invalid format specifiers: Format specifier missing precision",
+    );
+
+    expect_failure(
+        "
+        let str = \"1234\"
+        \"{str:.3f}\"
+        ",
+        "Incorrect type for format specifiers: Unknown format code Some('f') for object of type 'str'",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #264.


TODO:
- [x] Add format specifiers for strings (and possibly other types?)
- [x] Fix todos
- [x] Check that format specifiers are valid (currently anything invalid will crash Numbat)
- [x] Fix units not being printed in quantity interpolations with format specifiers
- [ ] Research possible choices other than `strfmt`
- [x] Add tests
- [x] Document
- [ ] Improve error messages
