### PR TITLE
Add yuan as renminbi alias

### DIFF
--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -127,7 +127,7 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Money` | [Norwegian krone](https://en.wikipedia.org/wiki/Norwegian_krone) | `NOK`, `norwegian_krone`, `norwegian_kroner` |
 | `Money` | [Philippine peso](https://en.wikipedia.org/wiki/Philippine_peso) | `philippine_peso`, `philippine_pesos`, `PHP`, `₱` |
 | `Money` | [Polish złoty](https://en.wikipedia.org/wiki/Polish_złoty) | `PLN`, `polish_zloty`, `polish_zlotys`, `zł` |
-| `Money` | [Chinese yuan](https://en.wikipedia.org/wiki/Renminbi) | `CNY`, `renminbi`, `元` |
+| `Money` | [Chinese yuan](https://en.wikipedia.org/wiki/Renminbi) | `CNY`, `renminbi`, `yuan`, `元` |
 | `Money` | [Romanian leu](https://en.wikipedia.org/wiki/Romanian_leu) | `lei`, `romanian_leu`, `romanian_leus`, `RON` |
 | `Money` | [Singapore dollar](https://en.wikipedia.org/wiki/Singapore_dollar) | `S$`, `SGD`, `singapore_dollar`, `singapore_dollars` |
 | `Money` | [South African rand](https://en.wikipedia.org/wiki/South_African_rand) | `south_african_rand`, `ZAR` |

--- a/numbat/modules/units/currencies.nbt
+++ b/numbat/modules/units/currencies.nbt
@@ -25,7 +25,7 @@ unit british_pound: Money = EUR / exchange_rate("GBP")
 
 @name("Chinese yuan")
 @url("https://en.wikipedia.org/wiki/Renminbi")
-@aliases(CNY: short, 元)
+@aliases(yuan, CNY: short, 元)
 unit renminbi: Money = EUR / exchange_rate("CNY")
 
 @name("Australian dollar")

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -523,6 +523,7 @@ impl Context {
                         "swiss_franc",
                         "swiss_francs",
                         "CNY",
+                        "yuan",
                         "renminbi",
                         "元",
                         "EUR",


### PR DESCRIPTION
I tried to use [yuan](https://en.wikipedia.org/wiki/Yuan_(currency)) in a currency conversion and it was missing, I think this should be enough to add it. Yuan is both the singular and plural form, but I see there's also "yens" defined in numbat as an alias for the japanese yen so maybe I should add "yuans" for convenience?