### PR TITLE
Typo fix docs number notation

### DIFF
--- a/book/src/number-notation.md
+++ b/book/src/number-notation.md
@@ -30,7 +30,7 @@ conversion operator `->`/`to`, so you can write expressions like:
 Examples:
 ```nbt
 0xffee to bin
-42 ot oct
+42 to oct
 2^16 - 1 to hex
 ```
 


### PR DESCRIPTION
Hi!

I just stumbled across this project and scrolled through your documentation. Great project!

In the convert number section of the number notation page are the following examples:

0xffee to bin
42 ot oct
2^16 - 1 to hex

I started a repl to try out this example: 42 ot oct
Which resulted in this error:

>>> 42 ot oct
error: while type checking
  ┌─ <input:3>:1:4
  │
1 │ 42 ot oct
  │    ^^ unknown identifier

The same example with the typo fixed works fine:

>>> 42 to oct

  oct(42)

    = 0o52    [String]
