### PR TITLE
Add normal distribution sampling

### DIFF
--- a/numbat/modules/core/random.nbt
+++ b/numbat/modules/core/random.nbt
@@ -1,3 +1,8 @@
 use core::scalar
+use math::functions
 
 fn random() -> Scalar
+
+fn rand_normal<T>(μ: T, σ: T) -> T =
+    # Sampling using the Box-Muller transform
+    μ + sqrt(-2 σ² × ln(random())) × sin(2π × random())


### PR DESCRIPTION
This PR adds the function `rand_normal(μ, σ)` which samples $\mathcal{N}(\mu,\sigma^2)$ using the [Box-Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform). The implementation is slightly inefficient as it has to discard every second sample.

Partially addresses #413.