### PR TITLE
Function decorators

### DIFF
--- a/book/src/cli-usage.md
+++ b/book/src/cli-usage.md
@@ -37,7 +37,7 @@ There is a set of special commands that only work in interactive mode:
 |---------|--------|
 | `list`, `ls` | List all functions, dimensions, variables and units |
 | `list <what>` | Where `<what>` can be `functions`, `dimensions`, `variables`, `units` |
-| `info <identifier>` | Get more information about units and variables |
+| `info <identifier>` | Get more information about units, variables and functions |
 | `clear` | Clear screen |
 | `help`, `?` | View short help text |
 | `quit`, `exit` | Quit the session |

--- a/numbat-cli/tests/integration.rs
+++ b/numbat-cli/tests/integration.rs
@@ -159,4 +159,13 @@ fn info_text() {
     numbat().write_stdin("info C").assert().success().stdout(
         predicates::str::contains("Coulomb").and(predicates::str::contains("1 coulomb = ")),
     );
+
+    numbat()
+        .write_stdin("info round")
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("Round")
+                .and(predicates::str::contains("Round to the nearest integer.")),
+        );
 }

--- a/numbat/modules/chemistry/elements.nbt
+++ b/numbat/modules/chemistry/elements.nbt
@@ -48,6 +48,7 @@ fn _convert_from_raw(raw: _ChemicalElementRaw) -> ChemicalElement =
         vaporization_heat: raw.vaporization_heat_kilojoule_per_mole * kJ/mol,
     }
 
-# Get properties of a chemical element by its symbol or name (case-insensitive).
+@name("Chemical element")
+@description("Get properties of a chemical element by its symbol or name (case-insensitive).")
 fn element(pattern: String) -> ChemicalElement =
     _convert_from_raw(_get_chemical_element_data_raw(pattern))

--- a/numbat/modules/core/error.nbt
+++ b/numbat/modules/core/error.nbt
@@ -1,2 +1,2 @@
-# Throw a user-defined error
+@description("Throw a user-defined error.")
 fn error(message: String) -> !

--- a/numbat/modules/core/functions.nbt
+++ b/numbat/modules/core/functions.nbt
@@ -1,5 +1,20 @@
+@name("Absolute value")
+@url("https://doc.rust-lang.org/std/primitive.f64.html#method.abs")
 fn abs<T>(x: T) -> T
+
+@name("Round")
+@url("https://doc.rust-lang.org/std/primitive.f64.html#method.round")
+@description("Round to the nearest integer.")
 fn round<T>(x: T) -> T
+
+@name("Floor function")
+@url("https://doc.rust-lang.org/std/primitive.f64.html#method.floor")
 fn floor<T>(x: T) -> T
+
+@name("Ceil function")
+@url("https://doc.rust-lang.org/std/primitive.f64.html#method.ceil")
 fn ceil<T>(x: T) -> T
+
+@name("Modulo")
+@url("https://doc.rust-lang.org/std/primitive.f64.html#method.rem_euclid")
 fn mod<T>(a: T, b: T) -> T

--- a/numbat/modules/core/random.nbt
+++ b/numbat/modules/core/random.nbt
@@ -4,30 +4,30 @@ use core::error
 use core::functions
 use math::functions
 
-# name: Standard uniform distribution sampling
-# description: Uniformly samples the interval [0,1).
+@name("Standard uniform distribution sampling")
+@description("Uniformly samples the interval [0,1).")
 fn random() -> Scalar
 
-# name: Continuous uniform distribution sampling
-# url: https://en.wikipedia.org/wiki/Continuous_uniform_distribution
-# description: Uniformly samples the interval [a,b) if a<=b or [b,a) if b<a using inversion sampling.
+@name("Continuous uniform distribution sampling")
+@url("https://en.wikipedia.org/wiki/Continuous_uniform_distribution")
+@description("Uniformly samples the interval [a,b) if a<=b or [b,a) if b<a using inversion sampling.")
 fn rand_uniform<T>(a: T, b: T) -> T =
     if a <= b
     then random() * (b - a) + a
     else random() * (a - b) + b
 
-# name: Discrete uniform distribution sampling
-# url: https://en.wikipedia.org/wiki/Discrete_uniform_distribution
-# description: Uniformly samples the integers in the interval [a, b].
+@name("Discrete uniform distribution sampling")
+@url("https://en.wikipedia.org/wiki/Discrete_uniform_distribution")
+@description("Uniformly samples the integers in the interval [a, b].")
 fn rand_int(a: Scalar, b: Scalar) -> Scalar =
     if a <= b
     then floor( random() * (floor(b) - ceil(a) + 1) ) + ceil(a)
     else floor( random() * (floor(a) - ceil(b) + 1) ) + ceil(b)
 
