### PR TITLE
List datatype

### DIFF
--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -1,0 +1,3 @@
+fn head<A>(xs: List<A>) -> A
+fn tail<A>(xs: List<A>) -> List<A>
+fn cons<A>(x: A, xs: List<A>) -> List<A>

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -1,3 +1,55 @@
+use core::scalar
+
+fn len<A>(xs: List<A>) -> Scalar
 fn head<A>(xs: List<A>) -> A
 fn tail<A>(xs: List<A>) -> List<A>
 fn cons<A>(x: A, xs: List<A>) -> List<A>
+
+fn is_empty<A>(xs: List<A>) -> Bool = len(xs) == 0
+
+# We definitely want to make the following functions generic, but this is not yet possible:
+# Also, we want the base case to be the empty list, but this is also not yet possible.
+
+fn generate(n: Scalar, f: Fn[() -> Scalar]) -> List<Scalar> =
+  if n == 1
+    then [f()]
+    else cons(f(), generate(n - 1, f))
+
+fn map(f: Fn[(Scalar) -> Scalar], xs: List<Scalar>) -> List<Scalar> =
+  if len(xs) == 1
+    then [f(head(xs))]
+    else cons(f(head(xs)), map(f, tail(xs)))
+
+fn cons_end(xs: List<Scalar>, x: Scalar) -> List<Scalar> =
+  if is_empty(xs)
+    then [x]
+    else cons(head(xs), cons_end(tail(xs), x))
+
+fn reverse(xs: List<Scalar>) -> List<Scalar> =
+  if len(xs) == 1
+    then xs
+    else cons_end(reverse(tail(xs)), head(xs))
+
+fn sequence(n: Scalar) -> List<Scalar> =
+  if n == 1
+    then [0]
+    else cons_end(sequence(n - 1), n - 1)
+
+fn foldl(f: Fn[(Scalar, Scalar) -> Scalar], acc: Scalar, xs: List<Scalar>) -> Scalar =
+  if len(xs) == 1
+    then f(acc, head(xs))
+    else foldl(f, f(acc, head(xs)), tail(xs))
+
+fn const_5() -> Scalar = 5
+
+fn inc(x: Scalar) -> Scalar = x + 1
+
+fn add(x: Scalar, y: Scalar) -> Scalar = x + y
+fn mul(x: Scalar, y: Scalar) -> Scalar = x * y
+
+assert(sequence(5) == [0, 1, 2, 3, 4])
+assert(generate(3, const_5) == [5, 5, 5])
+assert(map(inc, [1, 2, 3]) == [2, 3, 4])
+assert(reverse([1, 2, 3]) == [3, 2, 1])
+assert(foldl(add, 0, [1, 2, 3, 4, 5]) == 15)
+assert(foldl(mul, 1, [1, 2, 3, 4, 5]) == 120)

--- a/numbat/modules/prelude.nbt
+++ b/numbat/modules/prelude.nbt
@@ -2,6 +2,7 @@ use core::scalar
 use core::quantities
 use core::dimensions
 use core::functions
+use core::lists
 use core::strings
 use core::error
 use core::random

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -262,6 +262,7 @@ pub enum TypeAnnotation {
     String(Span),
     DateTime(Span),
     Fn(Span, Vec<TypeAnnotation>, Box<TypeAnnotation>),
+    List(Span, Box<TypeAnnotation>),
 }
 
 impl TypeAnnotation {
@@ -273,6 +274,7 @@ impl TypeAnnotation {
             TypeAnnotation::String(span) => *span,
             TypeAnnotation::DateTime(span) => *span,
             TypeAnnotation::Fn(span, _, _) => *span,
+            TypeAnnotation::List(span, _) => *span,
         }
     }
 }
@@ -299,6 +301,12 @@ impl PrettyPrint for TypeAnnotation {
                     + m::space()
                     + return_type.pretty_print()
                     + m::operator("]")
+            }
+            TypeAnnotation::List(_, element_type) => {
+                m::type_identifier("List")
+                    + m::operator("<")
+                    + element_type.pretty_print()
+                    + m::operator(">")
             }
         }
     }
@@ -439,6 +447,9 @@ impl ReplaceSpans for TypeAnnotation {
             TypeAnnotation::DateTime(_) => TypeAnnotation::DateTime(Span::dummy()),
             TypeAnnotation::Fn(_, pt, rt) => {
                 TypeAnnotation::Fn(Span::dummy(), pt.clone(), rt.clone())
+            }
+            TypeAnnotation::List(_, et) => {
+                TypeAnnotation::List(Span::dummy(), Box::new(et.replace_spans()))
             }
         }
     }

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -92,6 +92,7 @@ pub enum Expression {
         fields: Vec<(Span, String, Expression)>,
     },
     AccessField(Span, Span, Box<Expression>, String),
