### PR TITLE
Add julian_date conversions

### DIFF
--- a/book/src/list-functions-datetime.md
+++ b/book/src/list-functions-datetime.md
@@ -74,6 +74,14 @@ Parses a string (time only) into a `DateTime` object.
 fn time(input: String) -> DateTime
 ```
 
+### `julian_date` (Julian date)
+Convert a `DateTime` to a Julian date, the number of days since the origin of the Julian date system (noon on November 24, 4714 BC in the propleptic Gregorian calendar).
+More information [here](https://en.wikipedia.org/wiki/Julian_day).
+
+```nbt
+fn julian_date(dt: DateTime) -> Time
+```
+
 ### `human` (Human-readable time duration)
 Converts a time duration to a human-readable string in days, hours, minutes and seconds.
 More information [here](https://numbat.dev/doc/date-and-time.html).

--- a/examples/tests/datetime.nbt
+++ b/examples/tests/datetime.nbt
@@ -17,3 +17,11 @@ assert_eq(format_datetime("%Y/%m/%d", z + 12 hours), "2021/03/01")
 # Regression test for #376
 let dt_376 = datetime("Fri, 23 Feb 2024 14:01:54 -0800")
 assert_eq(format_datetime("%Y-%m-%dT%H:%M:%S%:z", dt_376), "2024-02-23T14:01:54-08:00")
+
+
+# Julian date
+
+let dt_jd = datetime("2013-01-01 00:30:00 UTC")
+assert_eq(dt_jd -> julian_date, 2_456_293.520_833 days, 1e-6 days)
+
+assert_eq(epoch -> julian_date, 2_440_587.5 days, 1e-6 days)

--- a/numbat/modules/datetime/functions.nbt
+++ b/numbat/modules/datetime/functions.nbt
@@ -42,3 +42,9 @@ fn date(input: String) -> DateTime =
 @description("Parses a string (time only) into a `DateTime` object.")
 fn time(input: String) -> DateTime =
   datetime("{_today_str()} {input}")
+
+@name("Julian date")
+@description("Convert a `DateTime` to a Julian date, the number of days since the origin of the Julian date system (noon on November 24, 4714 BC in the propleptic Gregorian calendar).")
+@url("https://en.wikipedia.org/wiki/Julian_day")
+fn julian_date(dt: DateTime) -> Time =
+  (dt - datetime("-4713-11-24 12:00:00 +0000")) -> days


### PR DESCRIPTION
> The Julian date (JD) of any [instant](https://en.wikipedia.org/wiki/Instant) is the Julian day number plus the fraction of a day since the preceding noon in Universal Time. Julian dates are expressed as a Julian day number with a decimal fraction added.[[8]](https://en.wikipedia.org/wiki/Julian_day#cite_note-IAU-9) For example, the Julian Date for 00:30:00.0 UT January 1, 2013, is 2456293.520833.[[9]](https://en.wikipedia.org/wiki/Julian_day#cite_note-10) This article was loaded at 2024-07-25 19:37:54 ([UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time)) – expressed as a Julian date this is 2460517.3179861.

https://en.wikipedia.org/wiki/Julian_day