### PR TITLE
info: Print readable function signatures

### DIFF
--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -56,7 +56,6 @@ use markup::Markup;
 use module_importer::{ModuleImporter, NullImporter};
 use prefix_transformer::Transformer;
 
-use pretty_print::PrettyPrint;
 use resolver::CodeSource;
 use resolver::Resolver;
 use resolver::ResolverError;
@@ -437,7 +436,7 @@ impl Context {
 
             help += m::text("Signature:  ")
                 + m::space()
-                + fn_signature.fn_type.pretty_print()
+                + fn_signature.pretty_print(self.typechecker.registry())
                 + m::nl();
 
             if let Some(description) = &metadata.description {

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -176,9 +176,11 @@ impl TypeChecker {
         argument_types: Vec<Type>,
     ) -> Result<typed_ast::Expression> {
         let FunctionSignature {
+            name: _,
             definition_span,
             type_parameters: _,
             parameters,
+            return_type_annotation: _,
             fn_type,
         } = signature;
 
@@ -1377,7 +1379,7 @@ impl TypeChecker {
 
                 let parameters: Vec<_> = typed_parameters
                     .iter()
-                    .map(|(span, name, _, _)| (*span, name.clone()))
+                    .map(|(span, name, _, annotation)| (*span, name.clone(), (*annotation).clone()))
                     .collect();
                 let parameter_types = typed_parameters
                     .iter()
@@ -1390,9 +1392,11 @@ impl TypeChecker {
                 typechecker_fn.env.add_function(
                     function_name.clone(),
                     FunctionSignature {
+                        name: function_name.clone(),
                         definition_span: *function_name_span,
                         type_parameters: type_parameters.clone(),
                         parameters,
+                        return_type_annotation: return_type_annotation.clone(),
                         fn_type: fn_type.clone(),
                     },
                     FunctionMetadata {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4c330b1d-f679-402a-87f5-94c1436c3c0c)


closes #491

Also improves pretty-printing of function types with user-supplied type annotations.