### PR TITLE
Skip serializing 'enter_repl'

### DIFF
--- a/numbat-cli/src/config.rs
+++ b/numbat-cli/src/config.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub intro_banner: IntroBanner,
     pub prompt: String,
     pub pretty_print: PrettyPrintMode,
+
+    #[serde(skip)]
     pub enter_repl: bool,
 
     #[serde(skip_serializing)]


### PR DESCRIPTION
This pull request fixes a small error that I made in #370 which accidentally made the 'enter_repl' variable accessible in the config file.