### PR TITLE
Always embed modules

### DIFF
--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -26,7 +26,7 @@ heck = { version = "0.4.1", features = ["unicode"] }
 unicode-ident = "1.0.12"
 unicode-width = "0.1.11"
 libc = "0.2.152"
-rust-embed = { version = "8.2.0", features = ["interpolate-folder-path"] }
+rust-embed = { version = "8.2.0", features = ["interpolate-folder-path", "debug-embed"] }
 num-format = "0.4.4"
 walkdir = "2"
 chrono = "0.4.31"


### PR DESCRIPTION
This enables embedding of modules into the binary, even in debug mode. The idea of rust-embed to load files from disk when in debug mode is neat, but I've tripped over this one too many times. It's just confusing that things behave differently in debug and release mode. So let's fix this.