### PR TITLE
More statistics, list and string functions

### DIFF
--- a/examples/list_tests.nbt
+++ b/examples/list_tests.nbt
@@ -18,6 +18,20 @@ assert_eq(concat([], xs), xs)
 assert_eq(concat(xs, []), xs)
 assert_eq(concat(xs, xs), [1, 2, 3, 1, 2, 3])
 
+assert_eq(take(0, xs), [])
+assert_eq(take(1, xs), [1])
+assert_eq(take(2, xs), [1, 2])
+assert_eq(take(3, xs), [1, 2, 3])
+assert_eq(take(4, xs), [1, 2, 3])
+assert_eq(take(0, []), [])
+
+assert_eq(drop(0, xs), [1, 2, 3])
+assert_eq(drop(1, xs), [2, 3])
+assert_eq(drop(2, xs), [3])
+assert_eq(drop(3, xs), [])
+assert_eq(drop(4, xs), [])
+assert_eq(drop(0, []), [])
+
 assert_eq(range(0, 0), [0])
 assert_eq(range(0, 5), [0, 1, 2, 3, 4, 5])
 

--- a/examples/list_tests.nbt
+++ b/examples/list_tests.nbt
@@ -47,6 +47,21 @@ assert_eq(filter(is_even, range(1, 10)), [2, 4, 6, 8, 10])
 fn mul(x, y) = x * y
 assert_eq(foldl(mul, 1, [1, 2, 3, 4, 5]), 120)
 
+# sort:
+assert_eq(sort([]), [])
+
+assert_eq(sort([1]), [1])
+
+assert_eq(sort([1, 2]), [1, 2])
+assert_eq(sort([2, 1]), [1, 2])
+
+assert_eq(sort([1, 2, 3]), [1, 2, 3])
+assert_eq(sort([1, 3, 2]), [1, 2, 3])
+assert_eq(sort([2, 1, 3]), [1, 2, 3])
+assert_eq(sort([2, 3, 1]), [1, 2, 3])
+assert_eq(sort([3, 1, 2]), [1, 2, 3])
+assert_eq(sort([3, 2, 1]), [1, 2, 3])
+
 assert_eq(intersperse(0, []), [])
 assert_eq(intersperse(0, [1]), [1])
 assert_eq(intersperse(0, [1, 2, 3]), [1, 0, 2, 0, 3])

--- a/examples/list_tests.nbt
+++ b/examples/list_tests.nbt
@@ -44,18 +44,19 @@ assert_eq(linspace(0, 1, 2), [0, 1])
 assert_eq(linspace(0, 1, 5), [0, 0.25, 0.5, 0.75, 1])
 assert_eq(linspace(0, 2 m, 5), [0 m, 0.5 m, 1 m, 1.5 m, 2 m])
 
+assert_eq(split("", ","), [])
+assert_eq(split("a", ","), ["a"])
+assert_eq(split("a,b,c", ","), ["a", "b", "c"])
+assert_eq(split("foo,bar,baz", ","), ["foo", "bar", "baz"])
+
+assert_eq(join([], ","), "")
+assert_eq(join(["a"], ","), "a")
+assert_eq(join(["a", "b", "c"], ","), "a,b,c")
+assert_eq(join(["foo", "bar", "baz"], ","), "foo,bar,baz")
+
 # Non-dtype lists
 let words = ["hello", "world"]
 assert_eq(head(words), "hello")
-
-fn join(xs: List<String>, sep: String) =
-  if is_empty(xs)
-    then ""
-    else if len(xs) == 1
-      then head(xs)
-      else "{head(xs)}{sep}{join(tail(xs), sep)}"
-
-assert_eq(join(words, " "), "hello world")
 
 fn gen_range(n) = range(1, n)
 assert_eq(map(gen_range, xs), [[1], [1, 2], [1, 2, 3]])

--- a/examples/prelude_tests.nbt
+++ b/examples/prelude_tests.nbt
@@ -120,6 +120,7 @@ assert_eq(mean([1 m, 300 cm]), 2 m)
 
 # variance
 
+assert_eq(variance([]), 0)
 assert_eq(variance([1]), 0)
 assert_eq(variance([1, 1, 1, 1]), 0)
 assert_eq(variance([1, 2, 3, 4, 5]), 2.0)
