### PR TITLE
Fix formatting issue in list-functions.md

### DIFF
--- a/book/src/list-functions.md
+++ b/book/src/list-functions.md
@@ -115,6 +115,7 @@ fn rand_poisson<T>(λ: T) -> T
 fn rand_exponential<T>(λ: T) -> 1/T
 fn rand_lognormal(μ: Scalar, σ: Scalar) -> Scalar
 fn rand_pareto<T>(α: Scalar, min: T) -> T
+```
 
 ### Algebra (experimental)
 


### PR DESCRIPTION
This PR simply closes the code block for rand functions in the documentation to fix the formatting of the following header.