### PR TITLE
Multiline functions: local variables

### DIFF
--- a/assets/articles/index.js
+++ b/assets/articles/index.js
@@ -54,7 +54,7 @@ ace.define(
           {
             token: "keyword",
             regex:
-              "\\b(?:per|to|let|fn|where|dimension|unit|use|long|short|both|none|print|assert|assert_eq|type|if|then|else|true|false)\\b",
+              "\\b(?:per|to|let|fn|where|and|dimension|unit|use|long|short|both|none|print|assert|assert_eq|type|if|then|else|true|false)\\b",
           },
           {
             token: "constant.numeric",

--- a/assets/articles/index.js
+++ b/assets/articles/index.js
@@ -54,7 +54,7 @@ ace.define(
           {
             token: "keyword",
             regex:
-              "\\b(?:per|to|let|fn|dimension|unit|use|long|short|both|none|print|assert|assert_eq|type|if|then|else|true|false)\\b",
+              "\\b(?:per|to|let|fn|where|dimension|unit|use|long|short|both|none|print|assert|assert_eq|type|if|then|else|true|false)\\b",
           },
           {
             token: "constant.numeric",

--- a/assets/numbat.sublime-syntax
+++ b/assets/numbat.sublime-syntax
@@ -7,7 +7,7 @@ file_extensions:
 scope: source.nbt
 contexts:
   main:
-    - match: \b(per|to|let|fn|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\b
+    - match: \b(per|to|let|fn|where|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\b
       scope: keyword.control.nbt
     - match: '#(.*)'
       scope: comment.line.nbt

--- a/assets/numbat.sublime-syntax
+++ b/assets/numbat.sublime-syntax
@@ -7,7 +7,7 @@ file_extensions:
 scope: source.nbt
 contexts:
   main:
-    - match: \b(per|to|let|fn|where|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\b
+    - match: \b(per|to|let|fn|where|and|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\b
       scope: keyword.control.nbt
     - match: '#(.*)'
       scope: comment.line.nbt

--- a/assets/numbat.vim
+++ b/assets/numbat.vim
@@ -5,7 +5,7 @@ if exists("b:current_syntax")
 endif
 
 " Numbat Keywords
-syn keyword numbatKeywords per to let fn where dimension unit use struct long short both none if then else true false NaN inf print assert assert_eq type
+syn keyword numbatKeywords per to let fn where and dimension unit use struct long short both none if then else true false NaN inf print assert assert_eq type
 highlight default link numbatKeywords Keyword
 
 " Physical dimensions (every capitalized word)

--- a/assets/numbat.vim
+++ b/assets/numbat.vim
@@ -5,7 +5,7 @@ if exists("b:current_syntax")
 endif
 
 " Numbat Keywords
-syn keyword numbatKeywords per to let fn dimension unit use struct long short both none if then else true false NaN inf print assert assert_eq type
+syn keyword numbatKeywords per to let fn where dimension unit use struct long short both none if then else true false NaN inf print assert assert_eq type
 highlight default link numbatKeywords Keyword
 
 " Physical dimensions (every capitalized word)

--- a/book/numbat.js
+++ b/book/numbat.js
@@ -4,7 +4,7 @@ hljs.registerLanguage('numbat', function(hljs) {
     aliases: ['nbt'],
     case_insensitive: false,
     keywords: {
-      keyword: 'per to let fn where dimension unit use struct long short both none if then else true false print assert assert_eq type',
+      keyword: 'per to let fn where and dimension unit use struct long short both none if then else true false print assert assert_eq type',
     },
     contains: [
       hljs.HASH_COMMENT_MODE,

--- a/book/numbat.js
+++ b/book/numbat.js
@@ -4,7 +4,7 @@ hljs.registerLanguage('numbat', function(hljs) {
     aliases: ['nbt'],
     case_insensitive: false,
     keywords: {
-      keyword: 'per to let fn dimension unit use struct long short both none if then else true false print assert assert_eq type',
+      keyword: 'per to let fn where dimension unit use struct long short both none if then else true false print assert assert_eq type',
     },
     contains: [
       hljs.HASH_COMMENT_MODE,

--- a/book/src/example-numbat_syntax.md
+++ b/book/src/example-numbat_syntax.md
@@ -71,6 +71,9 @@ fn foo(z: Scalar) -> Scalar = 2 * z + 3                   # A simple function
 fn speed(len: Length, dur: Time) -> Velocity = len / dur  # Two parameters
 fn my_sqrt<T: Dim>(q: T^2) -> T = q^(1/2)                 # A generic function
 fn is_non_negative(x: Scalar) -> Bool = x ≥ 0             # Returns a bool
+fn power_4(x: Scalar) = z                                 # A function with local variables
+  where y = x * x
+    and z = y * y
 
 # 6. Dimension definitions
 

--- a/examples/numbat_syntax.nbt
+++ b/examples/numbat_syntax.nbt
@@ -68,7 +68,7 @@ fn my_sqrt<T: Dim>(q: T^2) -> T = q^(1/2)                 # A generic function
 fn is_non_negative(x: Scalar) -> Bool = x ≥ 0             # Returns a bool
 fn power_4(x: Scalar) = z                                 # A function with local variables
   where y = x * x
-        z = y * y
+    and z = y * y
 
 # 6. Dimension definitions
 

--- a/examples/numbat_syntax.nbt
+++ b/examples/numbat_syntax.nbt
@@ -66,6 +66,9 @@ fn foo(z: Scalar) -> Scalar = 2 * z + 3                   # A simple function
 fn speed(len: Length, dur: Time) -> Velocity = len / dur  # Two parameters
 fn my_sqrt<T: Dim>(q: T^2) -> T = q^(1/2)                 # A generic function
 fn is_non_negative(x: Scalar) -> Bool = x ≥ 0             # Returns a bool
+fn power_4(x: Scalar) = z                                 # A function with local variables
+  where y = x * x
+        z = y * y
 
 # 6. Dimension definitions
 

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -38,6 +38,10 @@ assert_eq(drop(0, []), [])
 assert_eq(range(0, 0), [0])
 assert_eq(range(0, 5), [0, 1, 2, 3, 4, 5])
 
+assert_eq(insert_at(12, 0, range(0, 5)), [12, 0, 1, 2, 3, 4, 5])
+assert_eq(insert_at(12, 1, range(0, 5)), [0, 12, 1, 2, 3, 4, 5])
+assert_eq(insert_at(12, len(range(0, 5)), range(0, 5)), [0, 1, 2, 3, 4, 5, 12])
+
 assert_eq(reverse([]), [])
 assert_eq(reverse(xs), [3, 2, 1])
 

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -38,10 +38,6 @@ assert_eq(drop(0, []), [])
 assert_eq(range(0, 0), [0])
 assert_eq(range(0, 5), [0, 1, 2, 3, 4, 5])
 
-assert_eq(insert_at(12, 0, range(0, 5)), [12, 0, 1, 2, 3, 4, 5])
-assert_eq(insert_at(12, 1, range(0, 5)), [0, 12, 1, 2, 3, 4, 5])
-assert_eq(insert_at(12, len(range(0, 5)), range(0, 5)), [0, 1, 2, 3, 4, 5, 12])
-
 assert_eq(reverse([]), [])
 assert_eq(reverse(xs), [3, 2, 1])
 

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -44,6 +44,12 @@ fn element_at<A>(i: Scalar, xs: List<A>) -> A =
     then head(xs)
     else element_at(i - 1, tail(xs))
 
+@description("Insert the element at index `i` in a list")
+fn insert_at<A>(el: A, i: Scalar, xs: List<A>) -> List<A> =
+  if i == 0
+    then cons(el, xs)
+    else cons(head(xs), insert_at(el, i - 1, tail(xs)))
+
 @description("Generate a range of integer numbers from `start` to `end` (inclusive)")
 fn range(start: Scalar, end: Scalar) -> List<Scalar> =
   if start > end

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -138,5 +138,7 @@ fn split(input: String, separator: String) -> List<String> =
     then []
     else if !str_contains(input, separator)
       then [input]
-      else cons(str_slice(input, 0, str_find(input, separator)),  # TODO: avoid duplication
-                split(str_slice(input, str_find(input, separator) + str_length(separator), str_length(input)), separator))
+      else cons(str_slice(input, 0, idx_separator),
+                split(str_slice(input, idx_separator + str_length(separator), str_length(input)), separator))
+  where
+    idx_separator = str_find(input, separator)

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -44,12 +44,6 @@ fn element_at<A>(i: Scalar, xs: List<A>) -> A =
     then head(xs)
     else element_at(i - 1, tail(xs))
 
-@description("Insert the element at index `i` in a list")
-fn insert_at<A>(el: A, i: Scalar, xs: List<A>) -> List<A> =
-  if i == 0
-    then cons(el, xs)
-    else cons(head(xs), insert_at(el, i - 1, tail(xs)))
-
 @description("Generate a range of integer numbers from `start` to `end` (inclusive)")
 fn range(start: Scalar, end: Scalar) -> List<Scalar> =
   if start > end

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -32,9 +32,8 @@ fn str_find(haystack: String, needle: String) -> Scalar =
       else if str_find(tail_haystack, needle) == -1
         then -1
         else 1 + str_find(tail_haystack, needle)
-  where
-    len_haystack = str_length(haystack)
-    tail_haystack = str_slice(haystack, 1, len_haystack)
+  where len_haystack = str_length(haystack)
+    and tail_haystack = str_slice(haystack, 1, len_haystack)
 
 @description("Check if a string contains a substring")
 fn str_contains(haystack: String, needle: String) -> Bool =

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -25,13 +25,16 @@ fn str_append(a: String, b: String) -> String = "{a}{b}"
 
 @description("Find the first occurrence of a substring in a string")
 fn str_find(haystack: String, needle: String) -> Scalar =
-  if str_length(haystack) == 0
+  if len_haystack == 0
     then -1
     else if str_slice(haystack, 0, str_length(needle)) == needle
       then 0
-      else if str_find(str_slice(haystack, 1, str_length(haystack)), needle) == -1  # TODO: we need local variables!
+      else if str_find(tail_haystack, needle) == -1
         then -1
-        else 1 + str_find(str_slice(haystack, 1, str_length(haystack)), needle)
+        else 1 + str_find(tail_haystack, needle)
+  where
+    len_haystack = str_length(haystack)
+    tail_haystack = str_slice(haystack, 1, len_haystack)
 
 @description("Check if a string contains a substring")
 fn str_contains(haystack: String, needle: String) -> Bool =
@@ -60,12 +63,16 @@ fn _oct_digit(x: Scalar) -> String =
   chr(48 + mod(x, 8))
 
 fn _hex_digit(x: Scalar) -> String =
-    if mod(x, 16) < 10 then chr(48 + mod(x, 16)) else chr(97 + mod(x, 16) - 10)
+  if x_16 < 10 then chr(48 + x_16) else chr(97 + x_16 - 10)
+  where
+    x_16 = mod(x, 16)
 
 fn _digit_in_base(x: Scalar, base: Scalar) -> String =
   if base < 2 || base > 16
     then error("base must be between 2 and 16")
-    else if mod(x, 16) < 10 then chr(48 + mod(x, 16)) else chr(97 + mod(x, 16) - 10)
+    else if x_16 < 10 then chr(48 + x_16) else chr(97 + x_16 - 10)
+  where
+    x_16 = mod(x, 16)
 
 fn _number_in_base(x: Scalar, b: Scalar) -> String =
   if x < 0

--- a/numbat/modules/datetime/functions.nbt
+++ b/numbat/modules/datetime/functions.nbt
@@ -51,15 +51,18 @@ fn _add_years(dt: DateTime, n_years: Scalar) -> DateTime
 
 @description("Adds the given time span to a `DateTime`. This uses leap-year and DST-aware calendar arithmetic with variable-length days, months, and years.")
 fn calendar_add(dt: DateTime, span: Time) -> DateTime =
-   if unit_of(span) == days
+   if span_unit == days
      then _add_days(dt, span / days)
-     else if unit_of(span) == months
-       then _add_months(dt, span / months)
-       else if unit_of(span) == years
-         then _add_years(dt, span / years)
-         else if unit_of(span) == seconds || unit_of(span) == minutes || unit_of(span) == hours
-           then dt + span
-           else error("calendar_add: Unsupported unit: {unit_of(span)}")
+   else if span_unit == months
+     then _add_months(dt, span / months)
+   else if span_unit == years
+     then _add_years(dt, span / years)
+   else if span_unit == seconds || span_unit == minutes || span_unit == hours
+     then dt + span
+   else
+     error("calendar_add: Unsupported unit: {span_unit}")
+  where
+    span_unit = unit_of(span)
 
 @description("Subtract the given time span from a `DateTime`. This uses leap-year and DST-aware calendar arithmetic with variable-length days, months, and years.")
 fn calendar_sub(dt: DateTime, span: Time) -> DateTime =

--- a/numbat/modules/math/statistics.nbt
+++ b/numbat/modules/math/statistics.nbt
@@ -38,6 +38,8 @@ fn stdev<D: Dim>(xs: List<D>) -> D = sqrt(variance(xs))
 @url("https://en.wikipedia.org/wiki/Median")
 @description("Calculate the median of a list of quantities")
 fn median<D: Dim>(xs: List<D>) -> D =  # TODO: this is extremely inefficient
-  if mod(len(xs), 2) == 1
-    then element_at((len(xs) - 1) / 2, sort(xs))
-    else mean([element_at(len(xs) / 2 - 1, sort(xs)), element_at(len(xs) / 2, sort(xs))])
+  if mod(n, 2) == 1
+    then element_at((n - 1) / 2, sort(xs))
+    else mean([element_at(n / 2 - 1, sort(xs)), element_at(n / 2, sort(xs))])
+  where
+    n = len(xs)

--- a/numbat/modules/numerics/diff.nbt
+++ b/numbat/modules/numerics/diff.nbt
@@ -1,10 +1,9 @@
 use core::quantities
 
-# TODO: Move this to a local definition inside `diff` once we support that
-fn _delta<X: Dim>(x: X) -> X = 1e-10 × unit_of(x)
-
 @name("Numerical differentiation")
 @url("https://en.wikipedia.org/wiki/Numerical_differentiation")
 @description("Compute the numerical derivative of the function $f$ at point $x$ using the central difference method.")
 fn diff<X: Dim, Y: Dim>(f: Fn[(X) -> Y], x: X) -> Y / X =
-  (f(x + _delta(x)) - f(x - _delta(x))) / (2 _delta(x))
+  (f(x + Δx) - f(x - Δx)) / (2 Δx)
+  where
+    Δx = 1e-10 × unit_of(x)

--- a/numbat/modules/numerics/solve.nbt
+++ b/numbat/modules/numerics/solve.nbt
@@ -12,9 +12,8 @@ fn root_bisect<X: Dim, Y: Dim>(f: Fn[(X) -> Y], x1: X, x2: X, x_tol: X, y_tol: Y
       else if f_x_mean × f(x1) < 0
         then root_bisect(f, x1, x_mean, x_tol, y_tol)
         else root_bisect(f, x_mean, x2, x_tol, y_tol)
-  where
-    x_mean = (x1 + x2) / 2
-    f_x_mean = f(x_mean)
+  where x_mean = (x1 + x2) / 2
+    and f_x_mean = f(x_mean)
 
 fn _root_newton_helper<X: Dim, Y: Dim>(f: Fn[(X) -> Y], f_prime: Fn[(X) -> Y / X], x0: X, y_tol: Y, max_iterations: Scalar) -> X =
   if max_iterations <= 0

--- a/numbat/modules/numerics/solve.nbt
+++ b/numbat/modules/numerics/solve.nbt
@@ -6,20 +6,24 @@ use core::error
 @description("Find the root of the function $f$ in the interval $[x_1, x_2]$ using the bisection method. The function $f$ must be continuous and $f(x_1) \cdot f(x_2) < 0$.")
 fn root_bisect<X: Dim, Y: Dim>(f: Fn[(X) -> Y], x1: X, x2: X, x_tol: X, y_tol: Y) -> X =
   if abs(x1 - x2) < x_tol
-    then (x1 + x2) / 2
-    else if abs(f((x1 + x2) / 2)) < y_tol
-      then (x1 + x2) / 2
-      else if f((x1 + x2) / 2) * f(x1) < 0
-        then root_bisect(f, x1, (x1 + x2) / 2, x_tol, y_tol)
-        else root_bisect(f, (x1 + x2) / 2, x2, x_tol, y_tol)
-  # TODO: move (x1 + x2) / 2 to a local variable once we support them
+    then x_mean
+    else if abs(f_x_mean) < y_tol
+      then x_mean
+      else if f_x_mean × f(x1) < 0
+        then root_bisect(f, x1, x_mean, x_tol, y_tol)
+        else root_bisect(f, x_mean, x2, x_tol, y_tol)
+  where
+    x_mean = (x1 + x2) / 2
+    f_x_mean = f(x_mean)
 
 fn _root_newton_helper<X: Dim, Y: Dim>(f: Fn[(X) -> Y], f_prime: Fn[(X) -> Y / X], x0: X, y_tol: Y, max_iterations: Scalar) -> X =
   if max_iterations <= 0
     then error("root_newton: Maximum number of iterations reached. Try another initial guess?")
-    else if abs(f(x0)) < y_tol
+    else if abs(f_x0) < y_tol
       then x0
-      else _root_newton_helper(f, f_prime, x0 - f(x0) / f_prime(x0), y_tol, max_iterations - 1)
+      else _root_newton_helper(f, f_prime, x0 - f_x0 / f_prime(x0), y_tol, max_iterations - 1)
+  where
+    f_x0 = f(x0)
 
 @name("Newton's method")
 @url("https://en.wikipedia.org/wiki/Newton%27s_method") 

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -324,7 +324,7 @@ impl BytecodeInterpreter {
 
             self.locals[current_depth].push(Local {
                 identifier: alias_name.clone(),
-                depth: 0,
+                depth: current_depth,
                 metadata: metadata.clone(),
             });
         }

--- a/numbat/src/keywords.rs
+++ b/numbat/src/keywords.rs
@@ -6,6 +6,7 @@ pub const KEYWORDS: &[&str] = &[
     "to ",
     "let ",
     "fn ",
+    "where ",
     "dimension ",
     "unit ",
     "use ",

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2652,6 +2652,58 @@ mod tests {
             },
         );
 
+        parse_as(
+            &["fn double_kef(x) = y where y = x * 2"],
+            Statement::DefineFunction {
+                function_name_span: Span::dummy(),
+                function_name: "double_kef".into(),
+                type_parameters: vec![],
+                parameters: vec![(Span::dummy(), "x".into(), None)],
+                body: Some(identifier!("y")),
+                local_variables: vec![DefineVariable {
+                    identifier_span: Span::dummy(),
+                    identifier: String::from("y"),
+                    expr: binop!(identifier!("x"), Mul, scalar!(2.0)),
+                    type_annotation: None,
+                    decorators: vec![],
+                }],
+                return_type_annotation: None,
+                decorators: vec![],
+            },
+        );
+
+        parse_as(
+            &["fn kefirausaure(x) = z + y
+                where
+                    y = x + x
+                    z = y + x"],
+            Statement::DefineFunction {
+                function_name_span: Span::dummy(),
+                function_name: "kefirausaure".into(),
+                type_parameters: vec![],
+                parameters: vec![(Span::dummy(), "x".into(), None)],
+                body: Some(binop!(identifier!("z"), Add, identifier!("y"))),
+                local_variables: vec![
+                    DefineVariable {
+                        identifier_span: Span::dummy(),
+                        identifier: String::from("y"),
+                        expr: binop!(identifier!("x"), Add, identifier!("x")),
+                        type_annotation: None,
+                        decorators: vec![],
+                    },
+                    DefineVariable {
+                        identifier_span: Span::dummy(),
+                        identifier: String::from("z"),
+                        expr: binop!(identifier!("y"), Add, identifier!("x")),
+                        type_annotation: None,
+                        decorators: vec![],
+                    },
+                ],
+                return_type_annotation: None,
+                decorators: vec![],
+            },
+        );
+
         should_fail_with(
             &["@aliases(foo) fn foobar(a: Scalar) -> Scalar"],
             ParseErrorKind::AliasUsedOnFunction,

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -230,6 +230,9 @@ pub enum ParseErrorKind {
 
     #[error("Empty string interpolation")]
     EmptyStringInterpolation,
+
+    #[error("Expected local variable definition after where/and")]
+    ExpectedLocalVariableDefinition,
 }
 
 #[derive(Debug, Clone, Error)]
@@ -392,7 +395,7 @@ impl<'a> Parser<'a> {
         }
 
         if self.match_exact(TokenKind::Let).is_some() {
-            self.parse_variable().map(Statement::DefineVariable)
+            self.parse_variable(true).map(Statement::DefineVariable)
         } else if self.match_exact(TokenKind::Fn).is_some() {
             self.parse_function_declaration()
         } else if self.match_exact(TokenKind::Dimension).is_some() {
@@ -412,7 +415,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_variable(&mut self) -> Result<DefineVariable> {
+    fn parse_variable(&mut self, flush_decorators: bool) -> Result<DefineVariable> {
         if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
             let identifier_span = self.last().unwrap().span;
 
@@ -431,14 +434,16 @@ impl<'a> Parser<'a> {
                 self.skip_empty_lines();
                 let expr = self.expression()?;
 
-                if decorator::contains_aliases_with_prefixes(&self.decorator_stack) {
-                    return Err(ParseError {
-                        kind: ParseErrorKind::DecoratorsWithPrefixOnLetDefinition,
-                        span: self.peek().span,
-                    });
-                }
                 let mut decorators = vec![];
-                std::mem::swap(&mut decorators, &mut self.decorator_stack);
+                if flush_decorators {
+                    if decorator::contains_aliases_with_prefixes(&self.decorator_stack) {
+                        return Err(ParseError {
+                            kind: ParseErrorKind::DecoratorsWithPrefixOnLetDefinition,
+                            span: self.peek().span,
+                        });
+                    }
+                    std::mem::swap(&mut decorators, &mut self.decorator_stack);
+                }
 
                 Ok(DefineVariable {
                     identifier_span,
@@ -564,23 +569,37 @@ impl<'a> Parser<'a> {
                 self.skip_empty_lines();
                 let body = self.expression()?;
 
-                // After parsing the `where` statement we have eaten all
-                // the newlines. We're not supposed to do that.
-                // We'll resume the parser to where we were at before doing that.
-                let mut step_back_to = self.current;
-
                 let mut local_variables = Vec::new();
-                self.skip_empty_lines();
-                if self.match_exact(TokenKind::Where).is_some() {
-                    step_back_to = self.current;
+
+                if self
+                    .match_exact_beyond_linebreaks(TokenKind::Where)
+                    .is_some()
+                {
+                    let keyword_span = self.last().unwrap().span;
                     self.skip_empty_lines();
-                    while let Ok(local_variable) = self.parse_variable() {
+                    if let Ok(local_variable) = self.parse_variable(false) {
                         local_variables.push(local_variable);
-                        step_back_to = self.current;
+                    } else {
+                        return Err(ParseError {
+                            kind: ParseErrorKind::ExpectedLocalVariableDefinition,
+                            span: keyword_span,
+                        });
+                    }
+
+                    while self.match_exact_beyond_linebreaks(TokenKind::And).is_some() {
+                        let keyword_span = self.last().unwrap().span;
                         self.skip_empty_lines();
+                        if let Ok(local_variable) = self.parse_variable(false) {
+                            local_variables.push(local_variable);
+                        } else {
+                            return Err(ParseError {
+                                kind: ParseErrorKind::ExpectedLocalVariableDefinition,
+                                span: keyword_span,
+                            });
+                        }
                     }
                 }
-                self.current = step_back_to;
+
                 (Some(body), local_variables)
             };
 
@@ -1761,6 +1780,26 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn look_ahead_beyond_linebreak(&self, token_kind: TokenKind) -> bool {
+        let mut i = self.current;
+        while i < self.tokens.len() {
+            if self.tokens[i].kind != TokenKind::Newline {
+                return self.tokens[i].kind == token_kind;
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Same as 'match_exact', but skips empty lines before matching. Note that this
+    /// does *not* skip empty lines in case there is no match.
+    fn match_exact_beyond_linebreaks(&mut self, token_kind: TokenKind) -> Option<&'a Token> {
+        if self.look_ahead_beyond_linebreak(token_kind) {
+            self.skip_empty_lines();
+        }
+        self.match_exact(token_kind)
+    }
+
     fn match_any(&mut self, kinds: &[TokenKind]) -> Option<&'a Token> {
         for kind in kinds {
             if let result @ Some(..) = self.match_exact(*kind) {
@@ -2698,9 +2737,8 @@ mod tests {
 
         parse_as(
             &["fn kefirausaure(x) = z + y
-                where
-                    y = x + x
-                    z = y + x"],
+                 where y = x + x
+                   and z = y + x"],
             Statement::DefineFunction {
                 function_name_span: Span::dummy(),
                 function_name: "kefirausaure".into(),
@@ -2726,6 +2764,16 @@ mod tests {
                 return_type_annotation: None,
                 decorators: vec![],
             },
+        );
+
+        should_fail_with(
+            &["fn f(x) = x where"],
+            ParseErrorKind::ExpectedLocalVariableDefinition,
+        );
+
+        should_fail_with(
+            &["fn f(x) = x where z = 1 and"],
+            ParseErrorKind::ExpectedLocalVariableDefinition,
         );
 
         should_fail_with(

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -302,7 +302,22 @@ impl<'a> Parser<'a> {
                 TokenKind::Eof => {
                     break;
                 }
-                _ => {}
+                TokenKind::Equal => {
+                    errors.push(ParseError {
+                        kind: ParseErrorKind::TrailingEqualSign(
+                            self.last().unwrap().lexeme.clone(),
+                        ),
+                        span: self.peek().span,
+                    });
+                    self.recover_from_error();
+                }
+                _ => {
+                    errors.push(ParseError {
+                        kind: ParseErrorKind::TrailingCharacters(self.peek().lexeme.clone()),
+                        span: self.peek().span,
+                    });
+                    self.recover_from_error();
+                }
             }
         }
 
@@ -543,22 +558,31 @@ impl<'a> Parser<'a> {
                 None
             };
 
-            let body = if self.match_exact(TokenKind::Equal).is_none() {
-                None
+            let (body, local_variables) = if self.match_exact(TokenKind::Equal).is_none() {
+                (None, vec![])
             } else {
                 self.skip_empty_lines();
-                Some(self.expression()?)
-            };
+                let body = self.expression()?;
 
-            let mut local_variables = Vec::new();
-            self.skip_empty_lines();
-            if self.match_exact(TokenKind::Where).is_some() {
+                // After parsing the `where` statement we have eaten all
+                // the newlines. We're not supposed to do that.
+                // We'll resume the parser to where we were at before doing that.
+                let mut step_back_to = self.current;
+
+                let mut local_variables = Vec::new();
                 self.skip_empty_lines();
-                while let Ok(local_variable) = self.parse_variable() {
-                    local_variables.push(local_variable);
+                if self.match_exact(TokenKind::Where).is_some() {
+                    step_back_to = self.current;
                     self.skip_empty_lines();
+                    while let Ok(local_variable) = self.parse_variable() {
+                        local_variables.push(local_variable);
+                        step_back_to = self.current;
+                        self.skip_empty_lines();
+                    }
                 }
-            }
+                self.current = step_back_to;
+                (Some(body), local_variables)
+            };
 
             if decorator::contains_aliases(&self.decorator_stack) {
                 return Err(ParseError {
@@ -3239,7 +3263,7 @@ mod tests {
             assert_eq(tamo + cool == 80)
             30m"), @r###"
         Successfully parsed:
-        DefineVariable { identifier_span: Span { start: SourceCodePositition { byte: 17, line: 2, position: 17 }, end: SourceCodePositition { byte: 21, line: 2, position: 21 }, code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: SourceCodePositition { byte: 24, line: 2, position: 24 }, end: SourceCodePositition { byte: 26, line: 2, position: 26 }, code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] }
+        DefineVariable(DefineVariable { identifier_span: Span { start: SourceCodePositition { byte: 17, line: 2, position: 17 }, end: SourceCodePositition { byte: 21, line: 2, position: 21 }, code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: SourceCodePositition { byte: 24, line: 2, position: 24 }, end: SourceCodePositition { byte: 26, line: 2, position: 26 }, code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] })
         ProcedureCall(Span { start: SourceCodePositition { byte: 68, line: 4, position: 13 }, end: SourceCodePositition { byte: 77, line: 4, position: 22 }, code_source_id: 0 }, AssertEq, [BinaryOperator { op: Equal, lhs: BinaryOperator { op: Add, lhs: Identifier(Span { start: SourceCodePositition { byte: 78, line: 4, position: 23 }, end: SourceCodePositition { byte: 82, line: 4, position: 27 }, code_source_id: 0 }, "tamo"), rhs: Identifier(Span { start: SourceCodePositition { byte: 85, line: 4, position: 30 }, end: SourceCodePositition { byte: 89, line: 4, position: 34 }, code_source_id: 0 }, "cool"), span_op: Some(Span { start: SourceCodePositition { byte: 83, line: 4, position: 28 }, end: SourceCodePositition { byte: 84, line: 4, position: 29 }, code_source_id: 0 }) }, rhs: Scalar(Span { start: SourceCodePositition { byte: 93, line: 4, position: 38 }, end: SourceCodePositition { byte: 95, line: 4, position: 40 }, code_source_id: 0 }, Number(80.0)), span_op: Some(Span { start: SourceCodePositition { byte: 90, line: 4, position: 35 }, end: SourceCodePositition { byte: 92, line: 4, position: 37 }, code_source_id: 0 }) }])
         Expression(BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 109, line: 5, position: 13 }, end: SourceCodePositition { byte: 111, line: 5, position: 15 }, code_source_id: 0 }, Number(30.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 111, line: 5, position: 15 }, end: SourceCodePositition { byte: 112, line: 5, position: 16 }, code_source_id: 0 }, "m"), span_op: None })
         Errors encountered:

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -392,447 +392,473 @@ impl<'a> Parser<'a> {
         }
 
         if self.match_exact(TokenKind::Let).is_some() {
-            if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
-                let identifier_span = self.last().unwrap().span;
+            self.parse_let()
+        } else if self.match_exact(TokenKind::Fn).is_some() {
+            self.parse_function_declaration()
+        } else if self.match_exact(TokenKind::Dimension).is_some() {
+            self.parse_dimension_declaration()
+        } else if self.match_exact(TokenKind::At).is_some() {
+            self.parse_decorators()
+        } else if self.match_exact(TokenKind::Unit).is_some() {
+            self.parse_unit_declaration()
+        } else if self.match_exact(TokenKind::Use).is_some() {
+            self.parse_use()
+        } else if self.match_exact(TokenKind::Struct).is_some() {
+            self.parse_struct()
+        } else if self.match_any(PROCEDURES).is_some() {
+            self.parse_procedure()
+        } else {
+            Ok(Statement::Expression(self.expression()?))
+        }
+    }
 
-                let type_annotation = if self.match_exact(TokenKind::Colon).is_some() {
-                    Some(self.type_annotation()?)
-                } else {
-                    None
-                };
+    fn parse_let(&mut self) -> Result<Statement> {
+        if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
+            let identifier_span = self.last().unwrap().span;
 
-                if self.match_exact(TokenKind::Equal).is_none() {
-                    Err(ParseError {
-                        kind: ParseErrorKind::ExpectedEqualOrColonAfterLetIdentifier,
-                        span: self.peek().span,
-                    })
-                } else {
-                    self.skip_empty_lines();
-                    let expr = self.expression()?;
-
-                    if decorator::contains_aliases_with_prefixes(&self.decorator_stack) {
-                        return Err(ParseError {
-                            kind: ParseErrorKind::DecoratorsWithPrefixOnLetDefinition,
-                            span: self.peek().span,
-                        });
-                    }
-                    let mut decorators = vec![];
-                    std::mem::swap(&mut decorators, &mut self.decorator_stack);
-
-                    Ok(Statement::DefineVariable {
-                        identifier_span,
-                        identifier: identifier.lexeme.clone(),
-                        expr,
-                        type_annotation,
-                        decorators,
-                    })
-                }
+            let type_annotation = if self.match_exact(TokenKind::Colon).is_some() {
+                Some(self.type_annotation()?)
             } else {
+                None
+            };
+
+            if self.match_exact(TokenKind::Equal).is_none() {
                 Err(ParseError {
-                    kind: ParseErrorKind::ExpectedIdentifierAfterLet,
+                    kind: ParseErrorKind::ExpectedEqualOrColonAfterLetIdentifier,
                     span: self.peek().span,
                 })
-            }
-        } else if self.match_exact(TokenKind::Fn).is_some() {
-            if let Some(fn_name) = self.match_exact(TokenKind::Identifier) {
-                let function_name_span = self.last().unwrap().span;
-                let mut type_parameters = vec![];
-                // Parsing the generic parameters if there are any
-                if self.match_exact(TokenKind::LessThan).is_some() {
-                    while self.match_exact(TokenKind::GreaterThan).is_none() {
-                        if let Some(type_parameter_name) = self.match_exact(TokenKind::Identifier) {
-                            let bound = if self.match_exact(TokenKind::Colon).is_some() {
-                                match self.match_exact(TokenKind::Identifier) {
-                                    Some(token) if token.lexeme == "Dim" => {
-                                        Some(TypeParameterBound::Dim)
-                                    }
-                                    Some(token) => {
-                                        return Err(ParseError {
-                                            kind: ParseErrorKind::UnknownBound(
-                                                token.lexeme.clone(),
-                                            ),
-                                            span: token.span,
-                                        });
-                                    }
-                                    None => {
-                                        return Err(ParseError {
-                                            kind: ParseErrorKind::ExpectedBoundInTypeParameterDefinition,
-                                            span: self.peek().span,
-                                        });
-                                    }
-                                }
-                            } else {
-                                None
-                            };
+            } else {
+                self.skip_empty_lines();
+                let expr = self.expression()?;
 
-                            let span = self.last().unwrap().span;
-                            type_parameters.push((
-                                span,
-                                type_parameter_name.lexeme.to_string(),
-                                bound,
-                            ));
-
-                            if self.match_exact(TokenKind::Comma).is_none()
-                                && self.peek().kind != TokenKind::GreaterThan
-                            {
-                                return Err(ParseError {
-                                    kind: ParseErrorKind::ExpectedCommaOrRightAngleBracket,
-                                    span: self.peek().span,
-                                });
-                            }
-                        } else {
-                            return Err(ParseError {
-                                kind: ParseErrorKind::ExpectedTypeParameterName,
-                                span: self.peek().span,
-                            });
-                        }
-                    }
-                }
-
-                if self.match_exact(TokenKind::LeftParen).is_none() {
+                if decorator::contains_aliases_with_prefixes(&self.decorator_stack) {
                     return Err(ParseError {
-                        kind: ParseErrorKind::ExpectedLeftParenInFunctionDefinition,
+                        kind: ParseErrorKind::DecoratorsWithPrefixOnLetDefinition,
                         span: self.peek().span,
                     });
                 }
+                let mut decorators = vec![];
+                std::mem::swap(&mut decorators, &mut self.decorator_stack);
 
-                let mut parameter_span = self.peek().span;
+                Ok(Statement::DefineVariable {
+                    identifier_span,
+                    identifier: identifier.lexeme.clone(),
+                    expr,
+                    type_annotation,
+                    decorators,
+                })
+            }
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedIdentifierAfterLet,
+                span: self.peek().span,
+            })
+        }
+    }
 
-                self.match_exact(TokenKind::Newline);
-                let mut parameters = vec![];
-                while self.match_exact(TokenKind::RightParen).is_none() {
-                    if let Some(param_name) = self.match_exact(TokenKind::Identifier) {
-                        let span = self.last().unwrap().span;
-                        let param_type_dexpr = if self.match_exact(TokenKind::Colon).is_some() {
-                            Some(self.type_annotation()?)
+    fn parse_function_declaration(&mut self) -> Result<Statement> {
+        if let Some(fn_name) = self.match_exact(TokenKind::Identifier) {
+            let function_name_span = self.last().unwrap().span;
+            let mut type_parameters = vec![];
+            // Parsing the generic parameters if there are any
+            if self.match_exact(TokenKind::LessThan).is_some() {
+                while self.match_exact(TokenKind::GreaterThan).is_none() {
+                    if let Some(type_parameter_name) = self.match_exact(TokenKind::Identifier) {
+                        let bound = if self.match_exact(TokenKind::Colon).is_some() {
+                            match self.match_exact(TokenKind::Identifier) {
+                                Some(token) if token.lexeme == "Dim" => {
+                                    Some(TypeParameterBound::Dim)
+                                }
+                                Some(token) => {
+                                    return Err(ParseError {
+                                        kind: ParseErrorKind::UnknownBound(token.lexeme.clone()),
+                                        span: token.span,
+                                    });
+                                }
+                                None => {
+                                    return Err(ParseError {
+                                        kind:
+                                            ParseErrorKind::ExpectedBoundInTypeParameterDefinition,
+                                        span: self.peek().span,
+                                    });
+                                }
+                            }
                         } else {
                             None
                         };
 
-                        parameters.push((span, param_name.lexeme.to_string(), param_type_dexpr));
+                        let span = self.last().unwrap().span;
+                        type_parameters.push((span, type_parameter_name.lexeme.to_string(), bound));
 
-                        parameter_span = parameter_span.extend(&self.last().unwrap().span);
-
-                        self.skip_empty_lines();
-                        let has_comma = self.match_exact(TokenKind::Comma).is_some();
-                        self.skip_empty_lines();
-                        if self.match_exact(TokenKind::RightParen).is_some() {
-                            break;
-                        }
-
-                        if !has_comma && self.peek().kind != TokenKind::RightParen {
+                        if self.match_exact(TokenKind::Comma).is_none()
+                            && self.peek().kind != TokenKind::GreaterThan
+                        {
                             return Err(ParseError {
-                                kind: ParseErrorKind::ExpectedCommaEllipsisOrRightParenInFunctionDefinition,
+                                kind: ParseErrorKind::ExpectedCommaOrRightAngleBracket,
                                 span: self.peek().span,
                             });
                         }
                     } else {
                         return Err(ParseError {
-                            kind: ParseErrorKind::ExpectedParameterNameInFunctionDefinition,
+                            kind: ParseErrorKind::ExpectedTypeParameterName,
                             span: self.peek().span,
                         });
                     }
                 }
-
-                let return_type_annotation = if self.match_exact(TokenKind::Arrow).is_some() {
-                    Some(self.type_annotation()?)
-                } else {
-                    None
-                };
-
-                let body = if self.match_exact(TokenKind::Equal).is_none() {
-                    None
-                } else {
-                    self.skip_empty_lines();
-                    Some(self.expression()?)
-                };
-
-                if decorator::contains_aliases(&self.decorator_stack) {
-                    return Err(ParseError {
-                        kind: ParseErrorKind::AliasUsedOnFunction,
-                        span: self.peek().span,
-                    });
-                }
-
-                let mut decorators = vec![];
-                std::mem::swap(&mut decorators, &mut self.decorator_stack);
-
-                Ok(Statement::DefineFunction {
-                    function_name_span,
-                    function_name: fn_name.lexeme.clone(),
-                    type_parameters,
-                    parameters,
-                    body,
-                    return_type_annotation,
-                    decorators,
-                })
-            } else {
-                Err(ParseError {
-                    kind: ParseErrorKind::ExpectedIdentifierAfterFn,
-                    span: self.peek().span,
-                })
             }
-        } else if self.match_exact(TokenKind::Dimension).is_some() {
-            if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
-                if identifier.lexeme.starts_with("__") {
-                    return Err(ParseError::new(
-                        ParseErrorKind::DoubleUnderscoreTypeNamesReserved,
-                        identifier.span,
-                    ));
-                }
 
-                if self.match_exact(TokenKind::Equal).is_some() {
-                    self.skip_empty_lines();
-                    let mut dexprs = vec![self.dimension_expression()?];
-
-                    while self.match_exact(TokenKind::Equal).is_some() {
-                        self.skip_empty_lines();
-                        dexprs.push(self.dimension_expression()?);
-                    }
-
-                    Ok(Statement::DefineDimension(
-                        identifier.span,
-                        identifier.lexeme.clone(),
-                        dexprs,
-                    ))
-                } else {
-                    Ok(Statement::DefineDimension(
-                        identifier.span,
-                        identifier.lexeme.clone(),
-                        vec![],
-                    ))
-                }
-            } else {
-                Err(ParseError {
-                    kind: ParseErrorKind::ExpectedIdentifierAfterDimension,
-                    span: self.peek().span,
-                })
-            }
-        } else if self.match_exact(TokenKind::At).is_some() {
-            if let Some(decorator) = self.match_exact(TokenKind::Identifier) {
-                let decorator = match decorator.lexeme.as_str() {
-                    "metric_prefixes" => Decorator::MetricPrefixes,
-                    "binary_prefixes" => Decorator::BinaryPrefixes,
-                    "aliases" => {
-                        if self.match_exact(TokenKind::LeftParen).is_some() {
-                            let aliases = self.list_of_aliases()?;
-                            Decorator::Aliases(aliases)
-                        } else {
-                            return Err(ParseError {
-                                kind: ParseErrorKind::ExpectedLeftParenAfterDecorator,
-                                span: self.peek().span,
-                            });
-                        }
-                    }
-                    "url" | "name" | "description" => {
-                        if self.match_exact(TokenKind::LeftParen).is_some() {
-                            if let Some(token) = self.match_exact(TokenKind::StringFixed) {
-                                if self.match_exact(TokenKind::RightParen).is_none() {
-                                    return Err(ParseError::new(
-                                        ParseErrorKind::MissingClosingParen,
-                                        self.peek().span,
-                                    ));
-                                }
-
-                                let content = strip_and_escape(&token.lexeme);
-
-                                match decorator.lexeme.as_str() {
-                                    "url" => Decorator::Url(content),
-                                    "name" => Decorator::Name(content),
-                                    "description" => Decorator::Description(content),
-                                    _ => unreachable!(),
-                                }
-                            } else {
-                                return Err(ParseError {
-                                    kind: ParseErrorKind::ExpectedString,
-                                    span: self.peek().span,
-                                });
-                            }
-                        } else {
-                            return Err(ParseError {
-                                kind: ParseErrorKind::ExpectedLeftParenAfterDecorator,
-                                span: self.peek().span,
-                            });
-                        }
-                    }
-                    _ => {
-                        return Err(ParseError {
-                            kind: ParseErrorKind::UnknownDecorator,
-                            span: decorator.span,
-                        });
-                    }
-                };
-
-                self.decorator_stack.push(decorator); // TODO: make sure that there are no duplicate decorators
-
-                // A decorator is not yet a full statement. Continue parsing:
-                self.skip_empty_lines();
-                self.statement()
-            } else {
-                Err(ParseError {
-                    kind: ParseErrorKind::ExpectedDecoratorName,
-                    span: self.peek().span,
-                })
-            }
-        } else if self.match_exact(TokenKind::Unit).is_some() {
-            if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
-                let identifier_span = self.last().unwrap().span;
-                let (type_annotation_span, dexpr) = if self.match_exact(TokenKind::Colon).is_some()
-                {
-                    let type_annotation = self.dimension_expression()?;
-                    (Some(self.last().unwrap().span), Some(type_annotation))
-                } else {
-                    (None, None)
-                };
-
-                let unit_name = identifier.lexeme.clone();
-
-                let mut decorators = vec![];
-                std::mem::swap(&mut decorators, &mut self.decorator_stack);
-
-                if self.match_exact(TokenKind::Equal).is_some() {
-                    self.skip_empty_lines();
-                    let expr = self.expression()?;
-                    Ok(Statement::DefineDerivedUnit {
-                        identifier_span,
-                        identifier: unit_name,
-                        expr,
-                        type_annotation_span,
-                        type_annotation: dexpr.map(TypeAnnotation::TypeExpression),
-                        decorators,
-                    })
-                } else if dexpr.is_some() {
-                    Ok(Statement::DefineBaseUnit(
-                        identifier_span,
-                        unit_name,
-                        dexpr,
-                        decorators,
-                    ))
-                } else if self.is_end_of_statement() {
-                    Ok(Statement::DefineBaseUnit(
-                        identifier_span,
-                        unit_name,
-                        None,
-                        decorators,
-                    ))
-                } else {
-                    Err(ParseError {
-                        kind: ParseErrorKind::ExpectedColonOrEqualAfterUnitIdentifier,
-                        span: self.peek().span,
-                    })
-                }
-            } else {
-                Err(ParseError {
-                    kind: ParseErrorKind::ExpectedIdentifierAfterUnit,
-                    span: self.peek().span,
-                })
-            }
-        } else if self.match_exact(TokenKind::Use).is_some() {
-            let mut span = self.peek().span;
-
-            if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
-                let mut module_path = vec![identifier.lexeme.clone()];
-
-                while self.match_exact(TokenKind::DoubleColon).is_some() {
-                    if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
-                        module_path.push(identifier.lexeme.clone());
-                    } else {
-                        return Err(ParseError {
-                            kind: ParseErrorKind::ExpectedModuleNameAfterDoubleColon,
-                            span: self.peek().span,
-                        });
-                    }
-                }
-                span = span.extend(&self.last().unwrap().span);
-
-                Ok(Statement::ModuleImport(span, ModulePath(module_path)))
-            } else {
-                Err(ParseError {
-                    kind: ParseErrorKind::ExpectedModulePathAfterUse,
-                    span: self.peek().span,
-                })
-            }
-        } else if self.match_exact(TokenKind::Struct).is_some() {
-            let name = self.identifier()?;
-            let name_span = self.last().unwrap().span;
-
-            if self.match_exact(TokenKind::LeftCurly).is_none() {
+            if self.match_exact(TokenKind::LeftParen).is_none() {
                 return Err(ParseError {
-                    kind: ParseErrorKind::ExpectedLeftCurlyAfterStructName,
+                    kind: ParseErrorKind::ExpectedLeftParenInFunctionDefinition,
                     span: self.peek().span,
                 });
             }
 
-            self.skip_empty_lines();
+            let mut parameter_span = self.peek().span;
 
-            let mut fields = vec![];
-            while self.match_exact(TokenKind::RightCurly).is_none() {
-                self.skip_empty_lines();
+            self.match_exact(TokenKind::Newline);
+            let mut parameters = vec![];
+            while self.match_exact(TokenKind::RightParen).is_none() {
+                if let Some(param_name) = self.match_exact(TokenKind::Identifier) {
+                    let span = self.last().unwrap().span;
+                    let param_type_dexpr = if self.match_exact(TokenKind::Colon).is_some() {
+                        Some(self.type_annotation()?)
+                    } else {
+                        None
+                    };
 
-                let Some(field_name) = self.match_exact(TokenKind::Identifier) else {
+                    parameters.push((span, param_name.lexeme.to_string(), param_type_dexpr));
+
+                    parameter_span = parameter_span.extend(&self.last().unwrap().span);
+
+                    self.skip_empty_lines();
+                    let has_comma = self.match_exact(TokenKind::Comma).is_some();
+                    self.skip_empty_lines();
+                    if self.match_exact(TokenKind::RightParen).is_some() {
+                        break;
+                    }
+
+                    if !has_comma && self.peek().kind != TokenKind::RightParen {
+                        return Err(ParseError {
+                                kind: ParseErrorKind::ExpectedCommaEllipsisOrRightParenInFunctionDefinition,
+                                span: self.peek().span,
+                            });
+                    }
+                } else {
                     return Err(ParseError {
-                        kind: ParseErrorKind::ExpectedFieldNameInStruct,
-                        span: self.peek().span,
-                    });
-                };
-
-                self.skip_empty_lines();
-
-                if self.match_exact(TokenKind::Colon).is_none() {
-                    return Err(ParseError {
-                        kind: ParseErrorKind::ExpectedColonAfterFieldName,
+                        kind: ParseErrorKind::ExpectedParameterNameInFunctionDefinition,
                         span: self.peek().span,
                     });
                 }
-                self.skip_empty_lines();
-
-                let attr_type = self.type_annotation()?;
-
-                self.skip_empty_lines();
-
-                let has_comma = self.match_exact(TokenKind::Comma).is_some();
-
-                self.skip_empty_lines();
-
-                if !has_comma && self.peek().kind != TokenKind::RightCurly {
-                    return Err(ParseError {
-                        kind: ParseErrorKind::ExpectedCommaOrRightCurlyInStructFieldList,
-                        span: self.peek().span,
-                    });
-                }
-
-                fields.push((field_name.span, field_name.lexeme.to_owned(), attr_type));
             }
 
-            Ok(Statement::DefineStruct {
-                struct_name_span: name_span,
-                struct_name: name,
-                fields,
-            })
-        } else if self.match_any(PROCEDURES).is_some() {
-            let span = self.last().unwrap().span;
-            let procedure_kind = match self.last().unwrap().kind {
-                TokenKind::ProcedurePrint => ProcedureKind::Print,
-                TokenKind::ProcedureAssert => ProcedureKind::Assert,
-                TokenKind::ProcedureAssertEq => ProcedureKind::AssertEq,
-                TokenKind::ProcedureType => ProcedureKind::Type,
-                _ => unreachable!(),
+            let return_type_annotation = if self.match_exact(TokenKind::Arrow).is_some() {
+                Some(self.type_annotation()?)
+            } else {
+                None
             };
 
-            if self.match_exact(TokenKind::LeftParen).is_some() {
-                Ok(Statement::ProcedureCall(
-                    span,
-                    procedure_kind,
-                    self.arguments()?,
+            let body = if self.match_exact(TokenKind::Equal).is_none() {
+                None
+            } else {
+                self.skip_empty_lines();
+                Some(self.expression()?)
+            };
+
+            if decorator::contains_aliases(&self.decorator_stack) {
+                return Err(ParseError {
+                    kind: ParseErrorKind::AliasUsedOnFunction,
+                    span: self.peek().span,
+                });
+            }
+
+            let mut decorators = vec![];
+            std::mem::swap(&mut decorators, &mut self.decorator_stack);
+
+            Ok(Statement::DefineFunction {
+                function_name_span,
+                function_name: fn_name.lexeme.clone(),
+                type_parameters,
+                parameters,
+                body,
+                return_type_annotation,
+                decorators,
+            })
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedIdentifierAfterFn,
+                span: self.peek().span,
+            })
+        }
+    }
+
+    fn parse_dimension_declaration(&mut self) -> Result<Statement> {
+        if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
+            if identifier.lexeme.starts_with("__") {
+                return Err(ParseError::new(
+                    ParseErrorKind::DoubleUnderscoreTypeNamesReserved,
+                    identifier.span,
+                ));
+            }
+
+            if self.match_exact(TokenKind::Equal).is_some() {
+                self.skip_empty_lines();
+                let mut dexprs = vec![self.dimension_expression()?];
+
+                while self.match_exact(TokenKind::Equal).is_some() {
+                    self.skip_empty_lines();
+                    dexprs.push(self.dimension_expression()?);
+                }
+
+                Ok(Statement::DefineDimension(
+                    identifier.span,
+                    identifier.lexeme.clone(),
+                    dexprs,
+                ))
+            } else {
+                Ok(Statement::DefineDimension(
+                    identifier.span,
+                    identifier.lexeme.clone(),
+                    vec![],
+                ))
+            }
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedIdentifierAfterDimension,
+                span: self.peek().span,
+            })
+        }
+    }
+
+    fn parse_decorators(&mut self) -> Result<Statement> {
+        if let Some(decorator) = self.match_exact(TokenKind::Identifier) {
+            let decorator = match decorator.lexeme.as_str() {
+                "metric_prefixes" => Decorator::MetricPrefixes,
+                "binary_prefixes" => Decorator::BinaryPrefixes,
+                "aliases" => {
+                    if self.match_exact(TokenKind::LeftParen).is_some() {
+                        let aliases = self.list_of_aliases()?;
+                        Decorator::Aliases(aliases)
+                    } else {
+                        return Err(ParseError {
+                            kind: ParseErrorKind::ExpectedLeftParenAfterDecorator,
+                            span: self.peek().span,
+                        });
+                    }
+                }
+                "url" | "name" | "description" => {
+                    if self.match_exact(TokenKind::LeftParen).is_some() {
+                        if let Some(token) = self.match_exact(TokenKind::StringFixed) {
+                            if self.match_exact(TokenKind::RightParen).is_none() {
+                                return Err(ParseError::new(
+                                    ParseErrorKind::MissingClosingParen,
+                                    self.peek().span,
+                                ));
+                            }
+
+                            let content = strip_and_escape(&token.lexeme);
+
+                            match decorator.lexeme.as_str() {
+                                "url" => Decorator::Url(content),
+                                "name" => Decorator::Name(content),
+                                "description" => Decorator::Description(content),
+                                _ => unreachable!(),
+                            }
+                        } else {
+                            return Err(ParseError {
+                                kind: ParseErrorKind::ExpectedString,
+                                span: self.peek().span,
+                            });
+                        }
+                    } else {
+                        return Err(ParseError {
+                            kind: ParseErrorKind::ExpectedLeftParenAfterDecorator,
+                            span: self.peek().span,
+                        });
+                    }
+                }
+                _ => {
+                    return Err(ParseError {
+                        kind: ParseErrorKind::UnknownDecorator,
+                        span: decorator.span,
+                    });
+                }
+            };
+
+            self.decorator_stack.push(decorator); // TODO: make sure that there are no duplicate decorators
+
+            // A decorator is not yet a full statement. Continue parsing:
+            self.skip_empty_lines();
+            self.statement()
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedDecoratorName,
+                span: self.peek().span,
+            })
+        }
+    }
+
+    fn parse_unit_declaration(&mut self) -> Result<Statement> {
+        if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
+            let identifier_span = self.last().unwrap().span;
+            let (type_annotation_span, dexpr) = if self.match_exact(TokenKind::Colon).is_some() {
+                let type_annotation = self.dimension_expression()?;
+                (Some(self.last().unwrap().span), Some(type_annotation))
+            } else {
+                (None, None)
+            };
+
+            let unit_name = identifier.lexeme.clone();
+
+            let mut decorators = vec![];
+            std::mem::swap(&mut decorators, &mut self.decorator_stack);
+
+            if self.match_exact(TokenKind::Equal).is_some() {
+                self.skip_empty_lines();
+                let expr = self.expression()?;
+                Ok(Statement::DefineDerivedUnit {
+                    identifier_span,
+                    identifier: unit_name,
+                    expr,
+                    type_annotation_span,
+                    type_annotation: dexpr.map(TypeAnnotation::TypeExpression),
+                    decorators,
+                })
+            } else if dexpr.is_some() {
+                Ok(Statement::DefineBaseUnit(
+                    identifier_span,
+                    unit_name,
+                    dexpr,
+                    decorators,
+                ))
+            } else if self.is_end_of_statement() {
+                Ok(Statement::DefineBaseUnit(
+                    identifier_span,
+                    unit_name,
+                    None,
+                    decorators,
                 ))
             } else {
                 Err(ParseError {
-                    kind: ParseErrorKind::ExpectedLeftParenAfterProcedureName,
+                    kind: ParseErrorKind::ExpectedColonOrEqualAfterUnitIdentifier,
                     span: self.peek().span,
                 })
             }
         } else {
-            Ok(Statement::Expression(self.expression()?))
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedIdentifierAfterUnit,
+                span: self.peek().span,
+            })
+        }
+    }
+
+    fn parse_use(&mut self) -> Result<Statement> {
+        let mut span = self.peek().span;
+
+        if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
+            let mut module_path = vec![identifier.lexeme.clone()];
+
+            while self.match_exact(TokenKind::DoubleColon).is_some() {
+                if let Some(identifier) = self.match_exact(TokenKind::Identifier) {
+                    module_path.push(identifier.lexeme.clone());
+                } else {
+                    return Err(ParseError {
+                        kind: ParseErrorKind::ExpectedModuleNameAfterDoubleColon,
+                        span: self.peek().span,
+                    });
+                }
+            }
+            span = span.extend(&self.last().unwrap().span);
+
+            Ok(Statement::ModuleImport(span, ModulePath(module_path)))
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedModulePathAfterUse,
+                span: self.peek().span,
+            })
+        }
+    }
+
+    fn parse_struct(&mut self) -> Result<Statement> {
+        let name = self.identifier()?;
+        let name_span = self.last().unwrap().span;
+
+        if self.match_exact(TokenKind::LeftCurly).is_none() {
+            return Err(ParseError {
+                kind: ParseErrorKind::ExpectedLeftCurlyAfterStructName,
+                span: self.peek().span,
+            });
+        }
+
+        self.skip_empty_lines();
+
+        let mut fields = vec![];
+        while self.match_exact(TokenKind::RightCurly).is_none() {
+            self.skip_empty_lines();
+
+            let Some(field_name) = self.match_exact(TokenKind::Identifier) else {
+                return Err(ParseError {
+                    kind: ParseErrorKind::ExpectedFieldNameInStruct,
+                    span: self.peek().span,
+                });
+            };
+
+            self.skip_empty_lines();
+
+            if self.match_exact(TokenKind::Colon).is_none() {
+                return Err(ParseError {
+                    kind: ParseErrorKind::ExpectedColonAfterFieldName,
+                    span: self.peek().span,
+                });
+            }
+            self.skip_empty_lines();
+
+            let attr_type = self.type_annotation()?;
+
+            self.skip_empty_lines();
+
+            let has_comma = self.match_exact(TokenKind::Comma).is_some();
+
+            self.skip_empty_lines();
+
+            if !has_comma && self.peek().kind != TokenKind::RightCurly {
+                return Err(ParseError {
+                    kind: ParseErrorKind::ExpectedCommaOrRightCurlyInStructFieldList,
+                    span: self.peek().span,
+                });
+            }
+
+            fields.push((field_name.span, field_name.lexeme.to_owned(), attr_type));
+        }
+
+        Ok(Statement::DefineStruct {
+            struct_name_span: name_span,
+            struct_name: name,
+            fields,
+        })
+    }
+
+    fn parse_procedure(&mut self) -> Result<Statement> {
+        let span = self.last().unwrap().span;
+        let procedure_kind = match self.last().unwrap().kind {
+            TokenKind::ProcedurePrint => ProcedureKind::Print,
+            TokenKind::ProcedureAssert => ProcedureKind::Assert,
+            TokenKind::ProcedureAssertEq => ProcedureKind::AssertEq,
+            TokenKind::ProcedureType => ProcedureKind::Type,
+            _ => unreachable!(),
+        };
+
+        if self.match_exact(TokenKind::LeftParen).is_some() {
+            Ok(Statement::ProcedureCall(
+                span,
+                procedure_kind,
+                self.arguments()?,
+            ))
+        } else {
+            Err(ParseError {
+                kind: ParseErrorKind::ExpectedLeftParenAfterProcedureName,
+                span: self.peek().span,
+            })
         }
     }
 

--- a/numbat/src/resolver.rs
+++ b/numbat/src/resolver.rs
@@ -145,7 +145,10 @@ impl Resolver {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ast::Expression, number::Number};
+    use crate::{
+        ast::{DefineVariable, Expression},
+        number::Number,
+    };
 
     use super::*;
 
@@ -189,13 +192,13 @@ mod tests {
         assert_eq!(
             &program_inlined.replace_spans(),
             &[
-                Statement::DefineVariable {
+                Statement::DefineVariable(DefineVariable {
                     identifier_span: Span::dummy(),
                     identifier: "a".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
                     type_annotation: None,
                     decorators: Vec::new(),
-                },
+                }),
                 Statement::Expression(Expression::Identifier(Span::dummy(), "a".into()))
             ]
         );
@@ -219,13 +222,13 @@ mod tests {
         assert_eq!(
             &program_inlined.replace_spans(),
             &[
-                Statement::DefineVariable {
+                Statement::DefineVariable(DefineVariable {
                     identifier_span: Span::dummy(),
                     identifier: "a".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
                     type_annotation: None,
                     decorators: Vec::new(),
-                },
+                }),
                 Statement::Expression(Expression::Identifier(Span::dummy(), "a".into()))
             ]
         );
@@ -248,20 +251,20 @@ mod tests {
         assert_eq!(
             &program_inlined.replace_spans(),
             &[
-                Statement::DefineVariable {
+                Statement::DefineVariable(DefineVariable {
                     identifier_span: Span::dummy(),
                     identifier: "y".into(),
                     expr: Expression::Scalar(Span::dummy(), Number::from_f64(1.0)),
                     type_annotation: None,
                     decorators: Vec::new(),
-                },
-                Statement::DefineVariable {
+                }),
+                Statement::DefineVariable(DefineVariable {
                     identifier_span: Span::dummy(),
                     identifier: "x".into(),
                     expr: Expression::Identifier(Span::dummy(), "y".into()),
                     type_annotation: None,
                     decorators: Vec::new(),
-                },
+                }),
             ]
         );
     }

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -89,6 +89,7 @@ pub enum TokenKind {
     To,
     Let,
     Fn, // 'fn'
+    Where,
     Dimension,
     Unit,
     Use,
@@ -374,6 +375,7 @@ impl Tokenizer {
             m.insert("to", TokenKind::To);
             m.insert("let", TokenKind::Let);
             m.insert("fn", TokenKind::Fn);
+            m.insert("where", TokenKind::Where);
             m.insert("dimension", TokenKind::Dimension);
             m.insert("unit", TokenKind::Unit);
             m.insert("use", TokenKind::Use);

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -90,6 +90,7 @@ pub enum TokenKind {
     Let,
     Fn, // 'fn'
     Where,
+    And,
     Dimension,
     Unit,
     Use,
@@ -376,6 +377,7 @@ impl Tokenizer {
             m.insert("let", TokenKind::Let);
             m.insert("fn", TokenKind::Fn);
             m.insert("where", TokenKind::Where);
+            m.insert("and", TokenKind::And);
             m.insert("dimension", TokenKind::Dimension);
             m.insert("unit", TokenKind::Unit);
             m.insert("use", TokenKind::Use);

--- a/numbat/src/typechecker/substitutions.rs
+++ b/numbat/src/typechecker/substitutions.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::type_variable::TypeVariable;
-use crate::typed_ast::{DType, DTypeFactor, Expression, StructInfo, Type};
+use crate::typed_ast::{DType, DTypeFactor, DefineVariable, Expression, StructInfo, Type};
 use crate::Statement;
 
 #[derive(Debug, Clone)]
@@ -214,11 +214,15 @@ impl ApplySubstitution for Statement {
     fn apply(&mut self, s: &Substitution) -> Result<(), SubstitutionError> {
         match self {
             Statement::Expression(e) => e.apply(s),
-            Statement::DefineVariable(_, _, e, _annotation, type_, _) => {
+            Statement::DefineVariable(DefineVariable(_, _, e, _annotation, type_, _)) => {
                 e.apply(s)?;
                 type_.apply(s)
             }
-            Statement::DefineFunction(_, _, _, _, body, fn_type, _, _) => {
+            Statement::DefineFunction(_, _, _, _, body, local_variables, fn_type, _, _) => {
+                for local_variable in local_variables {
+                    local_variable.2.apply(s)?;
+                    local_variable.4.apply(s)?;
+                }
                 if let Some(body) = body {
                     body.apply(s)?;
                 }

--- a/numbat/src/typechecker/tests/mod.rs
+++ b/numbat/src/typechecker/tests/mod.rs
@@ -68,7 +68,7 @@ fn assert_successful_typecheck(input: &str) {
 fn get_inferred_fn_type(input: &str) -> TypeScheme {
     let statement = run_typecheck(input).expect("Input was expected to type-check");
     match statement {
-        Statement::DefineFunction(_, _, _, _, _, fn_type, _, _) => fn_type,
+        Statement::DefineFunction(_, _, _, _, _, _, fn_type, _, _) => fn_type,
         _ => {
             unreachable!();
         }

--- a/numbat/src/typechecker/tests/type_checking.rs
+++ b/numbat/src/typechecker/tests/type_checking.rs
@@ -194,9 +194,9 @@ fn recursive_functions() {
 fn function_definitions_with_local_variables() {
     assert_successful_typecheck("fn f(x: A) -> C = x * y where y: B = b");
     assert_successful_typecheck(
-        "fn f(x: A) -> C = y * z where
-                                    y = x * 2
-                                    z = b * 2",
+        "fn f(x: A) -> C = y * z
+           where y = x * 2
+             and z = b * 2",
     );
     assert!(matches!(
         get_typecheck_error("fn f(x: A) = y where y = x + b"),

--- a/numbat/src/typechecker/tests/type_checking.rs
+++ b/numbat/src/typechecker/tests/type_checking.rs
@@ -191,6 +191,20 @@ fn recursive_functions() {
 }
 
 #[test]
+fn function_definitions_with_local_variables() {
+    assert_successful_typecheck("fn f(x: A) -> C = x * y where y: B = b");
+    assert_successful_typecheck(
+        "fn f(x: A) -> C = y * z where
+                                    y = x * 2
+                                    z = b * 2",
+    );
+    assert!(matches!(
+        get_typecheck_error("fn f(x: A) = y where y = x + b"),
+        TypeCheckError::IncompatibleDimensions(_)
+    ));
+}
+
+#[test]
 fn generics_basic() {
     assert_successful_typecheck(
         "

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -568,16 +568,19 @@ impl Expression {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct DefineVariable(
+    pub String,
+    pub Vec<Decorator>,
+    pub Expression,
+    pub Option<TypeAnnotation>,
+    pub TypeScheme,
+    pub Markup,
+);
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     Expression(Expression),
-    DefineVariable(
-        String,
-        Vec<Decorator>,
-        Expression,
-        Option<TypeAnnotation>,
-        TypeScheme,
-        Markup,
-    ),
+    DefineVariable(DefineVariable),
     DefineFunction(
         String,
         Vec<Decorator>,                            // decorators
@@ -590,6 +593,7 @@ pub enum Statement {
             Markup,                 // readable parameter type
         )>,
         Option<Expression>,     // function body
+        Vec<DefineVariable>,    // local variables
         TypeScheme,             // function type
         Option<TypeAnnotation>, // return type annotation
         Markup,                 // readable return type
@@ -636,7 +640,14 @@ impl Statement {
     pub(crate) fn update_readable_types(&mut self, registry: &DimensionRegistry) {
         match self {
             Statement::Expression(_) => {}
-            Statement::DefineVariable(_, _, _, type_annotation, type_, readable_type) => {
+            Statement::DefineVariable(DefineVariable(
+                _,
+                _,
+                _,
+                type_annotation,
+                type_,
+                readable_type,
+            )) => {
                 *readable_type = Self::create_readable_type(registry, type_, type_annotation);
             }
             Statement::DefineFunction(
@@ -645,6 +656,7 @@ impl Statement {
                 type_parameters,
                 parameters,
                 _,
+                local_variables,
                 fn_type,
                 return_type_annotation,
                 readable_return_type,
@@ -652,6 +664,12 @@ impl Statement {
                 let (fn_type, _) = fn_type.instantiate_for_printing(Some(
                     type_parameters.iter().map(|(n, _)| n.clone()).collect(),
                 ));
+
+                for DefineVariable(_, _, _, type_annotation, type_, readable_type) in
+                    local_variables
+                {
+                    *readable_type = Self::create_readable_type(registry, type_, type_annotation);
+                }
 
                 let Type::Fn(parameter_types, return_type) = fn_type.inner else {
                     unreachable!("Expected a function type")
@@ -894,14 +912,14 @@ pub fn pretty_print_function_signature(
 impl PrettyPrint for Statement {
     fn pretty_print(&self) -> Markup {
         match self {
-            Statement::DefineVariable(
+            Statement::DefineVariable(DefineVariable(
                 identifier,
                 _decs,
                 expr,
                 _annotation,
                 _type,
                 readable_type,
-            ) => {
+            )) => {
                 m::keyword("let")
                     + m::space()
                     + m::identifier(identifier)
@@ -919,6 +937,7 @@ impl PrettyPrint for Statement {
                 type_parameters,
                 parameters,
                 body,
+                local_variables,
                 fn_type,
                 _return_type_annotation,
                 readable_return_type,
@@ -926,6 +945,31 @@ impl PrettyPrint for Statement {
                 let (fn_type, type_parameters) = fn_type.instantiate_for_printing(Some(
                     type_parameters.iter().map(|(n, _)| n.clone()).collect(),
                 ));
+
+                let mut pretty_local_variables = None;
+                if !local_variables.is_empty() {
+                    let mut plv = m::keyword("where");
+                    for DefineVariable(
+                        identifier,
+                        _decs,
+                        expr,
+                        _annotation,
+                        _type,
+                        readable_type,
+                    ) in local_variables
+                    {
+                        plv += m::space()
+                            + m::identifier(identifier)
+                            + m::operator(":")
+                            + m::space()
+                            + readable_type.clone()
+                            + m::space()
+                            + m::operator("=")
+                            + m::space()
+                            + expr.pretty_print();
+                    }
+                    pretty_local_variables = Some(plv);
+                }
 
                 pretty_print_function_signature(
                     function_name,
@@ -939,6 +983,7 @@ impl PrettyPrint for Statement {
                     .as_ref()
                     .map(|e| m::space() + m::operator("=") + m::space() + e.pretty_print())
                     .unwrap_or_default()
+                    + pretty_local_variables.unwrap_or_default()
             }
             Statement::Expression(expr) => expr.pretty_print(),
             Statement::DefineDimension(identifier, dexprs) if dexprs.is_empty() => {

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -947,8 +947,9 @@ impl PrettyPrint for Statement {
                 ));
 
                 let mut pretty_local_variables = None;
+                let mut first = true;
                 if !local_variables.is_empty() {
-                    let mut plv = m::keyword("where");
+                    let mut plv = m::empty();
                     for DefineVariable(
                         identifier,
                         _decs,
@@ -958,7 +959,16 @@ impl PrettyPrint for Statement {
                         readable_type,
                     ) in local_variables
                     {
-                        plv += m::space()
+                        let introducer_keyword = if first {
+                            first = false;
+                            m::space() + m::space() + m::keyword("where")
+                        } else {
+                            m::space() + m::space() + m::space() + m::space() + m::keyword("and")
+                        };
+
+                        plv += m::nl()
+                            + introducer_keyword
+                            + m::space()
                             + m::identifier(identifier)
                             + m::operator(":")
                             + m::space()

--- a/vscode-extension/syntaxes/numbat.tmLanguage.json
+++ b/vscode-extension/syntaxes/numbat.tmLanguage.json
@@ -32,7 +32,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.numbat",
-                    "match": "\\b(per|to|let|fn|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\\b"
+                    "match": "\\b(per|to|let|fn|where|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\\b"
                 }
             ]
         },

--- a/vscode-extension/syntaxes/numbat.tmLanguage.json
+++ b/vscode-extension/syntaxes/numbat.tmLanguage.json
@@ -32,7 +32,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.numbat",
-                    "match": "\\b(per|to|let|fn|where|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\\b"
+                    "match": "\\b(per|to|let|fn|where|and|dimension|unit|use|struct|long|short|both|none|if|then|else|true|false|print|assert|assert_eq|type)\\b"
                 }
             ]
         },


### PR DESCRIPTION
Fixes https://github.com/sharkdp/numbat/issues/509
Fixes https://github.com/sharkdp/numbat/issues/201

The error reporting of the parser got a little bit worse. We can't detect trailing character at the end of a statement now and the error reported will all be `ExpectedPrimary`.
In order to fix that we would either need some special error handling when the last statement parsed was a function.
Or a different syntax.

Right now that's what I parse:
```ocaml
fn power_4(x: Scalar) = z
  where y = x * x
        z = y * y
```

Maybe we prefer something looking like that;

```ocaml
fn power_4(x: Scalar) = z
  where y = x * x
  where z = y * y
```

The issue with the current implementation is that after parsing a where I must continue to parse as many variable declaration as possible + all whitespace and newlines.