@@ -128,6 +129,15 @@ assert_eq(variance([-2, -4, -6, -8]), 5.0)
 
 # standard deviation
 
-assert_eq(std([1]), 0)
-assert_eq(std([1, 1, 1, 1]), 0)
-assert_eq(std([1, 2, 3, 4, 5]), sqrt(2.0))
+assert_eq(stdev([]), 0)
+assert_eq(stdev([1]), 0)
+assert_eq(stdev([1, 1, 1, 1]), 0)
+assert_eq(stdev([1, 2, 3, 4, 5]), sqrt(2.0))
+
+# median
+
+assert_eq(median([1]), 1)
+assert_eq(median([1, 2]), 1.5)
+assert_eq(median([1, 2, 3]), 2)
+assert_eq(median([1, 2, 3, 4]), 2.5)
+assert_eq(median([1, 2, 3, 4, 5]), 3)

--- a/examples/prelude_tests.nbt
+++ b/examples/prelude_tests.nbt
@@ -97,13 +97,6 @@ assert((0xf -> hex) == "0xf")
 assert((0xabc1234567890 -> hex) == "0xabc1234567890")
 assert((-0xc0ffee -> hex) == "-0xc0ffee")
 
-# mean
-
-assert_eq(mean([]), 0)
-assert_eq(mean([1]), 1)
-assert_eq(mean([1, 3]), 2)
-assert_eq(mean([1 m, 300 cm]), 2 m)
-
 # maximum
 
 assert_eq(maximum([1]), 1)
@@ -117,3 +110,24 @@ assert_eq(minimum([1]), 1)
 assert_eq(minimum([1, 3]), 1)
 assert_eq(minimum([3, 1]), 1)
 assert_eq(minimum([100 cm, 3 m]), 100 cm)
+
+# mean
+
+assert_eq(mean([]), 0)
+assert_eq(mean([1]), 1)
+assert_eq(mean([1, 3]), 2)
+assert_eq(mean([1 m, 300 cm]), 2 m)
+
+# variance
+
+assert_eq(variance([1]), 0)
+assert_eq(variance([1, 1, 1, 1]), 0)
+assert_eq(variance([1, 2, 3, 4, 5]), 2.0)
+assert_eq(variance([1, -1, 1, -1]), 1.0)
+assert_eq(variance([-2, -4, -6, -8]), 5.0)
+
+# standard deviation
+
+assert_eq(std([1]), 0)
+assert_eq(std([1, 1, 1, 1]), 0)
+assert_eq(std([1, 2, 3, 4, 5]), sqrt(2.0))

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -35,6 +35,7 @@ fn drop<A>(n: Scalar, xs: List<A>) -> List<A> =
     then xs
     else drop(n - 1, tail(xs))
 
+@description("Get the element at index `i` in a list")
 fn element_at<A>(i: Scalar, xs: List<A>) -> A =
   if i == 0
     then head(xs)

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -1,5 +1,6 @@
 use core::scalar
 use core::error
+use core::strings
 
 @description("Get the length of a list")
 fn len<A>(xs: List<A>) -> Scalar
@@ -83,3 +84,20 @@ fn linspace<D: Dim>(start: D, end: D, n_steps: Scalar) -> List<D> =
   if n_steps <= 1
     then error("Number of steps must be larger than 1")
     else _linspace_helper(start, end, n_steps, 0)
+
+@description("Convert a list of strings into a single string by concatenating them with a separator")
+fn join(xs: List<String>, sep: String) =
+  if is_empty(xs)
+    then ""
+    else if len(xs) == 1
+      then head(xs)
+      else "{head(xs)}{sep}{join(tail(xs), sep)}"
+
+@description("Split a string into a list of strings using a separator")
+fn split(input: String, separator: String) -> List<String> =
+  if input == ""
+    then []
+    else if !str_contains(input, separator)
+      then [input]
+      else cons(str_slice(input, 0, str_find(input, separator)),  # TODO: avoid duplication
+                split(str_slice(input, str_find(input, separator) + str_length(separator), str_length(input)), separator))

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -35,6 +35,11 @@ fn drop<A>(n: Scalar, xs: List<A>) -> List<A> =
     then xs
     else drop(n - 1, tail(xs))
 
