### PR TITLE
Cache exchange rates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ name = "numbat-exchange-rates"
 version = "0.5.0"
 dependencies = [
  "attohttpc",
+ "dirs",
  "quick-xml",
 ]
 

--- a/numbat-exchange-rates/Cargo.toml
+++ b/numbat-exchange-rates/Cargo.toml
@@ -11,7 +11,8 @@ rust-version = "1.70"
 
 [dependencies]
 attohttpc = { version = "0.27.0", default-features = false, features = ["tls-rustls-webpki-roots"], optional = true }
+dirs = { version = "5", optional = true }
 quick-xml = "0.31.0"
 
 [features]
-fetch-exchangerates = ["dep:attohttpc"]
+fetch-exchangerates = ["dep:attohttpc", "dep:dirs"]


### PR DESCRIPTION
I use lots of short invocations of numbat with `fetching-policy = "on-first-use"` which means it re-fetches the rates every time I open it to do a quick currency conversion.  The `on-startup` fetching policy makes it a bit better, but the delay is still noticeable if the first thing I do uses currency, and it just feels wasteful to download them every time when they're only updated daily. This change reuses the fetched rates for 24 hours to alleviate that delay.

This could make the rates up to a day out of date (if you happened to fetch them the first time right before the European Central Bank releases the next day's rates). In my mind this isn't hugely important as anyone who needs super up-to-date rates is probably using a different source in the first place, but the max age could be changed to something shorter to make it fetch more aggressively. If users want even more control, `max-age` could be specified as a config option in the `[exchange-rates]` section.