+    List(Span, Vec<Expression>),
 }
 
 impl Expression {
@@ -125,6 +126,7 @@ impl Expression {
             Expression::String(span, _) => *span,
             Expression::InstantiateStruct { full_span, .. } => *full_span,
             Expression::AccessField(full_span, _ident_span, _, _) => *full_span,
+            Expression::List(span, _) => *span,
         }
     }
 }
@@ -222,6 +224,16 @@ macro_rules! struct_ {
 }
 
 #[cfg(test)]
+macro_rules! list {
+    ( $( $val:expr ),* ) => {
+        crate::ast::Expression::List(
+             Span::dummy(),
+            vec![$($val,)*],
+        )
+    };
+}
+
+#[cfg(test)]
 pub(crate) use binop;
 #[cfg(test)]
 pub(crate) use boolean;
@@ -231,6 +243,8 @@ pub(crate) use conditional;
 pub(crate) use factorial;
 #[cfg(test)]
 pub(crate) use identifier;
+#[cfg(test)]
+pub(crate) use list;
 #[cfg(test)]
 pub(crate) use logical_neg;
 #[cfg(test)]
@@ -536,6 +550,10 @@ impl ReplaceSpans for Expression {
                 Span::dummy(),
                 Box::new(expr.replace_spans()),
                 attr.clone(),
+            ),
+            Expression::List(_, elements) => Expression::List(
+                Span::dummy(),
+                elements.iter().map(|e| e.replace_spans()).collect(),
             ),
         }
     }

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -252,6 +252,13 @@ impl BytecodeInterpreter {
                 self.vm
                     .patch_u16_value_at(else_jump_offset, end_offset - (else_jump_offset + 2));
             }
+            Expression::List(_, elements, _) => {
+                for element in elements {
+                    self.compile_expression_with_simplify(element)?;
+                }
+
+                self.vm.add_op1(Op::BuildList, elements.len() as u16);
+            }
         };
 
         Ok(())
@@ -272,7 +279,8 @@ impl BytecodeInterpreter {
             | Expression::String(..)
             | Expression::Condition(..)
             | Expression::InstantiateStruct(..)
-            | Expression::AccessField(..) => {}
+            | Expression::AccessField(..)
+            | Expression::List(..) => {}
             Expression::BinaryOperator(..) | Expression::BinaryOperatorForDate(..) => {
                 self.vm.add_op(Op::FullSimplify);
             }

--- a/numbat/src/diagnostic.rs
+++ b/numbat/src/diagnostic.rs
@@ -328,6 +328,21 @@ impl ErrorDiagnostic for TypeCheckError {
                         .with_notes(vec![inner_error])
                 }
             }
