### PR TITLE
Add "UTC" variable

### DIFF
--- a/numbat/modules/datetime/functions.nbt
+++ b/numbat/modules/datetime/functions.nbt
@@ -6,5 +6,6 @@ fn format_datetime(format: String, input: DateTime) -> String
 fn get_local_timezone() -> String
 fn tz(tz: String) -> Fn[(DateTime) -> DateTime]
 let local: Fn[(DateTime) -> DateTime] = tz(get_local_timezone())
+let UTC: Fn[(DateTime) -> DateTime] = tz("UTC")
 fn unixtime(input: DateTime) -> Scalar
 fn from_unixtime(input: Scalar) -> DateTime


### PR DESCRIPTION
This adds a "UTC" variable, akin to the "local" variable to be used for more convenient timezone conversion.

In general, users are expected to add their own favorite timezones to their config file (assuming they want to bind a `tz("something")` conversation to a shorter variable name).  But the UTC timezone seems special enough to warrant a default binding.