### PR TITLE
Enable tests to run without internet access

### DIFF
--- a/examples/readme-demo.nbt
+++ b/examples/readme-demo.nbt
@@ -1,5 +1,3 @@
-use units::currencies
-
 8 km / (1 h + 25 min)
 140 € -> GBP
 atan2(30 cm, 1 m) -> deg

--- a/numbat/src/currency.rs
+++ b/numbat/src/currency.rs
@@ -1,6 +1,12 @@
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use numbat_exchange_rates::{parse_exchange_rates, ExchangeRates};
+use numbat_exchange_rates::parse_exchange_rates;
+
+#[derive(Debug)]
+pub(crate) enum ExchangeRates {
+    Real(numbat_exchange_rates::ExchangeRates),
+    TestRates,
+}
 
 static EXCHANGE_RATES: OnceLock<Mutex<Option<ExchangeRates>>> = OnceLock::new();
 
@@ -13,19 +19,29 @@ impl ExchangeRatesCache {
 
     pub fn get_rate(&self, currency: &str) -> Option<f64> {
         let rates = Self::fetch();
-        rates.as_ref().and_then(|r| r.get(currency)).cloned()
+        rates
+            .as_ref()
+            .and_then(|er| match er {
+                ExchangeRates::Real(er) => er.get(currency),
+                ExchangeRates::TestRates => Some(&1.0),
+            })
+            .cloned()
     }
 
     pub fn set_from_xml(xml_content: &str) {
         EXCHANGE_RATES
-            .set(Mutex::new(parse_exchange_rates(xml_content)))
+            .set(Mutex::new(
+                parse_exchange_rates(xml_content).map(ExchangeRates::Real),
+            ))
             .unwrap();
     }
 
     #[cfg(feature = "fetch-exchangerates")]
     pub fn fetch() -> MutexGuard<'static, Option<ExchangeRates>> {
         EXCHANGE_RATES
-            .get_or_init(|| Mutex::new(numbat_exchange_rates::fetch_exchange_rates()))
+            .get_or_init(|| {
+                Mutex::new(numbat_exchange_rates::fetch_exchange_rates().map(ExchangeRates::Real))
+            })
             .lock()
             .unwrap()
     }
@@ -33,5 +49,9 @@ impl ExchangeRatesCache {
     #[cfg(not(feature = "fetch-exchangerates"))]
     pub fn fetch() -> MutexGuard<'static, Option<ExchangeRates>> {
         EXCHANGE_RATES.get().unwrap().lock().unwrap()
+    }
+
+    pub fn use_test_rates() {
+        EXCHANGE_RATES.get_or_init(|| Mutex::new(Some(ExchangeRates::TestRates)));
     }
 }

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -136,6 +136,10 @@ impl Context {
         ExchangeRatesCache::set_from_xml(xml_content);
     }
 
+    pub fn use_test_exchange_rates() {
+        ExchangeRatesCache::use_test_rates();
+    }
+
     pub fn variable_names(&self) -> impl Iterator<Item = String> + '_ {
         self.prefix_transformer
             .variable_names

--- a/numbat/tests/common.rs
+++ b/numbat/tests/common.rs
@@ -13,6 +13,7 @@ pub fn get_test_context_without_prelude() -> Context {
     let mut importer = FileSystemImporter::default();
     importer.add_path(module_path);
 
+    Context::use_test_exchange_rates();
     Context::new(importer)
 }
 


### PR DESCRIPTION
Add a way to use dummy 1.0 exchange rates for testing.

closes #560