### PR TITLE
Make list slightly less embarrassingly slow

### DIFF
--- a/book/src/list-functions-lists.md
+++ b/book/src/list-functions-lists.md
@@ -30,6 +30,13 @@ Prepend an element to a list.
 fn cons<A>(x: A, xs: List<A>) -> List<A>
 ```
 
+### `cons_end`
+Append an element to the end of a list.
+
+```nbt
+fn cons_end<A>(xs: List<A>, x: A) -> List<A>
+```
+
 ### `is_empty`
 Check if a list is empty.
 
@@ -70,13 +77,6 @@ Generate a range of integer numbers from `start` to `end` (inclusive).
 
 ```nbt
 fn range(start: Scalar, end: Scalar) -> List<Scalar>
-```
-
-### `cons_end`
-Append an element to the end of a list.
-
-```nbt
-fn cons_end<A>(xs: List<A>, x: A) -> List<A>
 ```
 
 ### `reverse`

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -2,7 +2,7 @@ let xs = [1, 2, 3]
 
 assert_eq(len([]), 0)
 assert_eq(len(xs), 3)
-assert_eq(len(tail(xs)), 2)
+assert_eq(len(cons_end(xs, 4)), 4)
 
 assert_eq(head(xs), 1)
 assert_eq(head(tail(xs)), 2)

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -2,6 +2,7 @@ let xs = [1, 2, 3]
 
 assert_eq(len([]), 0)
 assert_eq(len(xs), 3)
+assert_eq(len(tail(xs)), 2)
 
 assert_eq(head(xs), 1)
 assert_eq(head(tail(xs)), 2)

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -2,7 +2,6 @@ let xs = [1, 2, 3]
 
 assert_eq(len([]), 0)
 assert_eq(len(xs), 3)
-assert_eq(len(cons_end(xs, 4)), 4)
 
 assert_eq(head(xs), 1)
 assert_eq(head(tail(xs)), 2)
@@ -10,6 +9,9 @@ assert_eq(head(tail(xs)), 2)
 assert_eq(tail(xs), [2, 3])
 
 assert_eq(cons(0, xs), [0, 1, 2, 3])
+
+assert_eq(cons_end(xs, 4), [1, 2, 3, 4])
+assert_eq(cons_end([], 0), [0])
 
 assert(is_empty([]))
 assert(!is_empty(xs))

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -14,6 +14,9 @@ fn tail<A>(xs: List<A>) -> List<A>
 @description("Prepend an element to a list")
 fn cons<A>(x: A, xs: List<A>) -> List<A>
 
+@description("Append an element to the end of a list")
+fn cons_end<A>(xs: List<A>, x: A) -> List<A>
+
 @description("Check if a list is empty")
 fn is_empty<A>(xs: List<A>) -> Bool = xs == []
 
@@ -47,11 +50,6 @@ fn range(start: Scalar, end: Scalar) -> List<Scalar> =
     then []
     else cons(start, range(start + 1, end))
 
-@description("Append an element to the end of a list")
-fn cons_end<A>(xs: List<A>, x: A) -> List<A> =
-  if is_empty(xs)
-    then [x]
-    else cons(head(xs), cons_end(tail(xs), x))
 
 @description("Reverse the order of a list")
 fn reverse<A>(xs: List<A>) -> List<A> =

--- a/numbat/src/ffi/functions.rs
+++ b/numbat/src/ffi/functions.rs
@@ -77,6 +77,7 @@ pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
         insert_function!(head, 1..=1);
         insert_function!(tail, 1..=1);
         insert_function!(cons, 2..=2);
+        insert_function!(cons_end, 2..=2);
 
         // Strings
         insert_function!(str_length, 1..=1);

--- a/numbat/src/ffi/lists.rs
+++ b/numbat/src/ffi/lists.rs
@@ -36,3 +36,11 @@ pub fn cons(mut args: Args) -> Result<Value> {
 
     return_list!(list)
 }
+
+pub fn cons_end(mut args: Args) -> Result<Value> {
+    let mut list = list_arg!(args);
+    let element = arg!(args);
+    list.push_back(element);
+
+    return_list!(list)
+}

--- a/numbat/src/ffi/lists.rs
+++ b/numbat/src/ffi/lists.rs
@@ -11,10 +11,12 @@ pub fn len(mut args: Args) -> Result<Value> {
 }
 
 pub fn head(mut args: Args) -> Result<Value> {
-    let mut list = list_arg!(args);
+    let list = list_arg!(args);
 
-    if let Some(first) = list.pop_front() {
-        Ok(first)
+    // We don't need to pop or drop anything, the whole allocation will
+    // be dropped if we're its last owner.
+    if let Some(first) = list.front() {
+        Ok(first.clone())
     } else {
         Err(RuntimeError::EmptyList)
     }
@@ -23,11 +25,8 @@ pub fn head(mut args: Args) -> Result<Value> {
 pub fn tail(mut args: Args) -> Result<Value> {
     let mut list = list_arg!(args);
 
-    if list.pop_front().is_some() {
-        return_list!(list)
-    } else {
-        Err(RuntimeError::EmptyList)
-    }
+    list.advance_view()?;
+    Ok(list.into())
 }
 
 pub fn cons(mut args: Args) -> Result<Value> {

--- a/numbat/src/ffi/lists.rs
+++ b/numbat/src/ffi/lists.rs
@@ -13,10 +13,8 @@ pub fn len(mut args: Args) -> Result<Value> {
 pub fn head(mut args: Args) -> Result<Value> {
     let list = list_arg!(args);
 
-    // We don't need to pop or drop anything, the whole allocation will
-    // be dropped if we're its last owner.
-    if let Some(first) = list.front() {
-        Ok(first.clone())
+    if let Some(first) = list.head() {
+        Ok(first)
     } else {
         Err(RuntimeError::EmptyList)
     }

--- a/numbat/src/ffi/lists.rs
+++ b/numbat/src/ffi/lists.rs
@@ -23,7 +23,7 @@ pub fn head(mut args: Args) -> Result<Value> {
 pub fn tail(mut args: Args) -> Result<Value> {
     let mut list = list_arg!(args);
 
-    list.advance_view()?;
+    list.tail()?;
     Ok(list.into())
 }
 

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -16,6 +16,7 @@ pub mod help;
 pub mod html_formatter;
 mod interpreter;
 pub mod keywords;
+pub mod list;
 pub mod markup;
 mod math;
 pub mod module_importer;

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -122,7 +122,7 @@ impl<T: Clone> NumbatList<T> {
         }
     }
 
-    /// Allocate iif the list being used by another value at the same time
+    /// Allocate if the list is being used by another value at the same time
     pub fn push_front(&mut self, element: T) {
         let (view, inner) = self.make_mut();
         if let Some((start, end)) = view {
@@ -141,7 +141,7 @@ impl<T: Clone> NumbatList<T> {
         }
     }
 
-    /// Allocate iif the list being used by another value at the same time
+    /// Allocate if the list is being used by another value at the same time
     pub fn push_back(&mut self, element: T) {
         let (view, inner) = self.make_mut();
         if let Some((_start, end)) = view {

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -91,13 +91,8 @@ impl<T> NumbatList<T> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.alloc
-            .iter()
-            .skip(self.view.map_or(0, |(start, _end)| start))
-            .take(
-                self.view
-                    .map_or(self.alloc.len(), |(start, end)| end - start),
-            )
+        let (start, end) = self.view.map_or((0, self.alloc.len()), |view| view);
+        self.alloc.iter().skip(start).take(end - start)
     }
 }
 

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -1,0 +1,155 @@
+use std::{collections::VecDeque, fmt, sync::Arc};
+
+use crate::{value::Value, RuntimeError};
+
+/// Reference counted list / list view
+#[derive(Clone, Eq)]
+pub struct NumbatList<T> {
+    /// The original alloc shared between all values
+    alloc: Arc<VecDeque<T>>,
+    /// The indexes accessible to us. If `None` we own the whole allocation
+    view: Option<(usize, usize)>,
+}
+
+impl<T: fmt::Debug + Clone> fmt::Debug for NumbatList<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<T: PartialEq> PartialEq for NumbatList<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Best case scenario, the slice don't have the same len and we can early exit
+        if self.len() != other.len() {
+            return false;
+        }
+        // Second best case scenario, the slice comes from the same allocation
+        // and have the same view => they are equal
+        if Arc::as_ptr(&self.alloc) == Arc::as_ptr(&other.alloc) && self.view == other.view {
+            true
+        } else {
+            // Worst case scenario, we need to compare all the elements one by one
+            self.iter().zip(other.iter()).all(|(l, r)| l == r)
+        }
+    }
+}
+
+impl<T> NumbatList<T> {
+    pub fn len(&self) -> usize {
+        if let Some(view) = self.view {
+            view.1 - view.0
+        } else {
+            self.alloc.len()
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            alloc: Arc::new(VecDeque::with_capacity(capacity)),
+            view: None,
+        }
+    }
+
+    pub fn front(&self) -> Option<&T> {
+        if let Some(view) = self.view {
+            self.alloc.get(view.0)
+        } else {
+            self.alloc.front()
+        }
+    }
+
+    /// Advance the view you have of the list by one.
+    pub fn advance_view(&mut self) -> Result<(), RuntimeError> {
+        if self.len() == 0 {
+            return Err(RuntimeError::EmptyList);
+        }
+        if let Some(view) = &mut self.view {
+            view.0 += 1;
+            // should be ensured by the if above
+            debug_assert!(view.0 <= view.1);
+        } else {
+            self.view = Some((1, self.len()));
+        }
+        Ok(())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.alloc
+            .iter()
+            .skip(self.view.map_or(0, |(start, _end)| start))
+            .take(
+                self.view
+                    .map_or(self.alloc.len(), |(start, end)| end - start),
+            )
+    }
+}
+
+impl<T: Clone> NumbatList<T> {
+    fn make_mut(&mut self) -> &mut VecDeque<T> {
+        if Arc::strong_count(&self.alloc) != 1 {
+            // If someone else is using the list we must clone it
+            self.alloc = Arc::new(self.iter().cloned().collect());
+            self.view = None;
+        }
+        // With our usage, this should never allocate since we know we're the only
+        // one holding a reference to this `Arc` and we don't use weak references.
+        Arc::make_mut(&mut self.alloc)
+    }
+
+    /// Allocate iif the list being used by another value at the same time
+    pub fn push_front(&mut self, element: T) {
+        let mut view = self.view;
+        let inner = self.make_mut();
+        if let Some((start, end)) = &mut view {
+            // if we were alone on the allocation and had a view of the inner allocation
+            // we can keep the allocation and overwrite the start-1 element.
+            // but we need to take care of the special case where the start is 0.
+            if *start == 0 {
+                inner.push_front(element);
+                *end += 1;
+            } else {
+                *start -= 1;
+                inner[*start] = element;
+            }
+        } else {
+            inner.push_front(element);
+        }
+        self.view = view;
+    }
+
+    /// Allocate iif the list being used by another value at the same time
+    pub fn push_back(&mut self, element: T) {
+        let mut view = self.view;
+        let inner = self.make_mut();
+        if let Some((_start, end)) = &mut view {
+            // if we were alone on the allocation and had a view of the inner allocation
+            // we can keep the allocation and overwrite the end+1 element.
+            // but we need to take care of the special case where the end is `alloc.len()`.
+            if *end == inner.len() {
+                inner.push_back(element);
+                *end += 1;
+            } else {
+                *end += 1;
+                inner[*end] = element;
+            }
+        } else {
+            inner.push_back(element);
+        }
+        self.view = view;
+    }
+}
+
+impl From<NumbatList<Value>> for Value {
+    fn from(list: NumbatList<Value>) -> Self {
+        Value::List(list)
+    }
+}
+
+impl From<VecDeque<Value>> for Value {
+    fn from(list: VecDeque<Value>) -> Self {
+        Value::List(NumbatList {
+            alloc: Arc::new(list),
+            view: None,
+        })
+    }
+}

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -41,7 +41,7 @@ impl<T: PartialEq> PartialEq for NumbatList<T> {
         }
         // Second best case, the other slice comes from the same allocation and
         // has the same view => they are equal
-        if Arc::as_ptr(&self.alloc) == Arc::as_ptr(&other.alloc) && self.view == other.view {
+        if Arc::ptr_eq(&self.alloc, &other.alloc) && self.view == other.view {
             true
         } else {
             // Worst case scenario, we need to compare all the elements one by one
@@ -256,15 +256,15 @@ mod test {
 
         let mut list2 = list1.clone();
 
-        assert_eq!(Arc::as_ptr(&list1.alloc), Arc::as_ptr(&list2.alloc));
+        assert!(Arc::ptr_eq(&list1.alloc, &list2.alloc));
 
         list2.tail().unwrap();
         // Even after advancing the list2 the alloc can still be shared between both instance
-        assert_eq!(Arc::as_ptr(&list1.alloc), Arc::as_ptr(&list2.alloc));
+        assert!(Arc::ptr_eq(&list1.alloc, &list2.alloc));
 
         // Pushing something new in the first list should re-allocate
         list1.push_front(2);
-        assert_ne!(Arc::as_ptr(&list1.alloc), Arc::as_ptr(&list2.alloc));
+        assert!(!Arc::ptr_eq(&list1.alloc, &list2.alloc));
 
         // Now that list2 is alone on its allocation it should be able
         // to push an element to the front without re-allocating anything

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -74,8 +74,9 @@ impl<T> NumbatList<T> {
         }
     }
 
-    /// Advance the view you have of the list by one.
-    pub fn advance_view(&mut self) -> Result<(), RuntimeError> {
+    /// Return the tail of the list without the first element.
+    /// Return an error if the list is empty.
+    pub fn tail(&mut self) -> Result<(), RuntimeError> {
         if self.is_empty() {
             return Err(RuntimeError::EmptyList);
         }
@@ -218,9 +219,9 @@ mod test {
         ]
         "###);
 
-        list.advance_view().unwrap();
+        list.tail().unwrap();
         assert_eq!(list.len(), 3);
-        list.advance_view().unwrap();
+        list.tail().unwrap();
         assert_eq!(list.len(), 2);
         assert_eq!(alloc, Arc::as_ptr(&list.alloc));
 
@@ -238,12 +239,12 @@ mod test {
         ]
         "###);
 
-        list.advance_view().unwrap();
-        list.advance_view().unwrap();
+        list.tail().unwrap();
+        list.tail().unwrap();
         assert!(list.is_empty());
         assert_eq!(alloc, Arc::as_ptr(&list.alloc));
 
-        assert_eq!(list.advance_view(), Err(RuntimeError::EmptyList));
+        assert_eq!(list.tail(), Err(RuntimeError::EmptyList));
     }
 
     #[test]
@@ -257,7 +258,7 @@ mod test {
 
         assert_eq!(Arc::as_ptr(&list1.alloc), Arc::as_ptr(&list2.alloc));
 
-        list2.advance_view().unwrap();
+        list2.tail().unwrap();
         // Even after advancing the list2 the alloc can still be shared between both instance
         assert_eq!(Arc::as_ptr(&list1.alloc), Arc::as_ptr(&list2.alloc));
 
@@ -284,7 +285,7 @@ mod test {
 
         assert_eq!(list1, list2);
 
-        list2.advance_view().unwrap();
+        list2.tail().unwrap();
         assert_ne!(list1, list2);
 
         // Even if the list do not share the same allocation they should match
@@ -297,7 +298,7 @@ mod test {
         let mut list1 = NumbatList::<usize>::new();
         list1.push_front(1);
         let _list2 = list1.clone();
-        list1.advance_view().unwrap();
+        list1.tail().unwrap();
         list1.push_front(2);
     }
 }

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -1,3 +1,10 @@
+//! This module defines a custom kind of list used in the [`numbat::Value::List`].
+//! The specificities of this list are that:
+//! - It's based on a `VecDeque`, which means insertion at the beginning or the end is `O(1)`.
+//! - It's stored behind an `Arc`, which makes cloning the value very cheap.
+//! - It tries to reduce the number of allocations as much as possible, even when shared between multiple values.
+//!   If you are the only owner of the list or while you're not pushing elements in it in, never re-allocate.
+
 use std::{collections::VecDeque, fmt, sync::Arc};
 
 use crate::{value::Value, RuntimeError};

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -120,6 +120,25 @@ impl<T: Clone> ArcListView<T> {
             inner.push_front(element);
         }
     }
+
+    /// Allocate iif the list being used by another value at the same time
+    pub fn push_back(&mut self, element: T) {
+        let inner = Arc::make_mut(&mut self.alloc);
+        if let Some((_start, end)) = &mut self.view {
+            // if we were alone on the allocation and had a view of the inner allocation
+            // we can keep the allocation and overwrite the end+1 element.
+            // but we need to take care of the special case where the end is `alloc.len()`.
+            if *end == inner.len() {
+                inner.push_back(element);
+                *end += 1;
+            } else {
+                *end += 1;
+                inner[*end] = element;
+            }
+        } else {
+            inner.push_back(element);
+        }
+    }
 }
 
 impl From<ArcListView<Value>> for Value {

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -1,8 +1,10 @@
-use std::{collections::VecDeque, fmt, sync::Arc};
+use std::sync::Arc;
 
 use itertools::Itertools;
 
-use crate::{pretty_print::PrettyPrint, quantity::Quantity, typed_ast::StructInfo, RuntimeError};
+use crate::{
+    list::NumbatList, pretty_print::PrettyPrint, quantity::Quantity, typed_ast::StructInfo,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionReference {
@@ -24,138 +26,6 @@ impl std::fmt::Display for FunctionReference {
     }
 }
 
-pub type NumbatList<T> = VecDeque<T>;
-
-/// Reference counted list / list view
-#[derive(Clone, Eq)]
-pub struct ArcListView<T> {
-    /// The original alloc shared between all values
-    alloc: Arc<VecDeque<T>>,
-    /// The indexes accessible to us. If `None` we own the whole allocation
-    view: Option<(usize, usize)>,
-}
-
-impl<T: fmt::Debug + Clone> fmt::Debug for ArcListView<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.iter()).finish()
-    }
-}
-
-impl<T: PartialEq> PartialEq for ArcListView<T> {
-    fn eq(&self, other: &Self) -> bool {
-        // Best case scenario, the slice don't have the same len and we can early exit
-        if self.len() != other.len() {
-            return false;
-        }
-        // Second best case scenario, the slice comes from the same allocation
-        // and have the same view => they are equal
-        if Arc::as_ptr(&self.alloc) == Arc::as_ptr(&other.alloc) && self.view == other.view {
-            true
-        } else {
-            // Worst case scenario, we need to compare all the elements one by one
-            self.iter().zip(other.iter()).all(|(l, r)| l == r)
-        }
-    }
-}
-
-impl<T> ArcListView<T> {
-    pub fn len(&self) -> usize {
-        if let Some(view) = self.view {
-            view.1 - view.0
-        } else {
-            self.alloc.len()
-        }
-    }
-
-    pub fn front(&self) -> Option<&T> {
-        if let Some(view) = self.view {
-            self.alloc.get(view.0)
-        } else {
-            self.alloc.front()
-        }
-    }
-
-    /// Advance the view you have of the list by one.
-    pub fn advance_view(&mut self) -> Result<(), RuntimeError> {
-        if self.len() == 0 {
-            return Err(RuntimeError::EmptyList);
-        }
-        if let Some(view) = &mut self.view {
-            view.0 += 1;
-            // should be ensured by the if above
-            debug_assert!(view.0 <= view.1);
-        } else {
-            self.view = Some((1, self.len()));
-        }
-        Ok(())
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.alloc
-            .iter()
-            .skip(self.view.map_or(0, |(start, _end)| start))
-            .take(
-                self.view
-                    .map_or(self.alloc.len(), |(start, end)| end - start),
-            )
-    }
-}
-
-impl<T: Clone> ArcListView<T> {
-    /// Allocate iif the list being used by another value at the same time
-    pub fn push_front(&mut self, element: T) {
-        let inner = Arc::make_mut(&mut self.alloc);
-        if let Some((start, end)) = &mut self.view {
-            // if we were alone on the allocation and had a view of the inner allocation
-            // we can keep the allocation and overwrite the start-1 element.
-            // but we need to take care of the special case where the start is 0.
-            if *start == 0 {
-                inner.push_front(element);
-                *end += 1;
-            } else {
-                *start -= 1;
-                inner[*start] = element;
-            }
-        } else {
-            inner.push_front(element);
-        }
-    }
-
-    /// Allocate iif the list being used by another value at the same time
-    pub fn push_back(&mut self, element: T) {
-        let inner = Arc::make_mut(&mut self.alloc);
-        if let Some((_start, end)) = &mut self.view {
-            // if we were alone on the allocation and had a view of the inner allocation
-            // we can keep the allocation and overwrite the end+1 element.
-            // but we need to take care of the special case where the end is `alloc.len()`.
-            if *end == inner.len() {
-                inner.push_back(element);
-                *end += 1;
-            } else {
-                *end += 1;
-                inner[*end] = element;
-            }
-        } else {
-            inner.push_back(element);
-        }
-    }
-}
-
-impl From<ArcListView<Value>> for Value {
-    fn from(list: ArcListView<Value>) -> Self {
-        Value::List(list)
-    }
-}
-
-impl From<VecDeque<Value>> for Value {
-    fn from(list: VecDeque<Value>) -> Self {
-        Value::List(ArcListView {
-            alloc: Arc::new(list),
-            view: None,
-        })
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     Quantity(Quantity),
@@ -166,7 +36,7 @@ pub enum Value {
     FunctionReference(FunctionReference),
     FormatSpecifiers(Option<String>),
     StructInstance(Arc<StructInfo>, Vec<Value>),
-    List(ArcListView<Value>),
+    List(NumbatList<Value>),
 }
 
 impl Value {
@@ -225,7 +95,7 @@ impl Value {
     }
 
     #[track_caller]
-    pub fn unsafe_as_list(self) -> ArcListView<Value> {
+    pub fn unsafe_as_list(self) -> NumbatList<Value> {
         if let Value::List(values) = self {
             values
         } else {

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -1,8 +1,8 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, fmt, sync::Arc};
 
 use itertools::Itertools;
 
-use crate::{pretty_print::PrettyPrint, quantity::Quantity, typed_ast::StructInfo};
+use crate::{pretty_print::PrettyPrint, quantity::Quantity, typed_ast::StructInfo, RuntimeError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionReference {
@@ -26,6 +26,117 @@ impl std::fmt::Display for FunctionReference {
 
 pub type NumbatList<T> = VecDeque<T>;
 
+/// Reference counted list / list view
+#[derive(Clone, Eq)]
+pub struct ArcListView<T> {
+    /// The original alloc shared between all values
+    alloc: Arc<VecDeque<T>>,
+    /// The indexes accessible to us. If `None` we own the whole allocation
+    view: Option<(usize, usize)>,
+}
+
+impl<T: fmt::Debug + Clone> fmt::Debug for ArcListView<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<T: PartialEq> PartialEq for ArcListView<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Best case scenario, the slice don't have the same len and we can early exit
+        if self.len() != other.len() {
+            return false;
+        }
+        // Second best case scenario, the slice comes from the same allocation
+        // and have the same view => they are equal
+        if Arc::as_ptr(&self.alloc) == Arc::as_ptr(&other.alloc) && self.view == other.view {
+            true
+        } else {
+            // Worst case scenario, we need to compare all the elements one by one
+            self.iter().zip(other.iter()).all(|(l, r)| l == r)
+        }
+    }
+}
+
+impl<T> ArcListView<T> {
+    pub fn len(&self) -> usize {
+        if let Some(view) = self.view {
+            view.1 - view.0
+        } else {
+            self.alloc.len()
+        }
+    }
+
+    pub fn front(&self) -> Option<&T> {
+        if let Some(view) = self.view {
+            self.alloc.get(view.0)
+        } else {
+            self.alloc.front()
+        }
+    }
+
+    /// Advance the view you have of the list by one.
+    pub fn advance_view(&mut self) -> Result<(), RuntimeError> {
+        if self.len() == 0 {
+            return Err(RuntimeError::EmptyList);
+        }
+        if let Some(view) = &mut self.view {
+            view.0 += 1;
+            // should be ensured by the if above
+            debug_assert!(view.0 <= view.1);
+        } else {
+            self.view = Some((1, self.len()));
+        }
+        Ok(())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.alloc
+            .iter()
+            .skip(self.view.map_or(0, |(start, _end)| start))
+            .take(
+                self.view
+                    .map_or(self.alloc.len(), |(start, end)| end - start),
+            )
+    }
+}
+
+impl<T: Clone> ArcListView<T> {
+    /// Allocate iif the list being used by another value at the same time
+    pub fn push_front(&mut self, element: T) {
+        let inner = Arc::make_mut(&mut self.alloc);
+        if let Some((start, end)) = &mut self.view {
+            // if we were alone on the allocation and had a view of the inner allocation
+            // we can keep the allocation and overwrite the start-1 element.
+            // but we need to take care of the special case where the start is 0.
+            if *start == 0 {
+                inner.push_front(element);
+                *end += 1;
+            } else {
+                *start -= 1;
+                inner[*start] = element;
+            }
+        } else {
+            inner.push_front(element);
+        }
+    }
+}
+
+impl From<ArcListView<Value>> for Value {
+    fn from(list: ArcListView<Value>) -> Self {
+        Value::List(list)
+    }
+}
+
+impl From<VecDeque<Value>> for Value {
+    fn from(list: VecDeque<Value>) -> Self {
+        Value::List(ArcListView {
+            alloc: Arc::new(list),
+            view: None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     Quantity(Quantity),
@@ -36,7 +147,7 @@ pub enum Value {
     FunctionReference(FunctionReference),
     FormatSpecifiers(Option<String>),
     StructInstance(Arc<StructInfo>, Vec<Value>),
-    List(NumbatList<Value>),
+    List(ArcListView<Value>),
 }
 
 impl Value {
@@ -95,7 +206,7 @@ impl Value {
     }
 
     #[track_caller]
-    pub fn unsafe_as_list(self) -> NumbatList<Value> {
+    pub fn unsafe_as_list(self) -> ArcListView<Value> {
         if let Value::List(values) = self {
             values
         } else {

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -4,9 +4,9 @@ use std::{cmp::Ordering, fmt::Display};
 
 use indexmap::IndexMap;
 
+use crate::list::NumbatList;
 use crate::span::Span;
 use crate::typed_ast::StructInfo;
-use crate::value::NumbatList;
 use crate::{
     ffi::{self, ArityRange, Callable, ForeignFunction},
     interpreter::{InterpreterResult, PrintFunction, Result, RuntimeError},

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -1037,7 +1037,7 @@ impl Vm {
                         list.push_front(self.pop());
                     }
 
-                    self.stack.push(Value::List(list));
+                    self.stack.push(list.into());
                 }
             }
         }


### PR DESCRIPTION
Make list faster in some cases.

Part of #448

On my computer, running:
```
time cargo run --release -- -e 'sum(map(sqrt, range(0, 10_000)))'
```

Take 42s on main vs 0.4s on my branch.

I don't think this approach is general enough, though. Having pattern matching would make performant numbat code easier to write.

-----

## How does it works?

I replaced the `NumbatList` type with a custom `ArcListView` type that shares its allocation with all other list referring to the same allocation.
It hold a reference counted ptr to the allocation + the bounds accessible by the allocation:

```rust
/// Reference counted list / list view
#[derive(Clone, Eq)]
pub struct ArcListView<T> {
    /// The original alloc shared between all values
    alloc: Arc<VecDeque<T>>,
    /// The indexes accessible to us. If `None` we own the whole allocation
    view: Option<(usize, usize)>,
}
```

Then, doing a `tail` is a matter of advancing the starting view by one.
`head` simply returns the first element.
And `push_front` check if he's the only owner of the allocation, if it's the case it never allocate (this is always the case while building the list for example so its important).
if it's not the only owner of the allocation, it clones the allocation entirely. We could probably do something smarter here with a chained list or something, but since it yields pretty good results, I didn't try harder.

We now need to take extra care while implementing PartialEq


-----

EDIT: While playing with list a little bit I noticed that the following code was still taking around 15s:
```rust
let a = now()
let list = range(0, 10_000)
print("Made the list in {human(now() - a)}")

let b = now()
let reversed = reverse(list)
print("Reversed the list in {human(now() - b)}")
```

Which is expected considering the number of operations we're doing to push something at the end of a list even though we internally uses a vecdeque.
By providing an ffi `cons_end` function I went from 15s to 0.002s