### PR TITLE
Full simplify arguments in function calls

### DIFF
--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -142,7 +142,7 @@ impl BytecodeInterpreter {
             Expression::FunctionCall(_span, _full_span, name, args, _type) => {
                 // Put all arguments on top of the stack
                 for arg in args {
-                    self.compile_expression(arg)?;
+                    self.compile_expression_with_simplify(arg)?;
                 }
 
                 if let Some(idx) = self.vm.get_ffi_callable_idx(name) {

--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -59,7 +59,7 @@ impl Quantity {
     }
 
     pub fn convert_to(&self, target_unit: &Unit) -> Result<Quantity> {
-        if &self.unit == target_unit || self.is_zero() {
+        if &self.unit == target_unit {
             Ok(Quantity::new(self.value, target_unit.clone()))
         } else {
             // Remove common unit factors to reduce unnecessary conversion procedures

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -595,3 +595,8 @@ fn test_overwrite_captured_constant() {
 fn test_pretty_print_prefixes() {
     expect_output("1 megabarn", "1 megabarn");
 }
+
+#[test]
+fn test_full_simplify_for_function_calls() {
+    expect_output("floor(1.2 hours / hour)", "1");
+}


### PR DESCRIPTION
Before this, we would get non-simplified outputs sometimes:
```
>>> floor(1.2 hours / hour)

      = 1 h/h
```

We can't do this *after* the function call, because otherwise we wouldn't be able to have functions like:
```
fn f(ratio: Scalar) = ratio -> cm/m
```