### PR TITLE
Improve unterminated string interpolation error

### DIFF
--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -30,7 +30,7 @@ pub enum TokenizerErrorKind {
     #[error("Unterminated string")]
     UnterminatedString,
 
-    #[error("Unterminated {{...}} interpolation in this string")]
+    #[error("Unterminated string interpolation")]
     UnterminatedStringInterpolation,
 
     #[error("Unexpected '{{' inside string interpolation")]
@@ -532,8 +532,8 @@ impl Tokenizer {
                     return Err(TokenizerError {
                         kind: TokenizerErrorKind::UnterminatedStringInterpolation,
                         span: Span {
-                            start: self.string_start,
-                            end: self.current,
+                            start: self.interpolation_start,
+                            end: self.last,
                             code_source_id: self.code_source_id,
                         },
                     });


### PR DESCRIPTION
Before, the error span would point to the whole string:

```
>>> {x} {1"
error: while parsing
  ┌─ <input:16>:1:1
  │
1 │ "{x} {1"
  │ ^^^^^^^^ Unterminated {...} interpolation in this string
```

Now it only points to the unfinished interpolation:

```
>>> "{x} {1"
error: while parsing
  ┌─ <input:2>:1:6
  │
1 │ "{x} {1"
  │      ^^ Unterminated string interpolation
```

How do you think I should go about adding a test for this, or is it not needed?