+fn element_at<A>(i: Scalar, xs: List<A>) -> A =
+  if i == 0
+    then head(xs)
+    else element_at(i - 1, tail(xs))
+
 @description("Generate a range of integer numbers from `start` to `end` (inclusive)")
 fn range(start: Scalar, end: Scalar) -> List<Scalar> =
   if start > end

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -23,6 +23,18 @@ fn concat<A>(xs1: List<A>, xs2: List<A>) -> List<A> =
     then xs2
     else cons(head(xs1), concat(tail(xs1), xs2))
 
+@description("Get the first `n` elements of a list")
+fn take<A>(n: Scalar, xs: List<A>) -> List<A> =
+  if n == 0 || is_empty(xs)
+    then []
+    else cons(head(xs), take(n - 1, tail(xs)))
+
+@description("Get everything but the first `n` elements of a list")
+fn drop<A>(n: Scalar, xs: List<A>) -> List<A> =
+  if n == 0 || is_empty(xs)
+    then xs
+    else drop(n - 1, tail(xs))
+
 @description("Generate a range of integer numbers from `start` to `end` (inclusive)")
 fn range(start: Scalar, end: Scalar) -> List<Scalar> =
   if start > end

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -73,6 +73,24 @@ fn foldl<A, B>(f: Fn[(A, B) -> A], acc: A, xs: List<B>) -> A =
     then acc
     else foldl(f, f(acc, head(xs)), tail(xs))
 
+fn _merge(xs, ys) =
+  if is_empty(xs)
+    then ys
+    else if is_empty(ys)
+      then xs
+      else if head(xs) < head(ys)
+        then cons(head(xs), _merge(tail(xs), ys))
+        else cons(head(ys), _merge(xs, tail(ys)))
+
+@description("Sort a list of quantities")
+fn sort<D: Dim>(xs: List<D>) -> List<D> =
+  if is_empty(xs)
+    then []
+    else if len(xs) == 1
+      then xs
+      else _merge(sort(take(floor(len(xs) / 2), xs)),  # This is extremely inefficient
+                  sort(drop(floor(len(xs) / 2), xs)))
+
 @description("Add an element between each pair of elements in a list")
 fn intersperse<A>(sep: A, xs: List<A>) -> List<A> =
   if is_empty(xs)

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -13,12 +13,17 @@ fn uppercase(s: String) -> String
 
 fn str_append(a: String, b: String) -> String = "{a}{b}"
 
-fn str_contains(haystack: String, needle: String) -> Bool =
+fn str_find(haystack: String, needle: String) -> Scalar =
   if str_length(haystack) == 0
-    then false
+    then -1
     else if str_slice(haystack, 0, str_length(needle)) == needle
-      then true
-      else str_contains(str_slice(haystack, 1, str_length(haystack)), needle)
+      then 0
+      else if str_find(str_slice(haystack, 1, str_length(haystack)), needle) == -1  # TODO: we need local variables!
+        then -1
+        else 1 + str_find(str_slice(haystack, 1, str_length(haystack)), needle)
+
+fn str_contains(haystack: String, needle: String) -> Bool =
+  str_find(haystack, needle) != -1
 
 fn str_replace(s: String, pattern: String, replacement: String) -> String =
   if pattern == ""

--- a/numbat/modules/extra/astronomy.nbt
+++ b/numbat/modules/extra/astronomy.nbt
@@ -1,6 +1,6 @@
+use physics::constants
 use units::si
 use units::astronomical
-use physics::constants
 
 unit lyr: Length = lightyear
 

--- a/numbat/modules/math/functions.nbt
+++ b/numbat/modules/math/functions.nbt
@@ -115,7 +115,6 @@ fn minimum<D: Dim>(xs: List<D>) -> D =
     then head(xs)
     else _min(head(xs), minimum(tail(xs)))
 
-
 @name("Arithmetic mean")
 @url("https://en.wikipedia.org/wiki/Arithmetic_mean")
 fn mean<D: Dim>(xs: List<D>) -> D = if is_empty(xs) then 0 else sum(xs) / len(xs)