+            TypeCheckError::IncompatibleTypesInList(
+                span_first,
+                type_first,
+                span_subsequent,
+                type_subsequent,
+            ) => d
+                .with_labels(vec![
+                    span_first
+                        .diagnostic_label(LabelStyle::Primary)
+                        .with_message(type_first.to_string()),
+                    span_subsequent
+                        .diagnostic_label(LabelStyle::Secondary)
+                        .with_message(type_subsequent.to_string()),
+                ])
+                .with_notes(vec![inner_error]),
             TypeCheckError::NoDimensionlessBaseUnit(span, unit_name) => d
                 .with_labels(vec![span
                     .diagnostic_label(LabelStyle::Primary)

--- a/numbat/src/ffi.rs
+++ b/numbat/src/ffi.rs
@@ -326,6 +326,14 @@ pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
         );
 
         m.insert(
+            "len".to_string(),
+            ForeignFunction {
+                name: "len".into(),
+                arity: 1..=1,
+                callable: Callable::Function(Box::new(len)),
+            },
+        );
+        m.insert(
             "head".to_string(),
             ForeignFunction {
                 name: "head".into(),
@@ -862,6 +870,14 @@ fn exchange_rate(args: &[Value]) -> Result<Value> {
     Ok(Value::Quantity(Quantity::from_scalar(
         exchange_rates.get_rate(rate).unwrap_or(f64::NAN),
     )))
+}
+
+fn len(args: &[Value]) -> Result<Value> {
+    assert!(args.len() == 1);
+
+    let list = args[0].unsafe_as_list();
+
+    Ok(Value::Quantity(Quantity::from_scalar(list.len() as f64)))
 }
 
 fn head(args: &[Value]) -> Result<Value> {

--- a/numbat/src/ffi.rs
+++ b/numbat/src/ffi.rs
@@ -326,6 +326,31 @@ pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
         );
 
         m.insert(
+            "head".to_string(),
+            ForeignFunction {
+                name: "head".into(),
+                arity: 1..=1,
+                callable: Callable::Function(Box::new(head)),
+            },
+        );
+        m.insert(
+            "tail".to_string(),
+            ForeignFunction {
+                name: "tail".into(),
+                arity: 1..=1,
+                callable: Callable::Function(Box::new(tail)),
+            },
+        );
+        m.insert(
+            "cons".to_string(),
+            ForeignFunction {
+                name: "cons".into(),
+                arity: 2..=2,
+                callable: Callable::Function(Box::new(cons)),
+            },
+        );
+
+        m.insert(
             "str_length".to_string(),
             ForeignFunction {
                 name: "str_length".into(),
@@ -837,6 +862,36 @@ fn exchange_rate(args: &[Value]) -> Result<Value> {
     Ok(Value::Quantity(Quantity::from_scalar(
         exchange_rates.get_rate(rate).unwrap_or(f64::NAN),
     )))
+}
+
+fn head(args: &[Value]) -> Result<Value> {
+    assert!(args.len() == 1);
+
+    let list = args[0].unsafe_as_list();
+
+    if let Some(first) = list.first() {
+        Ok(first.clone())
+    } else {
+        Err(RuntimeError::EmptyList)
+    }
+}
+
+fn tail(args: &[Value]) -> Result<Value> {
+    assert!(args.len() == 1);
+
+    let mut list = args[0].unsafe_as_list();
+    list.remove(0);
+
+    Ok(Value::List(list))
+}
+
+fn cons(args: &[Value]) -> Result<Value> {
+    assert!(args.len() == 2);
+
+    let mut list = args[1].unsafe_as_list().clone();
+    list.insert(0, args[0].clone());
+
+    Ok(Value::List(list))
 }
 
 fn str_length(args: &[Value]) -> Result<Value> {

--- a/numbat/src/interpreter.rs
+++ b/numbat/src/interpreter.rs
@@ -50,12 +50,14 @@ pub enum RuntimeError {
 
     #[error("Invalid format specifiers: {0}")]
     InvalidFormatSpecifiers(String),
-
     #[error("Incorrect type for format specifiers: {0}")]
     InvalidTypeForFormatSpecifiers(String),
 
     #[error("Chemical element not found: {0}")]
     ChemicalElementNotFound(String),
+
+    #[error("Empty list")]
+    EmptyList,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/numbat/src/keywords.rs
+++ b/numbat/src/keywords.rs
@@ -31,6 +31,8 @@ pub const KEYWORDS: &[&str] = &[
     "Bool",
     "String",
     "DateTime",
+    "Fn",
+    "List",
     // decorators
     "metric_prefixes",
     "binary_prefixes",

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -117,6 +117,13 @@ impl Transformer {
                 Box::new(self.transform_expression(*expr)),
                 attr,
             ),
+            Expression::List(span, elements) => Expression::List(
+                span,
+                elements
+                    .into_iter()
+                    .map(|e| self.transform_expression(e))
+                    .collect(),
+            ),
         }
     }
 

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -63,7 +63,6 @@ pub enum TokenKind {
     Multiply,
     Power,
     Divide,
-    Per,
     Comma,
     Arrow,
     Equal,
@@ -85,6 +84,8 @@ pub enum TokenKind {
     Period,
 
     // Keywords
+    Per,
+    To,
     Let,
     Fn, // 'fn'
     Dimension,
@@ -92,27 +93,26 @@ pub enum TokenKind {
     Use,
     Struct,
 
-    To,
-
-    Bool,
-    True,
-    False,
-    If,
-    Then,
-    Else,
-
-    String,
-    DateTime,
-
-    NaN,
-    Inf,
-
-    CapitalFn, // 'Fn'
-
     Long,
     Short,
     Both,
     None,
+
+    If,
+    Then,
+    Else,
+    True,
+    False,
+
+    NaN,
+    Inf,
+
+    // Type names
+    Bool,
+    String,
+    DateTime,
+    CapitalFn, // 'Fn'
+    List,
 
     // Procedure calls
     ProcedurePrint,
@@ -346,33 +346,40 @@ impl Tokenizer {
         static KEYWORDS: OnceLock<HashMap<&'static str, TokenKind>> = OnceLock::new();
         let keywords = KEYWORDS.get_or_init(|| {
             let mut m = HashMap::new();
+            // keywords
             m.insert("per", TokenKind::Per);
             m.insert("to", TokenKind::To);
             m.insert("let", TokenKind::Let);
             m.insert("fn", TokenKind::Fn);
-            m.insert("struct", TokenKind::Struct);
             m.insert("dimension", TokenKind::Dimension);
             m.insert("unit", TokenKind::Unit);
             m.insert("use", TokenKind::Use);
+            m.insert("struct", TokenKind::Struct);
             m.insert("long", TokenKind::Long);
             m.insert("short", TokenKind::Short);
             m.insert("both", TokenKind::Both);
             m.insert("none", TokenKind::None);
+            m.insert("if", TokenKind::If);
+            m.insert("then", TokenKind::Then);
+            m.insert("else", TokenKind::Else);
+            m.insert("true", TokenKind::True);
+            m.insert("false", TokenKind::False);
+            m.insert("NaN", TokenKind::NaN);
+            m.insert("inf", TokenKind::Inf);
+
+            // procedures
             m.insert("print", TokenKind::ProcedurePrint);
             m.insert("assert", TokenKind::ProcedureAssert);
             m.insert("assert_eq", TokenKind::ProcedureAssertEq);
             m.insert("type", TokenKind::ProcedureType);
+
+            // type names
             m.insert("Bool", TokenKind::Bool);
-            m.insert("true", TokenKind::True);
-            m.insert("false", TokenKind::False);
-            m.insert("if", TokenKind::If);
-            m.insert("then", TokenKind::Then);
-            m.insert("else", TokenKind::Else);
             m.insert("String", TokenKind::String);
             m.insert("DateTime", TokenKind::DateTime);
             m.insert("Fn", TokenKind::CapitalFn);
-            m.insert("NaN", TokenKind::NaN);
-            m.insert("inf", TokenKind::Inf);
+            m.insert("List", TokenKind::List);
+
             // Keep this list in sync with keywords::KEYWORDS!
             m
         });

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -1186,3 +1186,20 @@ fn test_field_access() {
         @"Error at (1, 11): `Expected digit`"
     );
 }
+
+#[test]
+fn test_lists() {
+    insta::assert_snapshot!(
+        tokenize_reduced_pretty("[1, 2.3, 4]").unwrap(),
+        @r###"
+    "[", LeftBracket, (1, 1)
+    "1", Number, (1, 2)
+    ",", Comma, (1, 3)
+    "2.3", Number, (1, 5)
+    ",", Comma, (1, 8)
+    "4", Number, (1, 10)
+    "]", RightBracket, (1, 11)
+    "", Eof, (1, 12)
+    "###
+    );
+}

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -450,6 +450,9 @@ fn evaluate_const_expr(expr: &typed_ast::Expression) -> Result<Exponent> {
         e @ typed_ast::Expression::AccessField(_, _, _, _, _, _) => Err(
             TypeCheckError::UnsupportedConstEvalExpression(e.full_span(), "access field of struct"),
         ),
+        e @ typed_ast::Expression::List(_, _, _) => Err(
+            TypeCheckError::UnsupportedConstEvalExpression(e.full_span(), "lists"),
+        ),
     }
 }
 
@@ -1268,6 +1271,29 @@ impl TypeChecker {
                     struct_info,
                     ret_ty,
                 )
+            }
+            ast::Expression::List(span, elements) => {
+                let elements_checked = elements
+                    .iter()
+                    .map(|e| self.check_expression(e))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let element_types: Vec<Type> =
+                    elements_checked.iter().map(|e| e.get_type()).collect();
+
+                let element_type = if element_types.is_empty() {
+                    todo!()
+                } else {
+                    let element_type = element_types[0].clone();
+                    for t in element_types.iter().skip(1) {
+                        if element_type != *t {
+                            todo!()
+                        }
+                    }
+                    element_type
+                };
+
+                typed_ast::Expression::List(*span, elements_checked, element_type)
             }
         })
     }

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -105,11 +105,11 @@ impl std::fmt::Display for Type {
 impl PrettyPrint for Type {
     fn pretty_print(&self) -> Markup {
         match self {
-            Type::Never => m::keyword("!"),
+            Type::Never => m::type_identifier("!"),
             Type::Dimension(d) => d.pretty_print(),
-            Type::Boolean => m::keyword("Bool"),
-            Type::String => m::keyword("String"),
-            Type::DateTime => m::keyword("DateTime"),
+            Type::Boolean => m::type_identifier("Bool"),
+            Type::String => m::type_identifier("String"),
+            Type::DateTime => m::type_identifier("DateTime"),
             Type::Fn(param_types, return_type) => {
                 m::type_identifier("Fn")
                     + m::operator("[(")
@@ -164,6 +164,7 @@ impl Type {
         match (self, other) {
             (Type::Never, _) => true,
             (_, Type::Never) => false,
+            (Type::List(el1), Type::List(el2)) => el1.is_subtype_of(el2),
             (t1, t2) => t1 == t2,
         }
     }

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -34,6 +34,7 @@ pub enum Value {
     FunctionReference(FunctionReference),
     FormatSpecifiers(Option<String>),
     StructInstance(Arc<StructInfo>, Vec<Value>),
+    List(Vec<Value>),
 }
 
 impl Value {
@@ -119,6 +120,14 @@ impl std::fmt::Display for Value {
                     )
                 }
             ),
+            Value::List(elements) => write!(
+                f,
+                "[{}]",
+                elements
+                    .iter()
+                    .map(|element| element.to_string())
+                    .join(", ")
+            ),
         }
     }
 }
@@ -154,6 +163,15 @@ impl PrettyPrint for Value {
                             + crate::markup::space()
                     }
                     + crate::markup::operator("}")
+            }
+            Value::List(elements) => {
+                crate::markup::operator("[")
+                    + itertools::Itertools::intersperse(
+                        elements.iter().map(|element| element.pretty_print()),
+                        crate::markup::operator(",") + crate::markup::space(),
+                    )
+                    .sum()
+                    + crate::markup::operator("]")
             }
         }
     }

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -91,6 +91,15 @@ impl Value {
             panic!("Expected value to be a struct");
         }
     }
+
+    #[track_caller]
+    pub fn unsafe_as_list(&self) -> Vec<Value> {
+        if let Value::List(values) = self {
+            values.clone()
+        } else {
+            panic!("Expected value to be a list");
+        }
+    }
 }
 
 impl std::fmt::Display for Value {

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -1016,6 +1016,7 @@ impl Vm {
                     for _ in 0..length {
                         list.push(self.pop());
                     }
+                    list.reverse();
 
                     self.stack.push(Value::List(list));
                 }


### PR DESCRIPTION
This is a basic implementation of lists for Numbat. We construct lists using `[…]` notation and the type of lists is specified as `List<T>` where `T` can be any type.

```
>>> [1, 2, 3]

    = [1, 2, 3]    [List<Scalar>]

>>> [1m, 30cm]

    = [1 m, 30 cm]    [List<Length>]

>>> [["foo", "bar"], ["baz"]]

    = [[foo, bar], [baz]]    [List<List<String>>]

```

Operationally, they work just fine. For example, we can add the functional-programming style primitives `head`, `tail` and `cons`:

```
fn head<A>(xs: List<A>) -> A
fn tail<A>(xs: List<A>) -> List<A>
fn cons<A>(x: A, xs: List<A>) -> List<A>
```

and they work as expected:

```
>>> cons(0, [1, 2, 3])

    = [0, 1, 2, 3]    [List<Scalar>]
```

We can even write some useful functions like
```
>>> fn generate(n: Scalar, f: Fn[() -> Scalar]) -> List<Scalar> =
  if n == 1
    then [f()]
    else cons(f(), generate(n - 1, f))
```

```
>>> generate(10, random)

    = [0.372604, 0.123614, 0.297907, 0.966904, 0.296039, 0.351666, 0.923613, 0.0140005, 0.254682, 0.518355]    [List<Scalar>]
```

Type checking of list construction also works fine:

```
>>> [1 m, 40 cm, 3 kg, 2 m]
error: while type checking
  ┌─ <input:3>:1:2
  │
1 │ [1 m, 40 cm, 3 kg, 2 m]
  │  ^^^         ---- Mass
  │  │            
  │  Length
  │
  = Incompatible types in list: expected 'Length', got 'Mass' instead
```

However, there are a number of open questions / issues regarding the handling of lists in the type checker:

- We don't have polymorphic *values* yet. So we can't type the empty list `[]`, which should have the type `∀D. List<D>`. We have a similar problem with typing `0`, `NaN` and `inf`, see #37.
- Almost all useful functions on lists will be generic over the element type. Very basic things (like len, head, tail, cons) work fine when implemented via the FFI. But if we want to use those functions to implement `map`, `filter`, etc., we are running into type inference problems (already reported as https://github.com/sharkdp/numbat/issues/166).
- Polymorphism in Numbat only works for *dimension types* (`Scalar`, `Length`, `Length^2`, `Length / Time`, etc). But so far, we can't be generic over *all* types, which means we can not give a type to a function that works on all lists, only on lists of arbitrary dimension types. So we can create things like `List<Bool>`,`List<String>` or `List<List<Length>>`, but we can't run `cons`, `head`, `tail` on them.

related ticket: #261 