-# name: Bernoulli distribution sampling
-# url: https://en.wikipedia.org/wiki/Bernoulli_distribution
-# description: Samples a Bernoulli random variable, that is, 1 with probability p, 0 with probability 1-p.
-#              Parameter p must be a probability (0 <= p <= 1).
+@name("Bernoulli distribution sampling")
+@url("https://en.wikipedia.org/wiki/Bernoulli_distribution")
+@description("Samples a Bernoulli random variable, that is, 1 with probability p, 0 with probability 1-p.
+              Parameter p must be a probability (0 <= p <= 1).")
 fn rand_bernoulli(p: Scalar) -> Scalar =
     if p>=0 && p<=1
     then (if random() < p
@@ -35,10 +35,10 @@ fn rand_bernoulli(p: Scalar) -> Scalar =
         else 0)
     else error("Argument p must be a probability (0 <= p <= 1).")
 
-# name: Binomial distribution sampling
-# url: https://en.wikipedia.org/wiki/Binomial_distribution
-# description: Samples a binomial distribution by doing n Bernoulli trials with probability p.
-#              Parameter n must be a positive integer, parameter p must be a probability (0 <= p <= 1).
+@name("Binomial distribution sampling")
+@url("https://en.wikipedia.org/wiki/Binomial_distribution")
+@description("Samples a binomial distribution by doing n Bernoulli trials with probability p.
+              Parameter n must be a positive integer, parameter p must be a probability (0 <= p <= 1).")
 fn rand_binom(n: Scalar, p: Scalar) -> Scalar =
     if n >= 1
     then rand_binom(n-1, p) + rand_bernoulli(p)
@@ -46,16 +46,16 @@ fn rand_binom(n: Scalar, p: Scalar) -> Scalar =
     then 0
     else error("Argument n must be a positive integer.")
 
-# name: Normal distribution sampling
-# url: https://en.wikipedia.org/wiki/Normal_distribution
-# description: Samples a normal distribution with mean μ and standard deviation σ using the Box-Muller transform.
+@name("Normal distribution sampling")
+@url("https://en.wikipedia.org/wiki/Normal_distribution")
+@description("Samples a normal distribution with mean μ and standard deviation σ using the Box-Muller transform.")
 fn rand_norm<T>(μ: T, σ: T) -> T =
     μ + sqrt(-2 σ² × ln(random())) × sin(2π × random())
 
-# name: Geometric distribution sampling
-# url: https://en.wikipedia.org/wiki/Geometric_distribution
-# description: Samples a geometric distribution (the distribution of the number of Bernoulli trials with probability p needed to get one success) by inversion sampling.
-#              Parameter p must be a probability (0 <= p <= 1).
+@name("Geometric distribution sampling")
+@url("https://en.wikipedia.org/wiki/Geometric_distribution")
+@description("Samples a geometric distribution (the distribution of the number of Bernoulli trials with probability p needed to get one success) by inversion sampling.
+              Parameter p must be a probability (0 <= p <= 1).")
 fn rand_geom(p: Scalar) -> Scalar =
     if p>=0 && p<=1
     then ceil( ln(1-random()) / ln(1-p) )
@@ -67,35 +67,35 @@ fn _poisson(lim: Scalar, prod: Scalar) -> Scalar =
     then _poisson(lim,  prod × random()) + 1
     else -1
 
-# name: Poisson distribution sampling
-# url: https://en.wikipedia.org/wiki/Poisson_distribution
-# description: Sampling a poisson distribution with rate λ, that is, the distribution of the number of events occurring in a fixed interval if these events occur with mean rate λ.
-#              The rate parameter λ must not be negative.
+@name("Poisson distribution sampling")
+@url("https://en.wikipedia.org/wiki/Poisson_distribution")
+@description("Sampling a poisson distribution with rate λ, that is, the distribution of the number of events occurring in a fixed interval if these events occur with mean rate λ.
+              The rate parameter λ must not be negative.")
 # This implementation is based on the exponential distribution of inter-arrival times. For details see L. Devroye, Non-Uniform Random Variate Generation, p. 504, Lemma 3.3.
 fn rand_poisson(λ: Scalar) -> Scalar =
     if λ >= 0
     then _poisson(exp(-λ), 1)
     else error("Argument λ must not be negative.")
 
-# name: Exponential distribution sampling
-# url: https://en.wikipedia.org/wiki/Exponential_distribution
-# description: Sampling an exponential distribution (the distribution of the distance between events in a Poisson process with rate λ) using inversion sampling.
-#              The rate parameter λ must be positive.
+@name("Exponential distribution sampling")
+@url("https://en.wikipedia.org/wiki/Exponential_distribution")
+@description("Sampling an exponential distribution (the distribution of the distance between events in a Poisson process with rate λ) using inversion sampling.
+              The rate parameter λ must be positive.")
 fn rand_expon<T>(λ: T) -> 1/T =
     if value_of(λ) > 0
     then - ln(1-random()) / λ
     else error("Argument λ must be positive.")
 
-# name: Log-normal distribution sampling
-# url: https://en.wikipedia.org/wiki/Log-normal_distribution
-# description: Sampling a log-normal distribution, that is, a distribution whose log is a normal distribution with mean μ and standard deviation σ.
+@name("Log-normal distribution sampling")
+@url("https://en.wikipedia.org/wiki/Log-normal_distribution")
+@description("Sampling a log-normal distribution, that is, a distribution whose log is a normal distribution with mean μ and standard deviation σ.")
 fn rand_lognorm(μ: Scalar, σ: Scalar) -> Scalar =
     exp( μ + σ × rand_norm(0, 1) )
 
-# name: Pareto distribution sampling
-# url: https://en.wikipedia.org/wiki/Pareto_distribution
-# description: Sampling a Pareto distribution with minimum value min and shape parameter α using inversion sampling.
-#              Both parameters α and min must be positive.
+@name("Pareto distribution sampling")
+@url("https://en.wikipedia.org/wiki/Pareto_distribution")
+@description("Sampling a Pareto distribution with minimum value min and shape parameter α using inversion sampling.
+              Both parameters α and min must be positive.")
 fn rand_pareto<T>(α: Scalar, min: T) -> T =
     if value_of(min) > 0 && α > 0
     then min / ((1-random())^(1/α))

--- a/numbat/modules/datetime/functions.nbt
+++ b/numbat/modules/datetime/functions.nbt
@@ -6,7 +6,7 @@ use units::si
 fn now() -> DateTime
 
 @url("https://numbat.dev/doc/date-and-time.html")
-@description("Parses a string (date and time) into a DateTime object.")
+@description("Parses a string (date and time) into a DateTime object. See https://numbat.dev/doc/date-and-time.html#date-time-formats for an overview of the supported formats.")
 fn datetime(input: String) -> DateTime
 
 @url("https://numbat.dev/doc/date-and-time.html")

--- a/numbat/modules/datetime/functions.nbt
+++ b/numbat/modules/datetime/functions.nbt
@@ -1,26 +1,56 @@
 use core::strings
 use units::si
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Returns the current date and time.")
 fn now() -> DateTime
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Parses a string (date and time) into a DateTime object.")
 fn datetime(input: String) -> DateTime
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Formats a DateTime object as a string.")
 fn format_datetime(format: String, input: DateTime) -> String
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Returns the users local timezone.")
 fn get_local_timezone() -> String
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Returns a timezone conversion function, typically used with the conversion operator.")
 fn tz(tz: String) -> Fn[(DateTime) -> DateTime]
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Timezone conversion function targeting the users local timezone (datetime -> local).")
 let local: Fn[(DateTime) -> DateTime] = tz(get_local_timezone())
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Timezone conversion function to UTC.")
 let UTC: Fn[(DateTime) -> DateTime] = tz("UTC")
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Converts a DateTime to a UNIX timestamp.")
 fn unixtime(input: DateTime) -> Scalar
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Converts a UNIX timestamp to a DateTime object.")
 fn from_unixtime(input: Scalar) -> DateTime
 
 fn _today_str() = format_datetime("%Y-%m-%d", now())
+
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Returns the current date at midnight (in the local time).")
 fn today() -> DateTime = datetime("{_today_str()} 00:00:00")
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Parses a string (only date) into a DateTime object.")
 fn date(input: String) -> DateTime =
   if str_contains(input, " ")
     then datetime(str_replace(input, " ", " 00:00:00 "))
     else datetime("{input} 00:00:00")
 
+@url("https://numbat.dev/doc/date-and-time.html")
+@description(" Parses a string (only time) into a DateTime object.")
 fn time(input: String) -> DateTime =
   datetime("{_today_str()} {input}")

--- a/numbat/modules/datetime/human.nbt
+++ b/numbat/modules/datetime/human.nbt
@@ -30,6 +30,9 @@ fn _human_readable_duration(time: Time, dt: DateTime, num_days: Scalar) -> Strin
 # we skip hours/minutes/seconds for durations larger than 1000 days because:
 #   (a) we run into floating point precision problems at the nanosecond level at this point
 #   (b) for much larger numbers, we can't convert to DateTimes anymore
+@name("Human-readable time duration")
+@url("https://numbat.dev/doc/date-and-time.html")
+@description("Converts a time duration to a human-readable string in days, hours, minutes and seconds.")
 fn human(time: Time) =
   if _human_num_days(time) > 1000
     then "{_human_num_days(time)} days" 

--- a/numbat/modules/math/functions.nbt
+++ b/numbat/modules/math/functions.nbt
@@ -3,42 +3,101 @@ use math::constants
 
 ## Basics
 
+@name("Square root")
+@url("https://en.wikipedia.org/wiki/Square_root")
 fn sqrt<D>(x: D^2) -> D = x^(1/2)
+
+@name("Square function")
 fn sqr<D>(x: D) -> D^2 = x^2
 
 ## Exponential and logarithm
 
+@name("Exponential function")
+@url("https://en.wikipedia.org/wiki/Exponential_function")
 fn exp(x: Scalar) -> Scalar
+
+@name("Natural logarithm")
+@url("https://en.wikipedia.org/wiki/Natural_logarithm")
 fn ln(x: Scalar) -> Scalar
+
+@name("Natural logarithm")
+@url("https://en.wikipedia.org/wiki/Natural_logarithm")
 fn log(x: Scalar) -> Scalar = ln(x)
+
+@name("Common logarithm")
+@url("https://en.wikipedia.org/wiki/Common_logarithm")
 fn log10(x: Scalar) -> Scalar
+
+@name("Binary logarithm")
+@url("https://en.wikipedia.org/wiki/Binary_logarithm")
 fn log2(x: Scalar) -> Scalar
 
 ## Trigonometry
 
+@name("Sine")
+@url("https://en.wikipedia.org/wiki/Trigonometric_functions")
 fn sin(x: Scalar) -> Scalar
+
+@name("Cosine")
+@url("https://en.wikipedia.org/wiki/Trigonometric_functions")
 fn cos(x: Scalar) -> Scalar
+
+@name("Tangent")
+@url("https://en.wikipedia.org/wiki/Trigonometric_functions")
 fn tan(x: Scalar) -> Scalar
+
+@name("Arc sine")
+@url("https://en.wikipedia.org/wiki/Inverse_trigonometric_functions")
 fn asin(x: Scalar) -> Scalar
+
+@name("Arc cosine")
+@url("https://en.wikipedia.org/wiki/Inverse_trigonometric_functions")
 fn acos(x: Scalar) -> Scalar
+
+@name("Arc tangent")
+@url("https://en.wikipedia.org/wiki/Inverse_trigonometric_functions")
 fn atan(x: Scalar) -> Scalar
+
+@url("https://en.wikipedia.org/wiki/Atan2")
 fn atan2<T>(y: T, x: T) -> Scalar
 
+@name("Hyperbolic sine")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn sinh(x: Scalar) -> Scalar
+
+@name("Hyperbolic cosine")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn cosh(x: Scalar) -> Scalar
+
+@name("Hyperbolic tangent")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn tanh(x: Scalar) -> Scalar
+
+@name("Area hyperbolic sine")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn asinh(x: Scalar) -> Scalar
+
+@name("Area hyperbolic cosine")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn acosh(x: Scalar) -> Scalar
+
+@name("Area hyperbolic tangent ")
+@url("https://en.wikipedia.org/wiki/Hyperbolic_functions")
 fn atanh(x: Scalar) -> Scalar
 
 # Note: there are even more functions in `math::trigonmetry_extra`.
 
 ## Others
 
+
+@name("Gamma function")
+@url("https://en.wikipedia.org/wiki/Gamma_function")
 fn gamma(x: Scalar) -> Scalar
 
 ### Statistics
 
+@name("Arithmetic mean")
+@url("https://en.wikipedia.org/wiki/Arithmetic_mean")
 fn mean<D>(xs: D…) -> D
 fn maximum<D>(xs: D…) -> D
 fn minimum<D>(xs: D…) -> D

--- a/numbat/modules/physics/temperature_conversion.nbt
+++ b/numbat/modules/physics/temperature_conversion.nbt
@@ -4,11 +4,21 @@ use units::si
 
 let _offset_celsius = 273.15
 
+@description("Converts from degree Celsius to Kelvin.")
+@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
 fn from_celsius(t_celsius: Scalar) -> Temperature = (t_celsius + _offset_celsius) kelvin
+
+@description("Converts from Kelvin to degree Celsius.")
+@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
 fn celsius(t_kelvin: Temperature) -> Scalar = t_kelvin / kelvin - _offset_celsius
 
 let _offset_fahrenheit = 459.67
 let _scale_fahrenheit = 5 / 9
 
+@description("Converts from degree Fahrenheit to Kelvin.")
+@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
 fn from_fahrenheit(t_fahrenheit: Scalar) -> Temperature = ((t_fahrenheit + _offset_fahrenheit) × _scale_fahrenheit) kelvin
+
+@description("Converts from Kelvin to degree Fahrenheit.")
+@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
 fn fahrenheit(t_kelvin: Temperature) -> Scalar = (t_kelvin / kelvin) / _scale_fahrenheit - _offset_fahrenheit

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -388,6 +388,7 @@ pub enum Statement {
         return_type_annotation_span: Option<Span>,
         /// Optional annotated return type
         return_type_annotation: Option<TypeAnnotation>,
+        decorators: Vec<Decorator>,
     },
     DefineDimension(Span, String, Vec<TypeExpression>),
     DefineBaseUnit(Span, String, Option<TypeExpression>, Vec<Decorator>),
@@ -566,6 +567,7 @@ impl ReplaceSpans for Statement {
                 body,
                 return_type_annotation_span: return_type_span,
                 return_type_annotation,
+                decorators,
             } => Statement::DefineFunction {
                 function_name_span: Span::dummy(),
                 function_name: function_name.clone(),
@@ -587,6 +589,7 @@ impl ReplaceSpans for Statement {
                 body: body.clone().map(|b| b.replace_spans()),
                 return_type_annotation_span: return_type_span.map(|_| Span::dummy()),
                 return_type_annotation: return_type_annotation.as_ref().map(|t| t.replace_spans()),
+                decorators: decorators.clone(),
             },
             Statement::DefineDimension(_, name, dexprs) => Statement::DefineDimension(
                 Span::dummy(),

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -22,6 +22,7 @@ use crate::{decorator, ffi};
 pub struct DecoratorMetadata {
     pub name: Option<String>,
     pub url: Option<String>,
+    pub description: Option<String>,
     pub aliases: Vec<String>,
 }
 
@@ -297,6 +298,7 @@ impl BytecodeInterpreter {
                 let metadata = DecoratorMetadata {
                     name: crate::decorator::name(decorators),
                     url: crate::decorator::url(decorators),
+                    description: crate::decorator::description(decorators),
                     aliases: aliases.clone(),
                 };
 
@@ -326,6 +328,7 @@ impl BytecodeInterpreter {
                 let metadata = DecoratorMetadata {
                     name: crate::decorator::name(decorators),
                     url: crate::decorator::url(decorators),
+                    description: crate::decorator::description(decorators),
                     aliases: aliases.clone(),
                 };
 
@@ -373,6 +376,7 @@ impl BytecodeInterpreter {
                 let metadata = DecoratorMetadata {
                     name: crate::decorator::name(decorators),
                     url: crate::decorator::url(decorators),
+                    description: crate::decorator::description(decorators),
                     aliases: vec![],
                 };
 
@@ -410,6 +414,7 @@ impl BytecodeInterpreter {
                                 unit_name, decorators,
                             ),
                             url: decorator::url(decorators),
+                            description: decorator::description(decorators),
                             binary_prefixes: decorators.contains(&Decorator::BinaryPrefixes),
                             metric_prefixes: decorators.contains(&Decorator::MetricPrefixes),
                         },
@@ -453,6 +458,7 @@ impl BytecodeInterpreter {
                         name: decorator::name(decorators),
                         canonical_name: decorator::get_canonical_unit_name(unit_name, decorators),
                         url: decorator::url(decorators),
+                        description: decorator::description(decorators),
                         binary_prefixes: decorators.contains(&Decorator::BinaryPrefixes),
                         metric_prefixes: decorators.contains(&Decorator::MetricPrefixes),
                     },

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -19,7 +19,7 @@ use crate::vm::{Constant, ExecutionContext, Op, Vm};
 use crate::{decorator, ffi};
 
 #[derive(Debug, Clone, Default)]
-pub struct LocalMetadata {
+pub struct DecoratorMetadata {
     pub name: Option<String>,
     pub url: Option<String>,
     pub aliases: Vec<String>,
@@ -29,7 +29,7 @@ pub struct LocalMetadata {
 pub struct Local {
     identifier: String,
     depth: usize,
-    pub metadata: LocalMetadata,
+    pub metadata: DecoratorMetadata,
 }
 
 #[derive(Clone)]
@@ -40,7 +40,7 @@ pub struct BytecodeInterpreter {
     // Maps names of units to indices of the respective constants in the VM
     unit_name_to_constant_index: HashMap<String, u16>,
     /// List of functions
-    functions: HashMap<String, bool>,
+    functions: HashMap<String, (bool, DecoratorMetadata)>,
 }
 
 impl BytecodeInterpreter {
@@ -67,7 +67,7 @@ impl BytecodeInterpreter {
                     self.vm.add_op1(Op::GetUpvalue, upvalue_position as u16);
                 } else if LAST_RESULT_IDENTIFIERS.contains(&identifier.as_str()) {
                     self.vm.add_op(Op::GetLastResult);
-                } else if let Some(is_foreign) = self.functions.get(identifier) {
+                } else if let Some((is_foreign, _)) = self.functions.get(identifier) {
                     let index = self
                         .vm
                         .add_constant(Constant::FunctionReference(if *is_foreign {
@@ -294,7 +294,7 @@ impl BytecodeInterpreter {
                     .map(|(name, _)| name)
                     .cloned()
                     .collect::<Vec<_>>();
-                let metadata = LocalMetadata {
+                let metadata = DecoratorMetadata {
                     name: crate::decorator::name(decorators),
                     url: crate::decorator::url(decorators),
                     aliases: aliases.clone(),
@@ -312,36 +312,53 @@ impl BytecodeInterpreter {
             }
             Statement::DefineFunction(
                 name,
+                decorators,
                 _type_parameters,
                 parameters,
                 Some(expr),
                 _return_type_annotation,
                 _return_type,
             ) => {
-                self.vm.begin_function(name);
+                let aliases = crate::decorator::name_and_aliases(name, decorators)
+                    .map(|(fname, _)| fname)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let metadata = DecoratorMetadata {
+                    name: crate::decorator::name(decorators),
+                    url: crate::decorator::url(decorators),
+                    aliases: aliases.clone(),
+                };
 
-                self.locals.push(vec![]);
+                // This creates a copy of the function for each alias.
+                // A cleaner and more efficient way to handle aliases would probably be to use a 'function pointer'. This would also enable using aliases for FFI functions.
+                for alias_name in aliases {
+                    self.vm.begin_function(&alias_name);
 
-                let current_depth = self.current_depth();
-                for parameter in parameters {
-                    self.locals[current_depth].push(Local {
-                        identifier: parameter.1.clone(),
-                        depth: current_depth,
-                        metadata: LocalMetadata::default(),
-                    });
+                    self.locals.push(vec![]);
+
+                    let current_depth = self.current_depth();
+                    for parameter in parameters {
+                        self.locals[current_depth].push(Local {
+                            identifier: parameter.1.clone(),
+                            depth: current_depth,
+                            metadata: DecoratorMetadata::default(),
+                        });
+                    }
+
+                    self.compile_expression_with_simplify(expr)?;
+                    self.vm.add_op(Op::Return);
+
+                    self.locals.pop();
+
+                    self.vm.end_function();
+
+                    self.functions
+                        .insert(alias_name.clone(), (false, metadata.clone()));
                 }
-
-                self.compile_expression_with_simplify(expr)?;
-                self.vm.add_op(Op::Return);
-
-                self.locals.pop();
-
-                self.vm.end_function();
-
-                self.functions.insert(name.clone(), false);
             }
             Statement::DefineFunction(
                 name,
+                decorators,
                 _type_parameters,
                 parameters,
                 None,
@@ -353,6 +370,12 @@ impl BytecodeInterpreter {
 
                 let is_variadic = parameters.iter().any(|p| p.2);
 
+                let metadata = DecoratorMetadata {
+                    name: crate::decorator::name(decorators),
+                    url: crate::decorator::url(decorators),
+                    aliases: vec![],
+                };
+
                 self.vm.add_foreign_function(
                     name,
                     if is_variadic {
@@ -362,7 +385,8 @@ impl BytecodeInterpreter {
                     },
                 );
 
-                self.functions.insert(name.clone(), true);
+                self.functions
+                    .insert(name.clone(), (true, metadata.clone()));
             }
             Statement::DefineDimension(_name, _dexprs) => {
                 // Declaring a dimension is like introducing a new type. The information
@@ -508,6 +532,10 @@ impl BytecodeInterpreter {
 
     pub fn lookup_global(&self, name: &str) -> Option<&Local> {
         self.locals[0].iter().find(|l| l.identifier == name)
+    }
+
+    pub fn lookup_function(&self, name: &str) -> Option<&(bool, DecoratorMetadata)> {
+        self.functions.get(name)
     }
 }
 

--- a/numbat/src/decorator.rs
+++ b/numbat/src/decorator.rs
@@ -84,3 +84,13 @@ pub fn contains_aliases_with_prefixes(decorates: &[Decorator]) -> bool {
 
     false
 }
+
+pub fn contains_aliases(decorates: &[Decorator]) -> bool {
+    for decorator in decorates {
+        if let Decorator::Aliases(_) = decorator {
+            return true;
+        }
+    }
+
+    false
+}

--- a/numbat/src/decorator.rs
+++ b/numbat/src/decorator.rs
@@ -7,6 +7,7 @@ pub enum Decorator {
     Aliases(Vec<(String, Option<AcceptsPrefix>)>),
     Url(String),
     Name(String),
+    Description(String),
 }
 
 pub fn name_and_aliases<'a>(
@@ -71,6 +72,21 @@ pub fn url(decorators: &[Decorator]) -> Option<String> {
         }
     }
     None
+}
+
+pub fn description(decorators: &[Decorator]) -> Option<String> {
+    let mut description = String::new();
+    for decorator in decorators {
+        if let Decorator::Description(d) = decorator {
+            description += d;
+            description += "\n";
+        }
+    }
+    if !description.is_empty() {
+        Some(description)
+    } else {
+        None
+    }
 }
 
 pub fn contains_aliases_with_prefixes(decorates: &[Decorator]) -> bool {

--- a/numbat/src/decorator.rs
+++ b/numbat/src/decorator.rs
@@ -101,8 +101,8 @@ pub fn contains_aliases_with_prefixes(decorates: &[Decorator]) -> bool {
     false
 }
 
-pub fn contains_aliases(decorates: &[Decorator]) -> bool {
-    for decorator in decorates {
+pub fn contains_aliases(decorators: &[Decorator]) -> bool {
+    for decorator in decorators {
         if let Decorator::Aliases(_) = decorator {
             return true;
         }

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -311,6 +311,19 @@ impl Context {
                         + m::nl();
                 }
 
+                if let Some(description) = &md.description {
+                    let desc = "Description: ";
+                    let mut lines = description.lines();
+                    help += m::text(desc)
+                        + m::text(lines.by_ref().next().unwrap_or("").trim())
+                        + m::nl();
+
+                    for line in lines {
+                        help +=
+                            m::whitespace(" ".repeat(desc.len())) + m::text(line.trim()) + m::nl();
+                    }
+                }
+
                 if matches!(md.type_, Type::Dimension(d) if d.is_scalar()) {
                     help += m::text("A dimensionless unit ([")
                         + md.readable_type
@@ -373,6 +386,17 @@ impl Context {
                 help += m::text(" (") + m::string(url_encode(url)) + m::text(")");
             }
             help += m::nl();
+
+            if let Some(description) = &l.metadata.description {
+                let desc = "Description: ";
+                let mut lines = description.lines();
+                help +=
+                    m::text(desc) + m::text(lines.by_ref().next().unwrap_or("").trim()) + m::nl();
+
+                for line in lines {
+                    help += m::whitespace(" ".repeat(desc.len())) + m::text(line.trim()) + m::nl();
+                }
+            }
 
             if l.metadata.aliases.len() > 1 {
                 help += m::text("Aliases: ")

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -617,7 +617,7 @@ impl<'a> Parser<'a> {
                             });
                         }
                     }
-                    "url" | "name" => {
+                    "url" | "name" | "description" => {
                         if self.match_exact(TokenKind::LeftParen).is_some() {
                             if let Some(token) = self.match_exact(TokenKind::StringFixed) {
                                 if self.match_exact(TokenKind::RightParen).is_none() {
@@ -632,6 +632,7 @@ impl<'a> Parser<'a> {
                                 match decorator.lexeme.as_str() {
                                     "url" => Decorator::Url(content.into()),
                                     "name" => Decorator::Name(content.into()),
+                                    "description" => Decorator::Description(content.into()),
                                     _ => unreachable!(),
                                 }
                             } else {

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -204,8 +204,11 @@ impl Transformer {
                 body,
                 return_type_annotation_span: return_type_span,
                 return_type_annotation,
+                decorators,
             } => {
-                self.function_names.push(function_name.clone());
+                for (name, _) in decorator::name_and_aliases(&function_name, &decorators) {
+                    self.function_names.push(name.clone());
+                }
                 self.prefix_parser
                     .add_other_identifier(&function_name, function_name_span)?;
 
@@ -232,6 +235,7 @@ impl Transformer {
                     body: body.map(|expr| self.transform_expression(expr)),
                     return_type_annotation_span: return_type_span,
                     return_type_annotation,
+                    decorators,
                 }
             }
             Statement::DefineStruct {

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -206,9 +206,7 @@ impl Transformer {
                 return_type_annotation,
                 decorators,
             } => {
-                for (name, _) in decorator::name_and_aliases(&function_name, &decorators) {
-                    self.function_names.push(name.clone());
-                }
+                self.function_names.push(function_name.clone());
                 self.prefix_parser
                     .add_other_identifier(&function_name, function_name_span)?;
 

--- a/numbat/src/typechecker.rs
+++ b/numbat/src/typechecker.rs
@@ -1459,20 +1459,18 @@ impl TypeChecker {
                 return_type_annotation,
                 decorators,
             } => {
-                for (name, _) in decorator::name_and_aliases(function_name, decorators) {
-                    if body.is_none() {
-                        self.value_namespace.add_identifier(
-                            name.clone(),
-                            *function_name_span,
-                            "foreign function".to_owned(),
-                        )?;
-                    } else {
-                        self.value_namespace.add_identifier_allow_override(
-                            name.clone(),
-                            *function_name_span,
-                            "function".to_owned(),
-                        )?;
-                    }
+                if body.is_none() {
+                    self.value_namespace.add_identifier(
+                        function_name.clone(),
+                        *function_name_span,
+                        "foreign function".to_owned(),
+                    )?;
+                } else {
+                    self.value_namespace.add_identifier_allow_override(
+                        function_name.clone(),
+                        *function_name_span,
+                        "function".to_owned(),
+                    )?;
                 }
 
                 let mut typechecker_fn = self.clone();
@@ -1561,36 +1559,29 @@ impl TypeChecker {
                     .map(|annotation| typechecker_fn.type_from_annotation(annotation))
                     .transpose()?;
 
-                let add_function_signature =
-                    |tc: &mut TypeChecker, return_type: Type, name: &String| {
-                        let parameter_types = typed_parameters
-                            .iter()
-                            .map(|(span, _, _, _, t)| (*span, t.clone()))
-                            .collect();
-                        tc.function_signatures.insert(
-                            name.clone(),
-                            FunctionSignature {
-                                definition_span: *function_name_span,
-                                type_parameters: type_parameters.clone(),
-                                parameter_types,
-                                is_variadic,
-                                return_type,
-                            },
-                        );
-                    };
+                let add_function_signature = |tc: &mut TypeChecker, return_type: Type| {
+                    let parameter_types = typed_parameters
+                        .iter()
+                        .map(|(span, _, _, _, t)| (*span, t.clone()))
+                        .collect();
+                    tc.function_signatures.insert(
+                        function_name.clone(),
+                        FunctionSignature {
+                            definition_span: *function_name_span,
+                            type_parameters: type_parameters.clone(),
+                            parameter_types,
+                            is_variadic,
+                            return_type,
+                        },
+                    );
+                };
 
                 if let Some(ref return_type_specified) = return_type_specified {
                     // This is needed for recursive functions. If the return type
                     // has been specified, we can already provide a function
                     // signature before we check the body of the function. This
                     // way, the 'typechecker_fn' can resolve the recursive call.
-                    for (name, _) in decorator::name_and_aliases(function_name, decorators) {
-                        add_function_signature(
-                            &mut typechecker_fn,
-                            return_type_specified.clone(),
-                            name,
-                        );
-                    }
+                    add_function_signature(&mut typechecker_fn, return_type_specified.clone());
                 }
 
                 let body_checked = body
@@ -1664,9 +1655,7 @@ impl TypeChecker {
                     })?
                 };
 
-                for (name, _) in decorator::name_and_aliases(function_name, decorators) {
-                    add_function_signature(self, return_type.clone(), name);
-                }
+                add_function_signature(self, return_type.clone());
 
                 typed_ast::Statement::DefineFunction(
                     function_name.clone(),

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -274,7 +274,8 @@ pub enum Statement {
     DefineVariable(String, Vec<Decorator>, Expression, Markup, Type),
     DefineFunction(
         String,
-        Vec<String>, // type parameters
+        Vec<Decorator>, // decorators
+        Vec<String>,    // type parameters
         Vec<(
             // parameter:
             Span,   // span of the parameter
@@ -405,6 +406,7 @@ impl PrettyPrint for Statement {
             }
             Statement::DefineFunction(
                 function_name,
+                _decorators,
                 type_parameters,
                 parameters,
                 body,

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -383,6 +383,12 @@ fn decorator_markup(decorators: &Vec<Decorator>) -> Markup {
                 Decorator::Name(name) => {
                     m::decorator("@name") + m::operator("(") + m::string(name) + m::operator(")")
                 }
+                Decorator::Description(description) => {
+                    m::decorator("@description")
+                        + m::operator("(")
+                        + m::string(description)
+                        + m::operator(")")
+                }
             }
             + m::nl();
     }

--- a/numbat/src/unit_registry.rs
+++ b/numbat/src/unit_registry.rs
@@ -22,6 +22,7 @@ pub struct UnitMetadata {
     pub name: Option<String>,
     pub canonical_name: CanonicalName,
     pub url: Option<String>,
+    pub description: Option<String>,
     pub binary_prefixes: bool,
     pub metric_prefixes: bool,
 }


### PR DESCRIPTION
This PR addresses #421, enables decorators for functions and extends the `info` command to functions.

An additional `@description()` decorator is introduced which can be used on functions, as well as variables and units. If applied several times on the same function/variable/unit the descriptions are joined.

There are two caveats to the current implementation: 
- To add aliases of functions a copy of the function is made for each alias. This is not ideal as it wastes some resources and prohibits the use of aliases for FFI functions. A cleaner and more efficient way to handle aliases in the future  that would also enable using aliases for FFI functions could be to use a 'function pointer'.
- `info some_function` displays the signature of the function, however this currently only works for non-generic functions. 