### PR TITLE
Make local timezone support optional

### DIFF
--- a/numbat/Cargo.toml
+++ b/numbat/Cargo.toml
@@ -31,7 +31,7 @@ num-format = "0.4.4"
 walkdir = "2"
 chrono = "0.4.31"
 chrono-tz = "0.8.5"
-iana-time-zone = "0.1"
+iana-time-zone = { version = "0.1", optional = true }
 termcolor = { version = "1.4.1", optional = true }
 html-escape = { version = "0.2.13", optional = true }
 rand = "0.8.5"
@@ -40,9 +40,10 @@ indexmap = "2.2.6"
 mendeleev = "0.8.0"
 
 [features]
-default = ["fetch-exchangerates"]
+default = ["fetch-exchangerates", "local-timezone"]
 fetch-exchangerates = ["numbat-exchange-rates/fetch-exchangerates"]
 html-formatter = ["termcolor", "html-escape"]
+local-timezone = ["iana-time-zone"]
 
 [dev-dependencies]
 approx = "0.5"

--- a/numbat/src/datetime.rs
+++ b/numbat/src/datetime.rs
@@ -1,13 +1,20 @@
 use chrono::{DateTime, Datelike, FixedOffset, LocalResult};
 use chrono_tz::Tz;
 
+#[cfg(feature = "local-timezone")]
 pub fn get_local_timezone() -> Option<Tz> {
     let tz_str = iana_time_zone::get_timezone().ok()?;
     tz_str.parse().ok()
 }
 
+#[cfg(feature = "local-timezone")]
 pub fn get_local_timezone_or_utc() -> Tz {
     get_local_timezone().unwrap_or(chrono_tz::UTC)
+}
+
+#[cfg(not(feature = "local-timezone"))]
+pub fn get_local_timezone_or_utc() -> Tz {
+    chrono_tz::UTC
 }
 
 pub fn parse_datetime(input: &str) -> Option<DateTime<FixedOffset>> {


### PR DESCRIPTION
This is needed to make is possible to build numbat on targets that don't have a way to get a local timezone (for example, wasm32-wasi)

Feel free to reject this pull request.  I need this locally for some experiments I'm doing with compiling numbat to a wasm component (which uses the wasm32-wasi target)