### PR TITLE
Color format conversions

### DIFF
--- a/book/build.py
+++ b/book/build.py
@@ -255,6 +255,10 @@ list_of_functions(
                 "title": "Temperature conversion",
                 "modules": ["physics::temperature_conversion"],
             },
+            {
+                "title": "Color format conversion",
+                "modules": ["extra::color"],
+            },
         ],
     },
 )

--- a/book/src/list-functions-other.md
+++ b/book/src/list-functions-other.md
@@ -146,30 +146,35 @@ fn fahrenheit(t_kelvin: Temperature) -> Scalar
 Defined in: `extra::color`
 
 ### `rgb`
+Create a `Color` from RGB (red, green, blue) values in the range \\( [0, 256) \\).
 
 ```nbt
 fn rgb(red: Scalar, green: Scalar, blue: Scalar) -> Color
 ```
 
 ### `color`
+Create a `Color` from a (hexadecimal) value, e.g. `color(0xff7700)`.
 
 ```nbt
 fn color(rgb_hex: Scalar) -> Color
 ```
 
 ### `color_rgb`
+Convert a color to its RGB representation, e.g. `cyan -> color_rgb`.
 
 ```nbt
 fn color_rgb(color: Color) -> String
 ```
 
 ### `color_rgb_float`
+Convert a color to its RGB floating point representation, e.g. `cyan -> color_rgb_float`.
 
 ```nbt
 fn color_rgb_float(color: Color) -> String
 ```
 
 ### `color_hex`
+Convert a color to its hexadecimal representation, e.g. `rgb(225, 36, 143) -> color_hex`.
 
 ```nbt
 fn color_hex(color: Color) -> String

--- a/book/src/list-functions-other.md
+++ b/book/src/list-functions-other.md
@@ -1,6 +1,6 @@
 # Other functions
 
-[Error handling](#error-handling) · [Floating point](#floating-point) · [Quantities](#quantities) · [Chemical elements](#chemical-elements) · [Mixed unit conversion](#mixed-unit-conversion) · [Temperature conversion](#temperature-conversion)
+[Error handling](#error-handling) · [Floating point](#floating-point) · [Quantities](#quantities) · [Chemical elements](#chemical-elements) · [Mixed unit conversion](#mixed-unit-conversion) · [Temperature conversion](#temperature-conversion) · [Color format conversion](#color-format-conversion)
 
 ## Error handling
 
@@ -139,5 +139,39 @@ More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_te
 
 ```nbt
 fn fahrenheit(t_kelvin: Temperature) -> Scalar
