### PR TITLE
Bump iana-time-zone to no longer use a yanked package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",


### PR DESCRIPTION
[iana-time-zone 0.1.59 is yanked](https://crates.io/crates/iana-time-zone/0.1.59) so this removes that as a dep.

Thanks for this awesome tool!