### PR TITLE
Avoid cloning the typechecker in `elaborate_statement`

### DIFF
--- a/numbat/src/name_resolution.rs
+++ b/numbat/src/name_resolution.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use thiserror::Error;
 
-use crate::span::Span;
+use crate::{span::Span, typechecker::map_stack::MapStack};
 
 pub const LAST_RESULT_IDENTIFIERS: &[&str] = &["ans", "_"];
 
@@ -23,10 +21,18 @@ pub enum NameResolutionError {
 
 #[derive(Debug, Clone, Default)]
 pub struct Namespace {
-    seen: HashMap<String, (String, Span)>,
+    seen: MapStack<String, (String, Span)>,
 }
 
 impl Namespace {
+    pub(crate) fn save(&mut self) {
+        self.seen.save()
+    }
+
+    pub(crate) fn restore(&mut self) {
+        self.seen.restore()
+    }
+
     pub fn add_identifier_allow_override(
         &mut self,
         name: String,
@@ -73,7 +79,7 @@ impl Namespace {
             });
         }
 
-        self.seen.insert(name, (item_type, span));
+        let _ = self.seen.insert(name, (item_type, span));
 
         Ok(())
     }

--- a/numbat/src/typechecker/map_stack.rs
+++ b/numbat/src/typechecker/map_stack.rs
@@ -1,0 +1,82 @@
+use std::hash::Hash;
+use std::{borrow::Borrow, collections::HashMap};
+
+/// A stack of hash maps. All insertions affect the hash map at the top of the
+/// stack (which is the last element of the `stack` vector), preserving any
+/// entries in maps below. The `save` function can be used to push a new map on
+/// the top of the stack, in effect saving the current state of the map, which
+/// one can then restore with `restore`.
+///
+/// The stack vector should never be empty
+#[derive(Debug, Clone)]
+pub(crate) struct MapStack<K, V> {
+    stack: Vec<HashMap<K, V>>,
+}
+
+impl<K, V> Default for MapStack<K, V> {
+    fn default() -> Self {
+        MapStack {
+            stack: vec![Default::default()],
+        }
+    }
+}
+
+impl<K: Hash + Eq, V> MapStack<K, V> {
+    fn iter_dict(&self) -> impl Iterator<Item = &HashMap<K, V>> {
+        self.stack.iter().rev()
+    }
+
+    fn iter_dict_mut(&mut self) -> impl Iterator<Item = &mut HashMap<K, V>> {
+        self.stack.iter_mut().rev()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.iter_dict().flatten()
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.iter_dict_mut().flatten()
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &K> {
+        self.iter_dict().map(|dict| dict.keys()).flatten()
+    }
+
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.iter_dict().filter_map(|dict| dict.get(key)).nth(0)
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) {
+        let _ = self.stack.last_mut().unwrap().insert(key, value);
+    }
+
+    pub(crate) fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.iter_dict().any(|dict| dict.contains_key(key))
+    }
+
+    /// Remove the top hash map from the stack, making the next one the
+    /// current top of the stack, restoring the state of the map before the
+    /// last call to save.
+    pub(crate) fn restore(&mut self) {
+        let _ = self.stack.pop();
+        // The stack should never be empty
+        assert!(
+            !self.stack.is_empty(),
+            "Tried to restore the last saved state but nothing was saved"
+        );
+    }
+
+    /// Save the current state of the map by making the top of the stack a
+    /// new empty map.
+    pub(crate) fn save(&mut self) {
+        self.stack.push(HashMap::default());
+    }
+}

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -6,6 +6,7 @@ mod constraints;
 mod environment;
 mod error;
 mod incompatible_dimensions;
+pub mod map_stack;
 mod name_generator;
 pub mod qualified_type;
 mod substitutions;


### PR DESCRIPTION
Running `numbat` with `cargo flamegraph`, I found that a significant portion of the startup time was spent in the `DefineFunction` branch of `elaborate_statement` in the typechecker just cloning `TypeChecker` (line 1313 of `numbat/src/typechecker/mod.rs`). I think this is only due to the need to save and restore the `environment`, `value_namespace` and `type_namespace` members of `TypeChecker` after we have finished checking the function definition to remove any local names before continuing.

To avoid this, I experimented with replacing the `HashMap`s in `Environment` and `NameSpace` with a stack of `HashMap`s (a `MapStack` for lack of a better name) that can be used to save the current state of the map (when we start checking a definition) and restore it (when we are done) but otherwise behaves like a hash map. This seems to give good results to reduce startup time with little impact on the typechecker's code itself. Running `numbat` on the files in the `example/` directory with `hyperfine`, I observe a ~20-25% reduction in time. I've attached the results as Markdown files for `master` and this branch as well as the output of `cargo flamegraph` for master.

[bench-master.md](https://github.com/user-attachments/files/16648567/bench-master.md)
[bench-avoid-cloning-the-typechecker.md](https://github.com/user-attachments/files/16648566/bench-avoid-cloning-the-typechecker.md)

[flamegraph.svg](https://github.com/user-attachments/assets/a3386bda-2804-46ad-96ce-1d6d9ae745f9)

