### PR TITLE
 Newlines before closing ']' should be allowed in list expressions

### DIFF
--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -1247,12 +1247,15 @@ impl<'a> Parser<'a> {
             Ok(Expression::Scalar(span, Number::from_f64(f64::INFINITY)))
         } else if self.match_exact(TokenKind::LeftBracket).is_some() {
             let span = self.last().unwrap().span;
+            self.skip_empty_lines();
 
             let mut elements = vec![];
             while self.match_exact(TokenKind::RightBracket).is_none() {
                 self.skip_empty_lines();
 
                 elements.push(self.expression()?);
+
+                self.skip_empty_lines();
 
                 if self.match_exact(TokenKind::Comma).is_none()
                     && self.peek().kind != TokenKind::RightBracket
@@ -1262,6 +1265,8 @@ impl<'a> Parser<'a> {
                         span: self.peek().span,
                     });
                 }
+
+                self.skip_empty_lines();
             }
             let span = span.extend(&self.last().unwrap().span);
 
@@ -2928,7 +2933,6 @@ mod tests {
             ParseErrorKind::ExpectedCommaOrRightBracketInList,
         );
         should_fail_with(&["[1,\n2,\n,\n"], ParseErrorKind::ExpectedPrimary);
-
         should_fail_with(
             &["[1\n,2\n]\n]"],
             ParseErrorKind::TrailingCharacters("]".to_owned()),

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2933,10 +2933,6 @@ mod tests {
             ParseErrorKind::ExpectedCommaOrRightBracketInList,
         );
         should_fail_with(&["[1,\n2,\n,\n"], ParseErrorKind::ExpectedPrimary);
-        should_fail_with(
-            &["[1\n,2\n]\n]"],
-            ParseErrorKind::TrailingCharacters("]".to_owned()),
-        );
     }
 
     #[test]

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2896,8 +2896,20 @@ mod tests {
         parse_as_expression(&["[1]", "[1,]"], list!(scalar!(1.0)));
         parse_as_expression(&["[1, 2]", "[1, 2, ]"], list!(scalar!(1.0), scalar!(2.0)));
 
+        parse_as_expression(&["[\n]"], list!());
+        parse_as_expression(&["[1\n]", "[1,\n]"], list!(scalar!(1.0)));
+        parse_as_expression(
+            &["[1\n,2\n]", "[1,\n2,\n]"],
+            list!(scalar!(1.0), scalar!(2.0)),
+        );
+
         parse_as_expression(
             &["[[1,2], [3]]"],
+            list!(list!(scalar!(1.0), scalar!(2.0)), list!(scalar!(3.0))),
+        );
+
+        parse_as_expression(
+            &["[[1,\n2\n],\n [3\n]\n]"],
             list!(list!(scalar!(1.0), scalar!(2.0)), list!(scalar!(3.0))),
         );
 
@@ -2908,6 +2920,17 @@ mod tests {
         should_fail_with(&["[1, 2, ,"], ParseErrorKind::ExpectedPrimary);
         should_fail_with(
             &["[1, 2]]"],
+            ParseErrorKind::TrailingCharacters("]".to_owned()),
+        );
+
+        should_fail_with(
+            &["[1\n", "[1,\n 2,\n 3\n", "[1,\n 2\n)"],
+            ParseErrorKind::ExpectedCommaOrRightBracketInList,
+        );
+        should_fail_with(&["[1,\n2,\n,\n"], ParseErrorKind::ExpectedPrimary);
+
+        should_fail_with(
+            &["[1\n,2\n]\n]"],
             ParseErrorKind::TrailingCharacters("]".to_owned()),
         );
     }


### PR DESCRIPTION
- added list parsing test cases
- added skipping empty lines while parsing a list

Closes  #479