### PR TITLE
Disallow dimensionless base units

### DIFF
--- a/numbat/src/diagnostic.rs
+++ b/numbat/src/diagnostic.rs
@@ -340,6 +340,14 @@ impl ErrorDiagnostic for TypeCheckError {
                 );
                 d.with_labels(labels)
             }
+            TypeCheckError::NoDimensionlessBaseUnit(span, unit_name) => d
+                .with_labels(vec![span
+                    .diagnostic_label(LabelStyle::Primary)
+                    .with_message(inner_error)])
+                .with_notes(vec![
+                    format!("Use 'unit {unit_name}' for ad-hoc units."),
+                    format!("Use 'unit {unit_name}: Scalar = …' for derived units."),
+                ]),
             TypeCheckError::ForeignFunctionNeedsTypeAnnotations(span, _)
             | TypeCheckError::UnknownForeignFunction(span, _)
             | TypeCheckError::NonRationalExponent(span)

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -684,7 +684,7 @@ mod tests {
 
                  @aliases(rad: short)
                  @metric_prefixes
-                 unit radian: Scalar
+                 unit radian: Scalar = meter / meter
 
                  @aliases(°: none)
                  unit degree = 180/pi × radian


### PR DESCRIPTION
Will now show a new error:

    >>> unit page: Scalar
    error: while type checking
      ┌─ <input:1>:1:6
      │
    1 │ unit page: Scalar
      │      ^^^^ Base units can not be dimensionless.
      │
      = Use 'unit page' for ad-hoc units.
      = Use 'unit page: Scalar = …' for derived units.

closes #308