### PR TITLE
add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ FROM nginx:alpine
 # Copy the built files from the builder stage
 COPY --from=builder /usr/src/numbat/numbat-wasm/www /usr/share/nginx/html
 
-# Expose port 8192
-EXPOSE 8192
+# Expose port 80
+EXPOSE 80
 
 # The default command starts Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use a Rust base image
+FROM rust:1.76.0 as builder
+
+# Install wasm-pack
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Set the working directory
+WORKDIR /usr/src/numbat
+
+# Copy the entire project
+COPY . .
+
+# Build the WebAssembly package
+RUN cd numbat-wasm && wasm-pack build --target web --out-dir www/pkg
+
+# Use a lightweight web server as the final image
+FROM nginx:alpine
+
+# Copy the built files from the builder stage
+COPY --from=builder /usr/src/numbat/numbat-wasm/www /usr/share/nginx/html
+
+# Expose port 8192
+EXPOSE 8192
+
+# The default command starts Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  numbat-web:
+    # Option 1: Build from local codebase
+    build: .
+
+    # Option 2: Build from GitHub repository
+    # build:
+    #   context: https://github.com/sharkdp/numbat.git
+    #   dockerfile: Dockerfile
+    ports:
+      - "8192:8192"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,4 +9,4 @@ services:
     #   context: https://github.com/sharkdp/numbat.git
     #   dockerfile: Dockerfile
     ports:
-      - "8192:8192"
+      - "8192:80"


### PR DESCRIPTION
# Add Docker support for web deployment

This pull request adds Docker support to easily deploy the Numbat web application. It includes a `Dockerfile` for building the application and a `docker-compose.yaml` for orchestrating the deployment.

## Changes

### New file: `Dockerfile`

Added a multi-stage `Dockerfile` that:
1. Builds the WebAssembly package using Rust and wasm-pack.
2. Sets up an Nginx server to host the built files.

### New file: `docker-compose.yaml`

Added a `docker-compose.yaml` file that:
1. Defines the service for the Numbat web application.
2. Provides two options for building:
   a. From the local codebase
   b. Directly from the GitHub repository

## How to use

To deploy the Numbat web application using Docker:

1. Ensure Docker and Docker Compose are installed on your system.
2. Navigate to the project root directory.
3. Run `docker-compose up --build` to build and start the container.
4. Access the application at `http://localhost:8192`.

## Notes

- The `docker-compose.yaml` file includes two build options. Uncomment the preferred option before running.
- The application is exposed on port 8192. Adjust this in the `docker-compose.yaml` file if needed.

## Testing

- [ ] Verify that the Docker build process completes successfully.
- [ ] Confirm that the web application is accessible and functioning correctly when deployed using Docker.
- [ ] Test both build options in the `docker-compose.yaml` file.
