### PR TITLE
Enable using script and expression cli arguments at the same time

### DIFF
--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -229,9 +229,8 @@ impl Cli {
 
                 let result_status = match result {
                     std::ops::ControlFlow::Continue(()) => Ok(()),
-                    std::ops::ControlFlow::Break(ExitStatus::Success) => Ok(()),
-                    std::ops::ControlFlow::Break(ExitStatus::Error) => {
-                        bail!("Interpreter stopped due to error")
+                    std::ops::ControlFlow::Break(_) => {
+                        bail!("Interpreter stopped")
                     }
                 };
 

--- a/numbat-cli/tests/integration.rs
+++ b/numbat-cli/tests/integration.rs
@@ -78,6 +78,24 @@ fn read_code_from_file() {
 }
 
 #[test]
+fn process_code_from_file_and_cli_expression() {
+    numbat()
+        .arg("tests/examples/pendulum.nbt")
+        .arg("--expression")
+        .arg("oscillation_time(20cm)")
+        .assert()
+        .success();
+
+    numbat()
+        .arg("tests/examples/pendulum.nbt")
+        .arg("--expression")
+        .arg("oscillation_time(20kg)")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("while type checking"));
+}
+
+#[test]
 fn print_calls() {
     numbat()
         .arg("tests/examples/print.nbt")


### PR DESCRIPTION
This pull request should resolve issue #354.

With this modification it becomes possible to use the `FILE` and `-e <CODE>` arguments in the same command, first executing `FILE` and then `CODE`, regardless of the argument order.