### PR TITLE
Implement 'Never' type (!)

### DIFF
--- a/numbat/modules/core/error.nbt
+++ b/numbat/modules/core/error.nbt
@@ -1,3 +1,2 @@
-# TODO: Ideally, this function should have a '-> !' return type such that
-# it can be used everywhere. Not just instead of a Scalar.
-fn error(message: String) -> 1
+# Throw a user-defined error
+fn error(message: String) -> !

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -1,5 +1,6 @@
 use core::scalar
 use core::functions
+use core::error
 
 fn str_length(s: String) -> Scalar
 
@@ -44,7 +45,7 @@ fn _hex_digit(x: Scalar) -> String =
 
 fn _digit_in_base(x: Scalar, base: Scalar) -> String =
   if base < 2 || base > 16
-    then "?" # TODO: better error handling once we can specify the return type of 'error(msg)' as '!' (see error.nbt).
+    then error("base must be between 2 and 16")
     else if mod(x, 16) < 10 then chr(48 + mod(x, 16)) else chr(97 + mod(x, 16) - 10)
 
 fn _number_in_base(x: Scalar, b: Scalar) -> String =

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -217,6 +217,7 @@ pub(crate) use scalar;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeAnnotation {
+    Never(Span),
     DimensionExpression(DimensionExpression),
     Bool(Span),
     String(Span),
@@ -227,6 +228,7 @@ pub enum TypeAnnotation {
 impl TypeAnnotation {
     pub fn full_span(&self) -> Span {
         match self {
+            TypeAnnotation::Never(span) => *span,
             TypeAnnotation::DimensionExpression(d) => d.full_span(),
             TypeAnnotation::Bool(span) => *span,
             TypeAnnotation::String(span) => *span,
@@ -239,6 +241,7 @@ impl TypeAnnotation {
 impl PrettyPrint for TypeAnnotation {
     fn pretty_print(&self) -> Markup {
         match self {
+            TypeAnnotation::Never(_) => m::type_identifier("!"),
             TypeAnnotation::DimensionExpression(d) => d.pretty_print(),
             TypeAnnotation::Bool(_) => m::type_identifier("Bool"),
             TypeAnnotation::String(_) => m::type_identifier("String"),
@@ -384,6 +387,7 @@ pub trait ReplaceSpans {
 impl ReplaceSpans for TypeAnnotation {
     fn replace_spans(&self) -> Self {
         match self {
+            TypeAnnotation::Never(_) => TypeAnnotation::Never(Span::dummy()),
             TypeAnnotation::DimensionExpression(d) => {
                 TypeAnnotation::DimensionExpression(d.replace_spans())
             }

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -1237,7 +1237,9 @@ impl<'a> Parser<'a> {
     }
 
     fn type_annotation(&mut self) -> Result<TypeAnnotation> {
-        if let Some(token) = self.match_exact(TokenKind::Bool) {
+        if let Some(token) = self.match_exact(TokenKind::ExclamationMark) {
+            Ok(TypeAnnotation::Never(token.span))
+        } else if let Some(token) = self.match_exact(TokenKind::Bool) {
             Ok(TypeAnnotation::Bool(token.span))
         } else if let Some(token) = self.match_exact(TokenKind::String) {
             Ok(TypeAnnotation::String(token.span))

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -698,3 +698,14 @@ fn test_datetime_runtime_errors() {
         "Error in datetime format",
     )
 }
+
+#[test]
+fn test_user_errors() {
+    expect_failure("error(\"test\")", "User error: test");
+
+    // Make sure that the never type (!) can be used in all contexts
+    expect_failure("- error(\"test\")", "User error: test");
+    expect_failure("1 + error(\"test\")", "User error: test");
+    expect_failure("1 m + error(\"test\")", "User error: test");
+    expect_failure("if 3 < 2 then 2 m else error(\"test\")", "User error: test");
+}


### PR DESCRIPTION
This allow us to use `error(…)` in almost all contexts. In particular, it makes the following code compile for all `X`:

```hs
if <some precondition>
  then X
  else error("please make sure <some precondition> is met")
```

@Bzero This one is for you :smile: 