### PR TITLE
Initial, simple implementation of saving per-session history

### DIFF
--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -404,7 +404,7 @@ impl Cli {
                             }
                             "save" => {
                                 session_history.save(
-                                    "numbat_hist.nbt",
+                                    "history.nbt",
                                     SessionHistoryOptions {
                                         include_err_lines: false,
                                         trim_lines: true,

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -326,9 +326,7 @@ impl Cli {
             }
         }
 
-        let mut session_history = SessionHistory::default();
-
-        let result = self.repl_loop(&mut rl, &mut session_history, interactive);
+        let result = self.repl_loop(&mut rl, interactive);
 
         if interactive {
             rl.save_history(&history_path).context(format!(
@@ -343,9 +341,10 @@ impl Cli {
     fn repl_loop(
         &mut self,
         rl: &mut Editor<NumbatHelper, DefaultHistory>,
-        session_history: &mut SessionHistory,
         interactive: bool,
     ) -> Result<()> {
+        let mut session_history = SessionHistory::default();
+
         loop {
             let readline = rl.readline(&self.config.prompt);
             match readline {

--- a/numbat/src/interpreter/mod.rs
+++ b/numbat/src/interpreter/mod.rs
@@ -60,6 +60,9 @@ pub enum RuntimeError {
 
     #[error("Empty list")]
     EmptyList,
+
+    #[error("Could not write to file: {0:?}")]
+    FileWrite(std::path::PathBuf),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -32,6 +32,7 @@ mod product;
 mod quantity;
 mod registry;
 pub mod resolver;
+pub mod session_history;
 mod span;
 mod suggestion;
 mod tokenizer;

--- a/numbat/src/session_history.rs
+++ b/numbat/src/session_history.rs
@@ -6,25 +6,10 @@ use std::{
 
 use crate::RuntimeError;
 
-#[derive(Debug, Copy, Clone)]
-pub enum InputErrored {
-    Yes,
-    No,
-}
-
-impl<T, E> From<&Result<T, E>> for InputErrored {
-    fn from(value: &Result<T, E>) -> Self {
-        match value {
-            Ok(_) => Self::No,
-            Err(_) => Self::Yes,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct SessionHistoryItem {
     pub input: String,
-    pub errored: InputErrored,
+    pub errored: bool,
 }
 
 #[derive(Default)]
@@ -62,7 +47,7 @@ impl SessionHistory {
 
         let mut f = fs::File::create(dst).map_err(err_fn)?;
         for item in &self.0 {
-            if matches!(item.errored, InputErrored::Yes) && !include_err_lines {
+            if item.errored && !include_err_lines {
                 continue;
             }
 

--- a/numbat/src/session_history.rs
+++ b/numbat/src/session_history.rs
@@ -1,0 +1,79 @@
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+};
+
+use crate::RuntimeError;
+
+#[derive(Debug, Copy, Clone)]
+pub enum InputErrored {
+    Yes,
+    No,
+}
+
+impl<T, E> From<&Result<T, E>> for InputErrored {
+    fn from(value: &Result<T, E>) -> Self {
+        match value {
+            Ok(_) => Self::No,
+            Err(_) => Self::Yes,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SessionHistoryItem {
+    pub input: String,
+    pub errored: InputErrored,
+}
+
+#[derive(Default)]
+pub struct SessionHistory(Vec<SessionHistoryItem>);
+
+impl SessionHistory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SessionHistoryOptions {
+    pub include_err_lines: bool,
+    pub trim_lines: bool,
+}
+
+impl SessionHistory {
+    pub fn push(&mut self, item: SessionHistoryItem) {
+        self.0.push(item);
+    }
+
+    pub fn save(
+        &self,
+        dst: impl AsRef<Path>,
+        options: SessionHistoryOptions,
+    ) -> Result<(), RuntimeError> {
+        let SessionHistoryOptions {
+            include_err_lines,
+            trim_lines,
+        } = options;
+
+        let dst = dst.as_ref();
+        let err_fn = |_: io::Error| RuntimeError::FileWrite(dst.to_owned());
+
+        let mut f = fs::File::create(dst).map_err(err_fn)?;
+        for item in &self.0 {
+            if matches!(item.errored, InputErrored::Yes) && !include_err_lines {
+                continue;
+            }
+
+            let input = if trim_lines {
+                item.input.trim()
+            } else {
+                &item.input
+            };
+
+            writeln!(f, "{}", input).map_err(err_fn)?
+        }
+        Ok(())
+    }
+}

--- a/numbat/src/session_history.rs
+++ b/numbat/src/session_history.rs
@@ -52,7 +52,7 @@ impl SessionHistory {
                 &item.input
             };
 
-            writeln!(w, "{}", input).map_err(&err_fn)?
+            writeln!(w, "{input}").map_err(&err_fn)?
         }
         Ok(())
     }


### PR DESCRIPTION
This is branched from `master`, not from `commands`, so as to let it evolve in parallel and get feedback on design independently of `commands`. Once merged into `master`, I'll pull `master` into `commands` and update per-session history saving to work with the `Command` framework.