@@ -129,7 +128,15 @@ fn variance<D: Dim>(xs: List<D>) -> D^2 =
 @name("Standard deviation")
 @url("https://en.wikipedia.org/wiki/Standard_deviation")
 @description("Calculate the population standard deviation of a list of quantities")
-fn std<D: Dim>(xs: List<D>) -> D = sqrt(variance(xs))
+fn stdev<D: Dim>(xs: List<D>) -> D = sqrt(variance(xs))
+
+@name("Median")
+@url("https://en.wikipedia.org/wiki/Median")
+@description("Calculate the median of a list of quantities")
+fn median<D: Dim>(xs: List<D>) -> D =  # TODO: this is extremely inefficient
+  if mod(len(xs), 2) == 1
+    then element_at((len(xs) - 1) / 2, sort(xs))
+    else mean([element_at(len(xs) / 2 - 1, sort(xs)), element_at(len(xs) / 2, sort(xs))])
 
 
 ### Geometry

--- a/numbat/modules/math/functions.nbt
+++ b/numbat/modules/math/functions.nbt
@@ -97,10 +97,6 @@ fn gamma(x: Scalar) -> Scalar
 
 ### Statistics
 
-@name("Arithmetic mean")
-@url("https://en.wikipedia.org/wiki/Arithmetic_mean")
-fn mean<D: Dim>(xs: List<D>) -> D = if is_empty(xs) then 0 else sum(xs) / len(xs)
-
 # TODO: remove these helpers once we support local definitions
 fn _max<D: Dim>(x: D, y: D) -> D = if x > y then x else y
 fn _min<D: Dim>(x: D, y: D) -> D = if x < y then x else y
@@ -118,6 +114,23 @@ fn minimum<D: Dim>(xs: List<D>) -> D =
   if len(xs) == 1
     then head(xs)
     else _min(head(xs), minimum(tail(xs)))
+
+
+@name("Arithmetic mean")
+@url("https://en.wikipedia.org/wiki/Arithmetic_mean")
+fn mean<D: Dim>(xs: List<D>) -> D = if is_empty(xs) then 0 else sum(xs) / len(xs)
+
+@name("Variance")
+@url("https://en.wikipedia.org/wiki/Variance")
+@description("Calculate the population variance of a list of quantities")
+fn variance<D: Dim>(xs: List<D>) -> D^2 =
+  mean(map(sqr, xs)) - sqr(mean(xs))
+
+@name("Standard deviation")
+@url("https://en.wikipedia.org/wiki/Standard_deviation")
+@description("Calculate the population standard deviation of a list of quantities")
+fn std<D: Dim>(xs: List<D>) -> D = sqrt(variance(xs))
+
 
 ### Geometry
 


### PR DESCRIPTION
This PR adds the following functions — all implemented in Numbat!

Statistics:
```py
@name("Variance")
@url("https://en.wikipedia.org/wiki/Variance")
@description("Calculate the population variance of a list of quantities")
fn variance<D: Dim>(xs: List<D>) -> D^2

@name("Standard deviation")
@url("https://en.wikipedia.org/wiki/Standard_deviation")
@description("Calculate the population standard deviation of a list of quantities")
fn stdev<D: Dim>(xs: List<D>) -> D

@name("Median")
@url("https://en.wikipedia.org/wiki/Median")
@description("Calculate the median of a list of quantities")
fn median<D: Dim>(xs: List<D>) -> D
```

Lists:
```py
@description("Get the first `n` elements of a list")
fn take<A>(n: Scalar, xs: List<A>) -> List<A>

@description("Get everything but the first `n` elements of a list")
fn drop<A>(n: Scalar, xs: List<A>) -> List<A>

@description("Get the element at index `i` in a list")
fn element_at<A>(i: Scalar, xs: List<A>) -> A

@description("Sort a list of quantities")
fn sort<D: Dim>(xs: List<D>) -> List<D>
```

Lists and strings:
```py
@description("Convert a list of strings into a single string by concatenating them with a separator")
fn join(xs: List<String>, sep: String)

@description("Split a string into a list of strings using a separator")
fn split(input: String, separator: String) -> List<String>
```

Strings
```py
fn str_find(haystack: String, needle: String) -> Scalar
```


related ticket: #144 