### PR TITLE
Make the reverse function call more useful

### DIFF
--- a/book/src/list-functions-lists.md
+++ b/book/src/list-functions-lists.md
@@ -34,7 +34,7 @@ fn cons<A>(x: A, xs: List<A>) -> List<A>
 Append an element to the end of a list.
 
 ```nbt
-fn cons_end<A>(xs: List<A>, x: A) -> List<A>
+fn cons_end<A>(x: A, xs: List<A>) -> List<A>
 ```
 
 ### `is_empty`

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -10,8 +10,8 @@ assert_eq(tail(xs), [2, 3])
 
 assert_eq(cons(0, xs), [0, 1, 2, 3])
 
-assert_eq(cons_end(xs, 4), [1, 2, 3, 4])
-assert_eq(cons_end([], 0), [0])
+assert_eq(cons_end(4, xs), [1, 2, 3, 4])
+assert_eq(cons_end(0, []), [0])
 
 assert(is_empty([]))
 assert(!is_empty(xs))

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -15,7 +15,7 @@ fn tail<A>(xs: List<A>) -> List<A>
 fn cons<A>(x: A, xs: List<A>) -> List<A>
 
 @description("Append an element to the end of a list")
-fn cons_end<A>(xs: List<A>, x: A) -> List<A>
+fn cons_end<A>(x: A, xs: List<A>) -> List<A>
 
 @description("Check if a list is empty")
 fn is_empty<A>(xs: List<A>) -> Bool = xs == []
@@ -55,7 +55,7 @@ fn range(start: Scalar, end: Scalar) -> List<Scalar> =
 fn reverse<A>(xs: List<A>) -> List<A> =
   if is_empty(xs)
     then []
-    else cons_end(reverse(tail(xs)), head(xs))
+    else cons_end(head(xs), reverse(tail(xs)))
 
 @description("Generate a new list by applying a function to each element of the input list")
 fn map<A, B>(f: Fn[(A) -> B], xs: List<A>) -> List<B> =

--- a/numbat/src/ffi/lists.rs
+++ b/numbat/src/ffi/lists.rs
@@ -36,8 +36,8 @@ pub fn cons(mut args: Args) -> Result<Value> {
 }
 
 pub fn cons_end(mut args: Args) -> Result<Value> {
-    let mut list = list_arg!(args);
     let element = arg!(args);
+    let mut list = list_arg!(args);
     list.push_back(element);
 
     return_list!(list)


### PR DESCRIPTION
Hey, while working on https://github.com/sharkdp/numbat/pull/515, I didn't like the API around lists, especially the way we don't chain calls, which makes the code very hard to read.

With this PR, the following chunks of code are equivalent:
```ocaml
sum(map(sqrt, range(0, 10_000)))
range(0, 10_000) // map(sqrt) // sum
```

It's clearly inspired by the `|>` operator of OCaml; I believe Haskell has something similar with the `$` or `&` operator as well.
Obviously, it's not as clean as in these two languages since numbat uses parens to call functions.
But it still works, and it should become even more useful once we have closures.

> [!note]
> For the future, we should take care while designing the APIs (and especially the list/set/map APIs) that the data structure is always the last parameter


----

Also, I think I already asked you a long time ago and forgot the answer, but what do you think of renaming (or duplicating) this operator with another symbol?
I’ve never seen `//` anywhere else, and it doesn't ring a bell at all when I use it. I would be way more comfortable with the arroy of OCaml `|>`, which shows its intent more clearly.