### PR TITLE
Change error message for unterminated strings with interpolation.

### DIFF
--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -192,8 +192,8 @@ pub enum ParseErrorKind {
     #[error("Expected 'else' in if-then-else condition")]
     ExpectedElse,
 
-    #[error("Unterminated string interpolation")]
-    UnterminatedStringInterpolation,
+    #[error("Unterminated string")]
+    UnterminatedString,
 
     #[error("Expected a string")]
     ExpectedString,
@@ -1169,8 +1169,9 @@ impl<'a> Parser<'a> {
             }
 
             if !has_end {
+                span_full_string = span_full_string.extend(&self.last().unwrap().span);
                 return Err(ParseError::new(
-                    ParseErrorKind::UnterminatedStringInterpolation,
+                    ParseErrorKind::UnterminatedString,
                     span_full_string,
                 ));
             }
@@ -2537,10 +2538,7 @@ mod tests {
             ),
         );
 
-        should_fail_with(
-            &["\"test {1"],
-            ParseErrorKind::UnterminatedStringInterpolation,
-        );
+        should_fail_with(&["\"test {1"], ParseErrorKind::UnterminatedString);
     }
 
     #[test]


### PR DESCRIPTION
I was exploring the codebase when I stumbled into what seemed to be the cause of #314.

The parser section handling interpolated strings would error out as UnterminatedStringInterpolation but it was effectively checking for unterminated strings. I couldn't really find a case where the tokenizer would be unable to catch an unterminated interpolation where it wasn't also a case of an unterminated string (let me know if there is one.)

For reference, here's the error message behavior with this PR:

![image](https://github.com/sharkdp/numbat/assets/7103539/ea0893ac-7459-4e97-ba76-76caba0c914e)
![image](https://github.com/sharkdp/numbat/assets/7103539/668e90a2-053a-4d81-996f-94c92e1b8b67)
---

There might be more edge cases with newlines. The error messages seems mostly fine as is, but the last one is maybe a bit weird:
![image](https://github.com/sharkdp/numbat/assets/7103539/b1607328-c19a-4351-b569-a73f440b0999)
![image](https://github.com/sharkdp/numbat/assets/7103539/822c338d-67c9-4f77-a2f2-b5b4231714d3)
![image](https://github.com/sharkdp/numbat/assets/7103539/57966f0b-7462-45d0-935a-4ab95ec1312c)