+```
+
+## Color format conversion
+
+Defined in: `extra::color`
+
+### `rgb`
+
+```nbt
+fn rgb(red: Scalar, green: Scalar, blue: Scalar) -> Color
+```
+
+### `color`
+
+```nbt
+fn color(rgb_hex: Scalar) -> Color
+```
+
+### `color_rgb`
+
+```nbt
+fn color_rgb(color: Color) -> String
+```
+
+### `color_rgb_float`
+
+```nbt
+fn color_rgb_float(color: Color) -> String
+```
+
+### `color_hex`
+
+```nbt
+fn color_hex(color: Color) -> String
 ```
 

--- a/examples/tests/color.nbt
+++ b/examples/tests/color.nbt
@@ -1,0 +1,29 @@
+assert_eq(0x000000 -> color, black)
+assert_eq(0xffffff -> color, white)
+assert_eq(0x123456 -> color, Color { red: 0x12, green: 0x34, blue: 0x56 })
+
+assert_eq(black -> color_rgb, "rgb(0, 0, 0)")
+assert_eq(white -> color_rgb, "rgb(255, 255, 255)")
+assert_eq(red -> color_rgb, "rgb(255, 0, 0)")
+assert_eq(green -> color_rgb, "rgb(0, 255, 0)")
+assert_eq(blue -> color_rgb, "rgb(0, 0, 255)")
+assert_eq(0x123456 -> color -> color_rgb, "rgb(18, 52, 86)")
+
+assert_eq(black -> color_rgb_float, "rgb(0.000, 0.000, 0.000)")
+assert_eq(white -> color_rgb_float, "rgb(1.000, 1.000, 1.000)")
+assert_eq(red -> color_rgb_float, "rgb(1.000, 0.000, 0.000)")
+assert_eq(green -> color_rgb_float, "rgb(0.000, 1.000, 0.000)")
+assert_eq(blue -> color_rgb_float, "rgb(0.000, 0.000, 1.000)")
+assert_eq(0x123456 -> color -> color_rgb_float, "rgb(0.071, 0.204, 0.337)")
+
+assert_eq(black -> color_hex, "#000000")
+assert_eq(white -> color_hex, "#ffffff")
+assert_eq(red -> color_hex, "#ff0000")
+assert_eq(green -> color_hex, "#00ff00")
+assert_eq(blue -> color_hex, "#0000ff")
+assert_eq(0x123456 -> color -> color_hex, "#123456")
+
+# Examples:
+
+assert_eq(rgb(225, 36, 143) -> color_hex, "#e1248f")
+assert_eq(0xe1248f -> color -> color_rgb, "rgb(225, 36, 143)")

--- a/examples/tests/color.nbt
+++ b/examples/tests/color.nbt
@@ -1,3 +1,5 @@
+use extra::color
+
 assert_eq(0x000000 -> color, black)
 assert_eq(0xffffff -> color, white)
 assert_eq(0x123456 -> color, Color { red: 0x12, green: 0x34, blue: 0x56 })

--- a/numbat/modules/all.nbt
+++ b/numbat/modules/all.nbt
@@ -5,6 +5,7 @@ use units::stoney
 use units::hartree
 
 use extra::algebra
+use extra::color
 
 use numerics::diff
 use numerics::solve

--- a/numbat/modules/extra/color.nbt
+++ b/numbat/modules/extra/color.nbt
@@ -1,0 +1,39 @@
+use core::scalar
+use core::functions
+use core::strings
+
+struct Color {
+  red: Scalar,
+  green: Scalar,
+  blue: Scalar,
+}
+
+fn rgb(red: Scalar, green: Scalar, blue: Scalar) -> Color =
+  Color { red: red, green: green, blue: blue }
+
+fn color(rgb_hex: Scalar) -> Color =
+  rgb(
+    floor(rgb_hex / 256^2),
+    floor((mod(rgb_hex, 256^2)) / 256),
+    mod(rgb_hex, 256))
+
+fn _color_to_scalar(color: Color) -> Scalar =
+  color.red * 0x010000 + color.green * 0x000100 + color.blue
+
+fn color_rgb(color: Color) -> String =
+  "rgb({color.red}, {color.green}, {color.blue})"
+
+fn color_rgb_float(color: Color) -> String =
+  "rgb({color.red / 255:.3}, {color.green / 255:.3}, {color.blue / 255:.3})"
+
+fn color_hex(color: Color) -> String =
+  str_append("#", str_replace(str_replace("{color -> _color_to_scalar -> hex:>8}", "0x", ""), " ", "0"))
+
+let black: Color = rgb(0, 0, 0)
+let white: Color = rgb(255, 255, 255)
+let red: Color = rgb(255, 0, 0)
+let green: Color = rgb(0, 255, 0)
+let blue: Color = rgb(0, 0, 255)
+let yellow: Color = rgb(255, 255, 0)
+let cyan: Color = rgb(0, 255, 255)
+let magenta: Color = rgb(255, 0, 255)

--- a/numbat/modules/extra/color.nbt
+++ b/numbat/modules/extra/color.nbt
@@ -8,9 +8,11 @@ struct Color {
   blue: Scalar,
 }
 
+@description("Create a `Color` from RGB (red, green, blue) values in the range $[0, 256)$.")
 fn rgb(red: Scalar, green: Scalar, blue: Scalar) -> Color =
   Color { red: red, green: green, blue: blue }
 
+@description("Create a `Color` from a (hexadecimal) value, e.g. `color(0xff7700)`")
 fn color(rgb_hex: Scalar) -> Color =
   rgb(
     floor(rgb_hex / 256^2),
@@ -20,12 +22,15 @@ fn color(rgb_hex: Scalar) -> Color =
 fn _color_to_scalar(color: Color) -> Scalar =
   color.red * 0x010000 + color.green * 0x000100 + color.blue
 
+@description("Convert a color to its RGB representation, e.g. `cyan -> color_rgb`")
 fn color_rgb(color: Color) -> String =
   "rgb({color.red}, {color.green}, {color.blue})"
 
+@description("Convert a color to its RGB floating point representation, e.g. `cyan -> color_rgb_float`")
 fn color_rgb_float(color: Color) -> String =
   "rgb({color.red / 255:.3}, {color.green / 255:.3}, {color.blue / 255:.3})"
 
+@description("Convert a color to its hexadecimal representation, e.g. `rgb(225, 36, 143) -> color_hex`")
 fn color_hex(color: Color) -> String =
   str_append("#", str_replace(str_replace("{color -> _color_to_scalar -> hex:>8}", "0x", ""), " ", "0"))
 

--- a/numbat/modules/prelude.nbt
+++ b/numbat/modules/prelude.nbt
@@ -42,3 +42,5 @@ use chemistry::elements
 
 use datetime::functions
 use datetime::human
+
+use extra::color

--- a/numbat/modules/prelude.nbt
+++ b/numbat/modules/prelude.nbt
@@ -42,5 +42,3 @@ use chemistry::elements
 
 use datetime::functions
 use datetime::human
-
-use extra::color


### PR DESCRIPTION
This was initially more for fun, but this might be actually useful. It's implemented in Numbat, without any FFI/language support. This would allow us to do things like

![image](https://github.com/user-attachments/assets/cc8c5372-1f15-4468-8535-4f6fe7eafe01)


And if we want, we could add other color representations such as HSL, as well as other color spaces such as LCh, Lab*. We could also add color manipulation etc. I have written [a whole tool](https://github.com/sharkdp/pastel) for color operations like those, but it might be useful to have this inside an easily accessible calculator.