### PR TITLE
Add special symbols for arcmin, arcsec

### DIFF
--- a/book/src/list-units.md
+++ b/book/src/list-units.md
@@ -12,8 +12,8 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `AbsorbedDose` | [Gray](https://en.wikipedia.org/wiki/Gray_(unit)) | `gray`, `grays`, `Gy` |
 | `Activity` | [Becquerel](https://en.wikipedia.org/wiki/Becquerel) | `becquerel`, `becquerels`, `Bq` |
 | `AmountOfSubstance` | [Mole](https://en.wikipedia.org/wiki/Mole_(unit)) | `mol`, `mole`, `moles` |
-| `Angle` | [Minute of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcmin`, `arcminute`, `arcminutes` |
-| `Angle` | [Second of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcsec`, `arcsecond`, `arcseconds` |
+| `Angle` | [Minute of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcmin`, `arcminute`, `arcminutes`, `′` |
+| `Angle` | [Second of arc](https://en.wikipedia.org/wiki/Minute_and_second_of_arc) | `arcsec`, `arcsecond`, `arcseconds`, `″` |
 | `Angle` | [Degree](https://en.wikipedia.org/wiki/Degree_(angle)) | `deg`, `degree`, `degrees`, `°` |
 | `Angle` | [Gradian](https://en.wikipedia.org/wiki/Gradian) | `gon`, `gons`, `grad`, `grade`, `grades`, `gradian`, `gradians`, `grads` |
 | `Angle` | [Radian](https://en.wikipedia.org/wiki/Radian) | `rad`, `radian`, `radians` |

--- a/numbat/modules/units/si.nbt
+++ b/numbat/modules/units/si.nbt
@@ -202,12 +202,12 @@ unit degree: Angle = π / 180 × radian
 
 @name("Minute of arc")
 @url("https://en.wikipedia.org/wiki/Minute_and_second_of_arc")
-@aliases(arcminutes, arcmin)
+@aliases(arcminutes, arcmin, ′)
 unit arcminute: Angle = 1 / 60 × degree
 
 @name("Second of arc")
 @url("https://en.wikipedia.org/wiki/Minute_and_second_of_arc")
-@aliases(arcseconds, arcsec)
+@aliases(arcseconds, arcsec, ″)
 unit arcsecond: Angle = 1 / 60 × arcminute
 
 @name("Are")

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -51,7 +51,7 @@
 //! bin_number      ::=   "0b" [01]*
 //! integer         ::=   [0-9]([0-9_]*[0-9])?
 //! identifier      ::=   identifier_s identifier_c*
-//! identifier_s    ::=   Unicode_XID_Start | Unicode_Currency | "%" | "°" | "_"
+//! identifier_s    ::=   Unicode_XID_Start | Unicode_Currency | "%" | "°" | "′" | "″" | "_"
 //! identifier_c    ::=   Unicode_XID_Continue | Unicode_Currency  | "%"
 //! typed_hole      ::=   "?"
 //! boolean         ::=   "true" | "false"
@@ -2036,6 +2036,8 @@ mod tests {
         parse_as_expression(&["foo_bar"], identifier!("foo_bar"));
         parse_as_expression(&["MeineSchöneVariable"], identifier!("MeineSchöneVariable"));
         parse_as_expression(&["°"], identifier!("°"));
+        parse_as_expression(&["′"], identifier!("′"));
+        parse_as_expression(&["″"], identifier!("″"));
         parse_as_expression(&["Mass_H₂O"], identifier!("Mass_H₂O"));
     }
 

--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -337,7 +337,7 @@ impl PrettyPrint for Quantity {
         let unit_str = format!("{}", self.unit());
 
         markup::value(formatted_number)
-            + if unit_str == "°" || unit_str.is_empty() {
+            + if unit_str == "°" || unit_str == "′" || unit_str == "″" || unit_str.is_empty() {
                 markup::empty()
             } else {
                 markup::space()

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -200,6 +200,8 @@ fn is_identifier_start(c: char) -> bool {
         || is_currency_char(c)
         || is_other_allowed_identifier_char(c)
         || c == '°'
+        || c == '′'
+        || c == '″'
         || c == '_'
 }
 

--- a/numbat/src/unicode_input.rs
+++ b/numbat/src/unicode_input.rs
@@ -66,6 +66,8 @@ pub const UNICODE_INPUT: &[(&[&str], &str)] = &[
     (&["yen"], "¥"),
     (&["euro"], "€"),
     (&["degree"], "°"),
+    (&["arcmin"], "′"),
+    (&["arcsec"], "″"),
     (&["ohm"], "Ω"),
     (&["Angstrom"], "Å"),
     (&["percent"], "%"),


### PR DESCRIPTION
Add `′` and `″` as special symbols for arcminute and arcsecond, respectively. Allows us to write things like 38° + 53′ + 23″. This also adds support for typing `\arcmin<tab>` and `\arcsec<tab>` to easily get access to those Unicode symbols.