### PR TITLE
Add #[track_caller] annotation to some panicy VM functions

### DIFF
--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -515,6 +515,7 @@ impl Vm {
         self.stack.push(value);
     }
 
+    #[track_caller]
     fn pop_quantity(&mut self) -> Quantity {
         match self.pop() {
             Value::Quantity(q) => q,
@@ -522,10 +523,12 @@ impl Vm {
         }
     }
 
+    #[track_caller]
     fn pop_bool(&mut self) -> bool {
         self.pop().unsafe_as_bool()
     }
 
+    #[track_caller]
     fn pop_datetime(&mut self) -> chrono::DateTime<chrono::Utc> {
         match self.pop() {
             Value::DateTime(q, _) => q,
@@ -533,6 +536,7 @@ impl Vm {
         }
     }
 
+    #[track_caller]
     fn pop_string(&mut self) -> String {
         match self.pop() {
             Value::String(s) => s,
@@ -540,6 +544,7 @@ impl Vm {
         }
     }
 
+    #[track_caller]
     fn pop(&mut self) -> Value {
         self.stack.pop().expect("stack should not be empty")
     }


### PR DESCRIPTION
This improves the error messages a bit if the the panics are triggered in these functions

While adding new code into vm.rs, I often got the order of the stack mixed up, and would run into one of the panics like `pop_quantity()` "Expected quantity to be on the top of the stack"

Without `#[track_caller]`, the line number printed in the error message would be the line of the call to `panic!()`.  But with `#[track_caller]`, the line number now points to the caller of the `pop_xyz()` function, which is a bit more useful