### PR TITLE
Use local timezone, not local UTC offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "criterion",
  "glob",
  "heck",
+ "iana-time-zone",
  "insta",
  "itertools 0.12.0",
  "libc",

--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -31,6 +31,7 @@ num-format = "0.4.4"
 walkdir = "2"
 chrono = "0.4.31"
 chrono-tz = "0.8.5"
+iana-time-zone = "0.1"
 
 [features]
 default = ["fetch-exchangerates"]

--- a/numbat/src/datetime.rs
+++ b/numbat/src/datetime.rs
@@ -1,0 +1,22 @@
+use chrono::{DateTime, FixedOffset, Offset, TimeZone};
+use chrono_tz::Tz;
+
+fn get_local_timezone() -> Option<Tz> {
+    let tz_str = iana_time_zone::get_timezone().ok()?;
+    tz_str.parse().ok()
+}
+
+/// We use this function to get the UTC offset corresponding to
+/// the local timezone *at the specific instant in time* specified
+/// by 'dt', which might be different from the *current* UTC offset.
+///
+/// For example, in the timezone Europe/Berlin in 2024, we expect a
+/// UTC offset of +01:00 for 'dt's in winter, while we expect a UTC
+/// offset of +02:00 for 'dt's in summer, due to DST. If we were to
+/// use chronos 'Local', we would get a UTC offset depending on when
+/// we run the program.
+pub fn local_offset_for_datetime<O: TimeZone + Offset>(dt: &DateTime<O>) -> FixedOffset {
+    get_local_timezone()
+        .map(|tz| dt.with_timezone(&tz).offset().fix())
+        .unwrap_or_else(|| dt.offset().fix())
+}

--- a/numbat/src/ffi.rs
+++ b/numbat/src/ffi.rs
@@ -805,9 +805,9 @@ fn parse_datetime(args: &[Value]) -> Result<Value> {
         .or_else(|_| chrono::DateTime::parse_from_rfc2822(input))
         .map_err(RuntimeError::DateParsingError)?;
 
-    let offset = output.offset();
+    let offset = crate::datetime::local_offset_for_datetime(&output);
 
-    Ok(Value::DateTime(output.into(), *offset))
+    Ok(Value::DateTime(output.into(), offset))
 }
 
 fn format_datetime(args: &[Value]) -> Result<Value> {

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -3,6 +3,7 @@ mod ast;
 mod bytecode_interpreter;
 mod column_formatter;
 mod currency;
+mod datetime;
 mod decorator;
 pub mod diagnostic;
 mod dimension;

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -697,7 +697,7 @@ impl Vm {
                     let lhs = self.pop_datetime();
 
                     let offset = if rhs == "local" {
-                        chrono::Local::now().offset().fix()
+                        crate::datetime::local_offset_for_datetime(&lhs)
                     } else {
                         let tz: chrono_tz::Tz = rhs
                             .parse()


### PR DESCRIPTION
With this change, we treat "local" as the local timezone, whereas before, we treated "local" as the local (current) UTC offset.

The following behavior is shown for timezone Europe/Berlin, during winter.

Before: UTC offset is used for parse_datetime

    >>> parse_datetime("2024-01-01T12:00:00Z")
        = Mon, 1 Jan 2024 12:00:00 +0000    [DateTime]

After:

    >>> parse_datetime("2024-01-01T12:00:00Z")
        = Mon, 1 Jan 2024 13:00:00 +0100    [DateTime]

Before: "Winter" UTC offset is used for datetime in summer

    >>> parse_datetime("2024-07-01T12:00:00Z") -> "local"
        = Mon, 1 Jul 2024 13:00:00 +0100    [DateTime]

After: "Summer" UTC offset is used for datetime in summer

    >>> parse_datetime("2024-07-01T12:00:00Z") -> "local"
        = Mon, 1 Jul 2024 14:00:00 +0200    [DateTime]

After: "Winter" UTC offset is used for datetime in winter

    >>> parse_datetime("2024-01-01T12:00:00Z") -> "local"
        = Mon, 1 Jan 2024 13:00:00 +0100    [DateTime]