### PR TITLE
Add ability to hide 'private' functions and variables

### DIFF
--- a/numbat-cli/src/highlighter.rs
+++ b/numbat-cli/src/highlighter.rs
@@ -37,11 +37,8 @@ impl Highlighter for NumbatHighlighter {
         _completion: CompletionType,
     ) -> Cow<'c, str> {
         let ctx = self.context.lock().unwrap();
-        if ctx.variable_names().iter().any(|n| n == candidate)
-            || ctx
-                .function_names()
-                .iter()
-                .any(|n| format!("{}(", n) == candidate)
+        if ctx.variable_names().any(|n| n == candidate)
+            || ctx.function_names().any(|n| format!("{}(", n) == candidate)
         {
             Cow::Owned(ansi_format(&markup::identifier(candidate), false))
         } else if ctx

--- a/numbat/modules/physics/temperature_conversion.nbt
+++ b/numbat/modules/physics/temperature_conversion.nbt
@@ -2,13 +2,13 @@ use units::si
 
 ### Temperature conversion functions K <-> °C and K <-> °F
 
-let offset_celsius = 273.15
+let _offset_celsius = 273.15
 
-fn from_celsius(t_celsius: Scalar) -> Temperature = (t_celsius + offset_celsius) kelvin
-fn to_celsius(t_kelvin: Temperature) -> Scalar = t_kelvin / kelvin - offset_celsius
+fn from_celsius(t_celsius: Scalar) -> Temperature = (t_celsius + _offset_celsius) kelvin
+fn to_celsius(t_kelvin: Temperature) -> Scalar = t_kelvin / kelvin - _offset_celsius
 
-let offset_fahrenheit = 459.67
-let scale_fahrenheit = 5 / 9
+let _offset_fahrenheit = 459.67
+let _scale_fahrenheit = 5 / 9
 
-fn from_fahrenheit(t_fahrenheit: Scalar) -> Temperature = ((t_fahrenheit + offset_fahrenheit) × scale_fahrenheit) kelvin
-fn to_fahrenheit(t_kelvin: Temperature) -> Scalar = (t_kelvin / kelvin) / scale_fahrenheit - offset_fahrenheit
+fn from_fahrenheit(t_fahrenheit: Scalar) -> Temperature = ((t_fahrenheit + _offset_fahrenheit) × _scale_fahrenheit) kelvin
+fn to_fahrenheit(t_kelvin: Temperature) -> Scalar = (t_kelvin / kelvin) / _scale_fahrenheit - _offset_fahrenheit

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -128,12 +128,20 @@ impl Context {
         ExchangeRatesCache::set_from_xml(xml_content);
     }
 
-    pub fn variable_names(&self) -> &[String] {
-        &self.prefix_transformer.variable_names
+    pub fn variable_names(&self) -> impl Iterator<Item = String> + '_ {
+        self.prefix_transformer
+            .variable_names
+            .iter()
+            .filter(|name| !name.starts_with('_'))
+            .cloned()
     }
 
-    pub fn function_names(&self) -> &[String] {
-        &self.prefix_transformer.function_names
+    pub fn function_names(&self) -> impl Iterator<Item = String> + '_ {
+        self.prefix_transformer
+            .function_names
+            .iter()
+            .filter(|name| !name.starts_with('_'))
+            .cloned()
     }
 
     pub fn unit_names(&self) -> &[Vec<String>] {
@@ -145,13 +153,13 @@ impl Context {
     }
 
     pub fn print_environment(&self) -> Markup {
-        let mut functions = Vec::from(self.function_names());
+        let mut functions: Vec<_> = self.function_names().collect();
         functions.sort();
         let mut dimensions = Vec::from(self.dimension_names());
         dimensions.sort();
         let mut units = Vec::from(self.unit_names());
         units.sort();
-        let mut variables = Vec::from(self.variable_names());
+        let mut variables: Vec<_> = self.variable_names().collect();
         variables.sort();
 
         let mut output = m::empty();
@@ -179,7 +187,7 @@ impl Context {
     }
 
     pub fn print_functions(&self) -> Markup {
-        self.print_sorted(self.function_names().into(), FormatType::Identifier)
+        self.print_sorted(self.function_names().collect(), FormatType::Identifier)
     }
 
     pub fn print_dimensions(&self) -> Markup {
@@ -187,7 +195,7 @@ impl Context {
     }
 
     pub fn print_variables(&self) -> Markup {
-        self.print_sorted(self.variable_names().into(), FormatType::Identifier)
+        self.print_sorted(self.variable_names().collect(), FormatType::Identifier)
     }
 
     pub fn print_units(&self) -> Markup {


### PR DESCRIPTION
Preparation for some work on #323. This simply hides functions and variables with a leading underscore from `list` and from tab completion.

Somewhat addresses an issue raised in #201, although in a non-satisfactory way.