### PR TITLE
Runtime error for wrong format specifiers

### DIFF
--- a/numbat/src/ffi.rs
+++ b/numbat/src/ffi.rs
@@ -845,7 +845,6 @@ fn datetime(args: &[Value]) -> Result<Value> {
     let input = args[0].unsafe_as_string();
 
     let output = datetime::parse_datetime(input)
-        .map_err(RuntimeError::DateParsingError)?
         .ok_or(RuntimeError::DateParsingErrorUnknown)?
         .fixed_offset();
 

--- a/numbat/src/ffi.rs
+++ b/numbat/src/ffi.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use std::sync::OnceLock;
 
@@ -857,7 +858,8 @@ fn format_datetime(args: &[Value]) -> Result<Value> {
     let format = args[0].unsafe_as_string();
     let dt = args[1].unsafe_as_datetime();
 
-    let output = dt.format(format).to_string();
+    let mut output = String::new();
+    write!(output, "{}", dt.format(format)).map_err(|_| RuntimeError::DateFormattingError)?;
 
     Ok(Value::String(output))
 }

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -47,6 +47,8 @@ pub enum RuntimeError {
     DurationOutOfRange,
     #[error("DateTime out of range")]
     DateTimeOutOfRange,
+    #[error("Error in datetime format. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for possible format specifiers.")]
+    DateFormattingError,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -37,8 +37,6 @@ pub enum RuntimeError {
     CouldNotLoadExchangeRates,
     #[error("User error: {0}")]
     UserError(String),
-    #[error("Could not parse date: {0}")]
-    DateParsingError(chrono::ParseError),
     #[error("Unrecognized datetime format")]
     DateParsingErrorUnknown,
     #[error("Unknown timezone: {0}")]

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -95,7 +95,7 @@ impl PrettyPrint for Value {
             Value::Quantity(q) => q.pretty_print(),
             Value::Boolean(b) => b.pretty_print(),
             Value::String(s) => s.pretty_print(),
-            Value::DateTime(dt) => crate::markup::string(dt.to_rfc2822()),
+            Value::DateTime(dt) => crate::markup::string(crate::datetime::to_rfc2822_save(dt)),
             Value::FunctionReference(r) => crate::markup::string(r.to_string()),
         }
     }

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -866,7 +866,7 @@ impl Vm {
                             Value::Quantity(q) => q.to_string(),
                             Value::Boolean(b) => b.to_string(),
                             Value::String(s) => s,
-                            Value::DateTime(dt) => dt.to_rfc2822(),
+                            Value::DateTime(dt) => crate::datetime::to_rfc2822_save(&dt),
                             Value::FunctionReference(r) => r.to_string(),
                         };
                         joined = part + &joined; // reverse order

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -600,3 +600,21 @@ fn test_pretty_print_prefixes() {
 fn test_full_simplify_for_function_calls() {
     expect_output("floor(1.2 hours / hour)", "1");
 }
+
+#[test]
+fn test_datetime_runtime_errors() {
+    expect_failure("datetime(\"2000-01-99\")", "Unrecognized datetime format");
+    expect_failure("now() -> tz(\"Europe/NonExisting\")", "Unknown timezone");
+    expect_failure(
+        "date(\"2000-01-01\") + 1e100 years",
+        "Exceeded maximum size for time durations",
+    );
+    expect_failure(
+        "date(\"2000-01-01\") + 100000000 years",
+        "DateTime out of range",
+    );
+    expect_failure(
+        "format_datetime(\"%Y-%m-%dT%H%:M\", now())",
+        "Error in datetime format",
+    )
+}


### PR DESCRIPTION
Unfortunately, I didn't find a way to get a more detailed error message out of chrono.

Closes #377 and fixes a panic when rendering large dates in RFC2822