### PR TITLE
Shrink span

### DIFF
--- a/numbat/src/command.rs
+++ b/numbat/src/command.rs
@@ -2,7 +2,7 @@ use std::str::{FromStr, SplitWhitespace};
 
 use crate::{
     parser::ParseErrorKind,
-    span::{SourceCodePositition, Span},
+    span::{ByteIndex, Span},
     ParseError,
 };
 
@@ -152,16 +152,8 @@ impl<'a> CommandParser<'a> {
     /// The only role of `&self` here is to provide the `code_source_id`
     fn span_from_boundary(&self, (start, end): (u32, u32)) -> Span {
         Span {
-            start: SourceCodePositition {
-                byte: start,
-                line: 1,
-                position: start,
-            },
-            end: SourceCodePositition {
-                byte: end,
-                line: 1,
-                position: end,
-            },
+            start: ByteIndex(start),
+            end: ByteIndex(end),
             code_source_id: self.code_source_id,
         }
     }

--- a/numbat/src/ffi/lookup.rs
+++ b/numbat/src/ffi/lookup.rs
@@ -21,8 +21,8 @@ pub fn _get_chemical_element_data_raw(mut args: Args) -> Result<Value> {
         .find(|e| e.name().to_lowercase() == pattern || e.symbol().to_lowercase() == pattern)
     {
         let unknown_span = Span {
-            start: ByteIndex::start(),
-            end: ByteIndex::start(),
+            start: ByteIndex(0),
+            end: ByteIndex(0),
             code_source_id: 0,
         };
 

--- a/numbat/src/ffi/lookup.rs
+++ b/numbat/src/ffi/lookup.rs
@@ -7,7 +7,7 @@ use crate::value::Value;
 use crate::RuntimeError;
 
 pub fn _get_chemical_element_data_raw(mut args: Args) -> Result<Value> {
-    use crate::span::{SourceCodePositition, Span};
+    use crate::span::{ByteIndex, Span};
     use crate::typed_ast::StructInfo;
     use crate::typed_ast::Type;
     use indexmap::IndexMap;
@@ -21,8 +21,8 @@ pub fn _get_chemical_element_data_raw(mut args: Args) -> Result<Value> {
         .find(|e| e.name().to_lowercase() == pattern || e.symbol().to_lowercase() == pattern)
     {
         let unknown_span = Span {
-            start: SourceCodePositition::start(),
-            end: SourceCodePositition::start(),
+            start: ByteIndex::start(),
+            end: ByteIndex::start(),
             code_source_id: 0,
         };
 

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2900,7 +2900,7 @@ mod tests {
               2 m,
               5 m
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 56, line: 4, position: 14 }, code_source_id: 0 }, Identifier(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, "tamo"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 20, line: 2, position: 15 }, end: SourceCodePositition { byte: 21, line: 2, position: 16 }, code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 22, line: 2, position: 17 }, end: SourceCodePositition { byte: 23, line: 2, position: 18 }, code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 39, line: 3, position: 15 }, end: SourceCodePositition { byte: 40, line: 3, position: 16 }, code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 41, line: 3, position: 17 }, end: SourceCodePositition { byte: 42, line: 3, position: 18 }, code_source_id: 0 }, "m"), span_op: None }]))
+        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(56), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, "tamo"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(20), end: SourceCodePositition(21), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(22), end: SourceCodePositition(23), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(39), end: SourceCodePositition(40), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(41), end: SourceCodePositition(42), code_source_id: 0 }, "m"), span_op: None }]))
         "###);
 
         assert_snapshot!(snap_parse(
@@ -2908,12 +2908,12 @@ mod tests {
               2 m,
               5 m,
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 58, line: 4, position: 14 }, code_source_id: 0 }, Identifier(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, "kefir"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 21, line: 2, position: 15 }, end: SourceCodePositition { byte: 22, line: 2, position: 16 }, code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 23, line: 2, position: 17 }, end: SourceCodePositition { byte: 24, line: 2, position: 18 }, code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 40, line: 3, position: 15 }, end: SourceCodePositition { byte: 41, line: 3, position: 16 }, code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 42, line: 3, position: 17 }, end: SourceCodePositition { byte: 43, line: 3, position: 18 }, code_source_id: 0 }, "m"), span_op: None }]))
+        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(58), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, "kefir"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }]))
         "###);
         assert_snapshot!(snap_parse(
             "echo(
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 19, line: 2, position: 14 }, code_source_id: 0 }, Identifier(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, "echo"), []))
+        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(19), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, "echo"), []))
         "###);
         assert_snapshot!(snap_parse(
             "jax(
@@ -2922,7 +2922,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition { byte: 55, line: 4, position: 13 }, end: SourceCodePositition { byte: 55, line: 4, position: 13 }, code_source_id: 0 } }
+        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition(55), end: SourceCodePositition(55), code_source_id: 0 } }
         "###);
     }
 
@@ -3024,7 +3024,7 @@ mod tests {
               2 m,
               5 m
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 21, line: 2, position: 15 }, end: SourceCodePositition { byte: 22, line: 2, position: 16 }, code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 23, line: 2, position: 17 }, end: SourceCodePositition { byte: 24, line: 2, position: 18 }, code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 40, line: 3, position: 15 }, end: SourceCodePositition { byte: 41, line: 3, position: 16 }, code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 42, line: 3, position: 17 }, end: SourceCodePositition { byte: 43, line: 3, position: 18 }, code_source_id: 0 }, "m"), span_op: None }])
+        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }])
         "###);
 
         assert_snapshot!(snap_parse(
@@ -3032,12 +3032,12 @@ mod tests {
               2 m,
               5 m,
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 21, line: 2, position: 15 }, end: SourceCodePositition { byte: 22, line: 2, position: 16 }, code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 23, line: 2, position: 17 }, end: SourceCodePositition { byte: 24, line: 2, position: 18 }, code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 40, line: 3, position: 15 }, end: SourceCodePositition { byte: 41, line: 3, position: 16 }, code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 42, line: 3, position: 17 }, end: SourceCodePositition { byte: 43, line: 3, position: 18 }, code_source_id: 0 }, "m"), span_op: None }])
+        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }])
         "###);
         assert_snapshot!(snap_parse(
             "print(
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, Print, [])
+        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [])
         "###);
         println!("HEEEERE");
         assert_snapshot!(snap_parse(
@@ -3047,7 +3047,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition { byte: 57, line: 4, position: 13 }, end: SourceCodePositition { byte: 57, line: 4, position: 13 }, code_source_id: 0 } }
+        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition(57), end: SourceCodePositition(57), code_source_id: 0 } }
         "###);
     }
 
@@ -3056,15 +3056,15 @@ mod tests {
         // basic
         assert_snapshot!(snap_parse(
             "true || false"), @r###"
-        Expression(BinaryOperator { op: LogicalOr, lhs: Boolean(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition { byte: 8, line: 1, position: 9 }, end: SourceCodePositition { byte: 13, line: 1, position: 14 }, code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition { byte: 5, line: 1, position: 6 }, end: SourceCodePositition { byte: 7, line: 1, position: 8 }, code_source_id: 0 }) })
+        Expression(BinaryOperator { op: LogicalOr, lhs: Boolean(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition(8), end: SourceCodePositition(13), code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition(5), end: SourceCodePositition(7), code_source_id: 0 }) })
         "###);
         assert_snapshot!(snap_parse(
             "true && false"), @r###"
-        Expression(BinaryOperator { op: LogicalAnd, lhs: Boolean(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 4, line: 1, position: 5 }, code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition { byte: 8, line: 1, position: 9 }, end: SourceCodePositition { byte: 13, line: 1, position: 14 }, code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition { byte: 5, line: 1, position: 6 }, end: SourceCodePositition { byte: 7, line: 1, position: 8 }, code_source_id: 0 }) })
+        Expression(BinaryOperator { op: LogicalAnd, lhs: Boolean(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition(8), end: SourceCodePositition(13), code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition(5), end: SourceCodePositition(7), code_source_id: 0 }) })
         "###);
         assert_snapshot!(snap_parse(
             "!true"), @r###"
-        Expression(UnaryOperator { op: LogicalNeg, expr: Boolean(Span { start: SourceCodePositition { byte: 1, line: 1, position: 2 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 }, true), span_op: Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 1, line: 1, position: 2 }, code_source_id: 0 } })
+        Expression(UnaryOperator { op: LogicalNeg, expr: Boolean(Span { start: SourceCodePositition(1), end: SourceCodePositition(5), code_source_id: 0 }, true), span_op: Span { start: SourceCodePositition(0), end: SourceCodePositition(1), code_source_id: 0 } })
         "###);
 
         // priority
@@ -3397,9 +3397,9 @@ mod tests {
             "1 +\x20
             2 + 3"), @r###"
         Successfully parsed:
-        Expression(BinaryOperator { op: Add, lhs: Scalar(Span { start: SourceCodePositition { byte: 17, line: 2, position: 13 }, end: SourceCodePositition { byte: 18, line: 2, position: 14 }, code_source_id: 0 }, Number(2.0)), rhs: Scalar(Span { start: SourceCodePositition { byte: 21, line: 2, position: 17 }, end: SourceCodePositition { byte: 22, line: 2, position: 18 }, code_source_id: 0 }, Number(3.0)), span_op: Some(Span { start: SourceCodePositition { byte: 19, line: 2, position: 15 }, end: SourceCodePositition { byte: 20, line: 2, position: 16 }, code_source_id: 0 }) })
+        Expression(BinaryOperator { op: Add, lhs: Scalar(Span { start: SourceCodePositition(17), end: SourceCodePositition(18), code_source_id: 0 }, Number(2.0)), rhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(3.0)), span_op: Some(Span { start: SourceCodePositition(19), end: SourceCodePositition(20), code_source_id: 0 }) })
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition { byte: 4, line: 1, position: 5 }, end: SourceCodePositition { byte: 5, line: 1, position: 6 }, code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(4), end: SourceCodePositition(5), code_source_id: 0 } }
         "###);
         // error in the middle of something
         assert_snapshot!(snap_parse(
@@ -3409,11 +3409,11 @@ mod tests {
             assert_eq(tamo + cool == 80)
             30m"), @r###"
         Successfully parsed:
-        DefineVariable(DefineVariable { identifier_span: Span { start: SourceCodePositition { byte: 17, line: 2, position: 17 }, end: SourceCodePositition { byte: 21, line: 2, position: 21 }, code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: SourceCodePositition { byte: 24, line: 2, position: 24 }, end: SourceCodePositition { byte: 26, line: 2, position: 26 }, code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] })
-        ProcedureCall(Span { start: SourceCodePositition { byte: 68, line: 4, position: 13 }, end: SourceCodePositition { byte: 77, line: 4, position: 22 }, code_source_id: 0 }, AssertEq, [BinaryOperator { op: Equal, lhs: BinaryOperator { op: Add, lhs: Identifier(Span { start: SourceCodePositition { byte: 78, line: 4, position: 23 }, end: SourceCodePositition { byte: 82, line: 4, position: 27 }, code_source_id: 0 }, "tamo"), rhs: Identifier(Span { start: SourceCodePositition { byte: 85, line: 4, position: 30 }, end: SourceCodePositition { byte: 89, line: 4, position: 34 }, code_source_id: 0 }, "cool"), span_op: Some(Span { start: SourceCodePositition { byte: 83, line: 4, position: 28 }, end: SourceCodePositition { byte: 84, line: 4, position: 29 }, code_source_id: 0 }) }, rhs: Scalar(Span { start: SourceCodePositition { byte: 93, line: 4, position: 38 }, end: SourceCodePositition { byte: 95, line: 4, position: 40 }, code_source_id: 0 }, Number(80.0)), span_op: Some(Span { start: SourceCodePositition { byte: 90, line: 4, position: 35 }, end: SourceCodePositition { byte: 92, line: 4, position: 37 }, code_source_id: 0 }) }])
-        Expression(BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition { byte: 109, line: 5, position: 13 }, end: SourceCodePositition { byte: 111, line: 5, position: 15 }, code_source_id: 0 }, Number(30.0)), rhs: Identifier(Span { start: SourceCodePositition { byte: 111, line: 5, position: 15 }, end: SourceCodePositition { byte: 112, line: 5, position: 16 }, code_source_id: 0 }, "m"), span_op: None })
+        DefineVariable(DefineVariable { identifier_span: Span { start: SourceCodePositition(17), end: SourceCodePositition(21), code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: SourceCodePositition(24), end: SourceCodePositition(26), code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] })
+        ProcedureCall(Span { start: SourceCodePositition(68), end: SourceCodePositition(77), code_source_id: 0 }, AssertEq, [BinaryOperator { op: Equal, lhs: BinaryOperator { op: Add, lhs: Identifier(Span { start: SourceCodePositition(78), end: SourceCodePositition(82), code_source_id: 0 }, "tamo"), rhs: Identifier(Span { start: SourceCodePositition(85), end: SourceCodePositition(89), code_source_id: 0 }, "cool"), span_op: Some(Span { start: SourceCodePositition(83), end: SourceCodePositition(84), code_source_id: 0 }) }, rhs: Scalar(Span { start: SourceCodePositition(93), end: SourceCodePositition(95), code_source_id: 0 }, Number(80.0)), span_op: Some(Span { start: SourceCodePositition(90), end: SourceCodePositition(92), code_source_id: 0 }) }])
+        Expression(BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(109), end: SourceCodePositition(111), code_source_id: 0 }, Number(30.0)), rhs: Identifier(Span { start: SourceCodePositition(111), end: SourceCodePositition(112), code_source_id: 0 }, "m"), span_op: None })
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition { byte: 50, line: 3, position: 24 }, end: SourceCodePositition { byte: 51, line: 3, position: 25 }, code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(50), end: SourceCodePositition(51), code_source_id: 0 } }
         "###);
         // error on a multiline let
         assert_snapshot!(snap_parse(
@@ -3423,7 +3423,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition { byte: 40, line: 3, position: 17 }, end: SourceCodePositition { byte: 41, line: 3, position: 18 }, code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 } }
         "###);
         // error on a multiline if
         assert_snapshot!(snap_parse(
@@ -3434,18 +3434,18 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Expected 'then' in if-then-else condition - ParseError { kind: ExpectedThen, span: Span { start: SourceCodePositition { byte: 18, line: 2, position: 18 }, end: SourceCodePositition { byte: 19, line: 2, position: 19 }, code_source_id: 0 } }
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition { byte: 36, line: 3, position: 17 }, end: SourceCodePositition { byte: 40, line: 3, position: 21 }, code_source_id: 0 } }
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition { byte: 63, line: 4, position: 17 }, end: SourceCodePositition { byte: 67, line: 4, position: 21 }, code_source_id: 0 } }
+        Expected 'then' in if-then-else condition - ParseError { kind: ExpectedThen, span: Span { start: SourceCodePositition(18), end: SourceCodePositition(19), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(36), end: SourceCodePositition(40), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(63), end: SourceCodePositition(67), code_source_id: 0 } }
         "###);
 
         // #260
         assert_snapshot!(snap_parse(
             "x = 3"), @r###"
         Successfully parsed:
-        Expression(Identifier(Span { start: SourceCodePositition { byte: 0, line: 1, position: 1 }, end: SourceCodePositition { byte: 1, line: 1, position: 2 }, code_source_id: 0 }, "x"))
+        Expression(Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(1), code_source_id: 0 }, "x"))
         Errors encountered:
-        Trailing '=' sign. Use `let x = …` if you intended to define a new constant. - ParseError { kind: TrailingEqualSign("x"), span: Span { start: SourceCodePositition { byte: 2, line: 1, position: 3 }, end: SourceCodePositition { byte: 3, line: 1, position: 4 }, code_source_id: 0 } }
+        Trailing '=' sign. Use `let x = …` if you intended to define a new constant. - ParseError { kind: TrailingEqualSign("x"), span: Span { start: SourceCodePositition(2), end: SourceCodePositition(3), code_source_id: 0 } }
         "###);
     }
 }

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2900,7 +2900,7 @@ mod tests {
               2 m,
               5 m
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(56), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, "tamo"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(20), end: SourceCodePositition(21), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(22), end: SourceCodePositition(23), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(39), end: SourceCodePositition(40), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(41), end: SourceCodePositition(42), code_source_id: 0 }, "m"), span_op: None }]))
+        Expression(FunctionCall(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, Span { start: ByteIndex(0), end: ByteIndex(56), code_source_id: 0 }, Identifier(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, "tamo"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(20), end: ByteIndex(21), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: ByteIndex(22), end: ByteIndex(23), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(39), end: ByteIndex(40), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: ByteIndex(41), end: ByteIndex(42), code_source_id: 0 }, "m"), span_op: None }]))
         "###);
 
         assert_snapshot!(snap_parse(
@@ -2908,12 +2908,12 @@ mod tests {
               2 m,
               5 m,
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(58), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, "kefir"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }]))
+        Expression(FunctionCall(Span { start: ByteIndex(0), end: ByteIndex(5), code_source_id: 0 }, Span { start: ByteIndex(0), end: ByteIndex(58), code_source_id: 0 }, Identifier(Span { start: ByteIndex(0), end: ByteIndex(5), code_source_id: 0 }, "kefir"), [BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(21), end: ByteIndex(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: ByteIndex(23), end: ByteIndex(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(40), end: ByteIndex(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: ByteIndex(42), end: ByteIndex(43), code_source_id: 0 }, "m"), span_op: None }]))
         "###);
         assert_snapshot!(snap_parse(
             "echo(
             )"), @r###"
-        Expression(FunctionCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, Span { start: SourceCodePositition(0), end: SourceCodePositition(19), code_source_id: 0 }, Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, "echo"), []))
+        Expression(FunctionCall(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, Span { start: ByteIndex(0), end: ByteIndex(19), code_source_id: 0 }, Identifier(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, "echo"), []))
         "###);
         assert_snapshot!(snap_parse(
             "jax(
@@ -2922,7 +2922,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition(55), end: SourceCodePositition(55), code_source_id: 0 } }
+        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: ByteIndex(55), end: ByteIndex(55), code_source_id: 0 } }
         "###);
     }
 
@@ -3024,7 +3024,7 @@ mod tests {
               2 m,
               5 m
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }])
+        ProcedureCall(Span { start: ByteIndex(0), end: ByteIndex(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(21), end: ByteIndex(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: ByteIndex(23), end: ByteIndex(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(40), end: ByteIndex(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: ByteIndex(42), end: ByteIndex(43), code_source_id: 0 }, "m"), span_op: None }])
         "###);
 
         assert_snapshot!(snap_parse(
@@ -3032,12 +3032,12 @@ mod tests {
               2 m,
               5 m,
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: SourceCodePositition(23), end: SourceCodePositition(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: SourceCodePositition(42), end: SourceCodePositition(43), code_source_id: 0 }, "m"), span_op: None }])
+        ProcedureCall(Span { start: ByteIndex(0), end: ByteIndex(5), code_source_id: 0 }, Print, [BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(21), end: ByteIndex(22), code_source_id: 0 }, Number(2.0)), rhs: Identifier(Span { start: ByteIndex(23), end: ByteIndex(24), code_source_id: 0 }, "m"), span_op: None }, BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(40), end: ByteIndex(41), code_source_id: 0 }, Number(5.0)), rhs: Identifier(Span { start: ByteIndex(42), end: ByteIndex(43), code_source_id: 0 }, "m"), span_op: None }])
         "###);
         assert_snapshot!(snap_parse(
             "print(
             )"), @r###"
-        ProcedureCall(Span { start: SourceCodePositition(0), end: SourceCodePositition(5), code_source_id: 0 }, Print, [])
+        ProcedureCall(Span { start: ByteIndex(0), end: ByteIndex(5), code_source_id: 0 }, Print, [])
         "###);
         println!("HEEEERE");
         assert_snapshot!(snap_parse(
@@ -3047,7 +3047,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: SourceCodePositition(57), end: SourceCodePositition(57), code_source_id: 0 } }
+        Missing closing parenthesis ')' - ParseError { kind: MissingClosingParen, span: Span { start: ByteIndex(57), end: ByteIndex(57), code_source_id: 0 } }
         "###);
     }
 
@@ -3056,15 +3056,15 @@ mod tests {
         // basic
         assert_snapshot!(snap_parse(
             "true || false"), @r###"
-        Expression(BinaryOperator { op: LogicalOr, lhs: Boolean(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition(8), end: SourceCodePositition(13), code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition(5), end: SourceCodePositition(7), code_source_id: 0 }) })
+        Expression(BinaryOperator { op: LogicalOr, lhs: Boolean(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: ByteIndex(8), end: ByteIndex(13), code_source_id: 0 }, false), span_op: Some(Span { start: ByteIndex(5), end: ByteIndex(7), code_source_id: 0 }) })
         "###);
         assert_snapshot!(snap_parse(
             "true && false"), @r###"
-        Expression(BinaryOperator { op: LogicalAnd, lhs: Boolean(Span { start: SourceCodePositition(0), end: SourceCodePositition(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: SourceCodePositition(8), end: SourceCodePositition(13), code_source_id: 0 }, false), span_op: Some(Span { start: SourceCodePositition(5), end: SourceCodePositition(7), code_source_id: 0 }) })
+        Expression(BinaryOperator { op: LogicalAnd, lhs: Boolean(Span { start: ByteIndex(0), end: ByteIndex(4), code_source_id: 0 }, true), rhs: Boolean(Span { start: ByteIndex(8), end: ByteIndex(13), code_source_id: 0 }, false), span_op: Some(Span { start: ByteIndex(5), end: ByteIndex(7), code_source_id: 0 }) })
         "###);
         assert_snapshot!(snap_parse(
             "!true"), @r###"
-        Expression(UnaryOperator { op: LogicalNeg, expr: Boolean(Span { start: SourceCodePositition(1), end: SourceCodePositition(5), code_source_id: 0 }, true), span_op: Span { start: SourceCodePositition(0), end: SourceCodePositition(1), code_source_id: 0 } })
+        Expression(UnaryOperator { op: LogicalNeg, expr: Boolean(Span { start: ByteIndex(1), end: ByteIndex(5), code_source_id: 0 }, true), span_op: Span { start: ByteIndex(0), end: ByteIndex(1), code_source_id: 0 } })
         "###);
 
         // priority
@@ -3397,9 +3397,9 @@ mod tests {
             "1 +\x20
             2 + 3"), @r###"
         Successfully parsed:
-        Expression(BinaryOperator { op: Add, lhs: Scalar(Span { start: SourceCodePositition(17), end: SourceCodePositition(18), code_source_id: 0 }, Number(2.0)), rhs: Scalar(Span { start: SourceCodePositition(21), end: SourceCodePositition(22), code_source_id: 0 }, Number(3.0)), span_op: Some(Span { start: SourceCodePositition(19), end: SourceCodePositition(20), code_source_id: 0 }) })
+        Expression(BinaryOperator { op: Add, lhs: Scalar(Span { start: ByteIndex(17), end: ByteIndex(18), code_source_id: 0 }, Number(2.0)), rhs: Scalar(Span { start: ByteIndex(21), end: ByteIndex(22), code_source_id: 0 }, Number(3.0)), span_op: Some(Span { start: ByteIndex(19), end: ByteIndex(20), code_source_id: 0 }) })
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(4), end: SourceCodePositition(5), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: ByteIndex(4), end: ByteIndex(5), code_source_id: 0 } }
         "###);
         // error in the middle of something
         assert_snapshot!(snap_parse(
@@ -3409,11 +3409,11 @@ mod tests {
             assert_eq(tamo + cool == 80)
             30m"), @r###"
         Successfully parsed:
-        DefineVariable(DefineVariable { identifier_span: Span { start: SourceCodePositition(17), end: SourceCodePositition(21), code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: SourceCodePositition(24), end: SourceCodePositition(26), code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] })
-        ProcedureCall(Span { start: SourceCodePositition(68), end: SourceCodePositition(77), code_source_id: 0 }, AssertEq, [BinaryOperator { op: Equal, lhs: BinaryOperator { op: Add, lhs: Identifier(Span { start: SourceCodePositition(78), end: SourceCodePositition(82), code_source_id: 0 }, "tamo"), rhs: Identifier(Span { start: SourceCodePositition(85), end: SourceCodePositition(89), code_source_id: 0 }, "cool"), span_op: Some(Span { start: SourceCodePositition(83), end: SourceCodePositition(84), code_source_id: 0 }) }, rhs: Scalar(Span { start: SourceCodePositition(93), end: SourceCodePositition(95), code_source_id: 0 }, Number(80.0)), span_op: Some(Span { start: SourceCodePositition(90), end: SourceCodePositition(92), code_source_id: 0 }) }])
-        Expression(BinaryOperator { op: Mul, lhs: Scalar(Span { start: SourceCodePositition(109), end: SourceCodePositition(111), code_source_id: 0 }, Number(30.0)), rhs: Identifier(Span { start: SourceCodePositition(111), end: SourceCodePositition(112), code_source_id: 0 }, "m"), span_op: None })
+        DefineVariable(DefineVariable { identifier_span: Span { start: ByteIndex(17), end: ByteIndex(21), code_source_id: 0 }, identifier: "cool", expr: Scalar(Span { start: ByteIndex(24), end: ByteIndex(26), code_source_id: 0 }, Number(50.0)), type_annotation: None, decorators: [] })
+        ProcedureCall(Span { start: ByteIndex(68), end: ByteIndex(77), code_source_id: 0 }, AssertEq, [BinaryOperator { op: Equal, lhs: BinaryOperator { op: Add, lhs: Identifier(Span { start: ByteIndex(78), end: ByteIndex(82), code_source_id: 0 }, "tamo"), rhs: Identifier(Span { start: ByteIndex(85), end: ByteIndex(89), code_source_id: 0 }, "cool"), span_op: Some(Span { start: ByteIndex(83), end: ByteIndex(84), code_source_id: 0 }) }, rhs: Scalar(Span { start: ByteIndex(93), end: ByteIndex(95), code_source_id: 0 }, Number(80.0)), span_op: Some(Span { start: ByteIndex(90), end: ByteIndex(92), code_source_id: 0 }) }])
+        Expression(BinaryOperator { op: Mul, lhs: Scalar(Span { start: ByteIndex(109), end: ByteIndex(111), code_source_id: 0 }, Number(30.0)), rhs: Identifier(Span { start: ByteIndex(111), end: ByteIndex(112), code_source_id: 0 }, "m"), span_op: None })
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(50), end: SourceCodePositition(51), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: ByteIndex(50), end: ByteIndex(51), code_source_id: 0 } }
         "###);
         // error on a multiline let
         assert_snapshot!(snap_parse(
@@ -3423,7 +3423,7 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(40), end: SourceCodePositition(41), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: ByteIndex(40), end: ByteIndex(41), code_source_id: 0 } }
         "###);
         // error on a multiline if
         assert_snapshot!(snap_parse(
@@ -3434,18 +3434,18 @@ mod tests {
             "), @r###"
         Successfully parsed:
         Errors encountered:
-        Expected 'then' in if-then-else condition - ParseError { kind: ExpectedThen, span: Span { start: SourceCodePositition(18), end: SourceCodePositition(19), code_source_id: 0 } }
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(36), end: SourceCodePositition(40), code_source_id: 0 } }
-        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: SourceCodePositition(63), end: SourceCodePositition(67), code_source_id: 0 } }
+        Expected 'then' in if-then-else condition - ParseError { kind: ExpectedThen, span: Span { start: ByteIndex(18), end: ByteIndex(19), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: ByteIndex(36), end: ByteIndex(40), code_source_id: 0 } }
+        Expected one of: number, identifier, parenthesized expression, struct instantiation, list - ParseError { kind: ExpectedPrimary, span: Span { start: ByteIndex(63), end: ByteIndex(67), code_source_id: 0 } }
         "###);
 
         // #260
         assert_snapshot!(snap_parse(
             "x = 3"), @r###"
         Successfully parsed:
-        Expression(Identifier(Span { start: SourceCodePositition(0), end: SourceCodePositition(1), code_source_id: 0 }, "x"))
+        Expression(Identifier(Span { start: ByteIndex(0), end: ByteIndex(1), code_source_id: 0 }, "x"))
         Errors encountered:
-        Trailing '=' sign. Use `let x = …` if you intended to define a new constant. - ParseError { kind: TrailingEqualSign("x"), span: Span { start: SourceCodePositition(2), end: SourceCodePositition(3), code_source_id: 0 } }
+        Trailing '=' sign. Use `let x = …` if you intended to define a new constant. - ParseError { kind: TrailingEqualSign("x"), span: Span { start: ByteIndex(2), end: ByteIndex(3), code_source_id: 0 } }
         "###);
     }
 }

--- a/numbat/src/span.rs
+++ b/numbat/src/span.rs
@@ -1,30 +1,50 @@
 use codespan_reporting::diagnostic::{Label, LabelStyle};
+use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SourceCodePositition {
-    pub byte: u32,
-    pub line: u32,
-    pub position: u32,
+pub struct SourceCodePositition(pub u32);
+
+impl From<u32> for SourceCodePositition {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl Add<u32> for SourceCodePositition {
+    type Output = Self;
+
+    fn add(self, rhs: u32) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl AddAssign<u32> for SourceCodePositition {
+    fn add_assign(&mut self, rhs: u32) {
+        self.0 += rhs;
+    }
 }
 
 impl SourceCodePositition {
     pub fn start() -> Self {
-        Self {
-            byte: 0,
-            line: 1,
-            position: 1,
-        }
+        Self(0)
     }
 
-    pub fn single_character_span(&self, code_source_id: usize) -> Span {
+    pub fn single_character_span(self, code_source_id: usize) -> Span {
         Span {
-            start: *self,
-            end: *self,
+            start: self,
+            end: self,
             code_source_id,
         }
     }
+
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
 }
 
+/// The span of text from `start` to `end`, associated with `code_source_id`. `start`
+/// and `end` are both inclusive byte indices (so that if `start == end` we get a
+/// one-byte span).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
     pub start: SourceCodePositition,
@@ -46,7 +66,7 @@ impl Span {
         Label::new(
             style,
             self.code_source_id,
-            (self.start.byte as usize)..(self.end.byte as usize),
+            (self.start.as_usize())..(self.end.as_usize()),
         )
     }
 

--- a/numbat/src/span.rs
+++ b/numbat/src/span.rs
@@ -25,10 +25,6 @@ impl AddAssign<u32> for ByteIndex {
 }
 
 impl ByteIndex {
-    pub fn start() -> Self {
-        Self(0)
-    }
-
     pub fn single_character_span(self, code_source_id: usize) -> Span {
         Span {
             start: self,
@@ -73,8 +69,8 @@ impl Span {
     #[cfg(test)]
     pub fn dummy() -> Span {
         Self {
-            start: ByteIndex::start(),
-            end: ByteIndex::start(),
+            start: ByteIndex(0),
+            end: ByteIndex(0),
             code_source_id: 0,
         }
     }

--- a/numbat/src/span.rs
+++ b/numbat/src/span.rs
@@ -2,15 +2,15 @@ use codespan_reporting::diagnostic::{Label, LabelStyle};
 use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SourceCodePositition(pub u32);
+pub struct ByteIndex(pub u32);
 
-impl From<u32> for SourceCodePositition {
+impl From<u32> for ByteIndex {
     fn from(value: u32) -> Self {
         Self(value)
     }
 }
 
-impl Add<u32> for SourceCodePositition {
+impl Add<u32> for ByteIndex {
     type Output = Self;
 
     fn add(self, rhs: u32) -> Self::Output {
@@ -18,13 +18,13 @@ impl Add<u32> for SourceCodePositition {
     }
 }
 
-impl AddAssign<u32> for SourceCodePositition {
+impl AddAssign<u32> for ByteIndex {
     fn add_assign(&mut self, rhs: u32) {
         self.0 += rhs;
     }
 }
 
-impl SourceCodePositition {
+impl ByteIndex {
     pub fn start() -> Self {
         Self(0)
     }
@@ -47,8 +47,8 @@ impl SourceCodePositition {
 /// one-byte span).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
-    pub start: SourceCodePositition,
-    pub end: SourceCodePositition,
+    pub start: ByteIndex,
+    pub end: ByteIndex,
     pub code_source_id: usize,
 }
 
@@ -73,8 +73,8 @@ impl Span {
     #[cfg(test)]
     pub fn dummy() -> Span {
         Self {
-            start: SourceCodePositition::start(),
-            end: SourceCodePositition::start(),
+            start: ByteIndex::start(),
+            end: ByteIndex::start(),
             code_source_id: 0,
         }
     }

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -219,6 +219,7 @@ fn is_identifier_continue(c: char) -> bool {
 /// When scanning a string interpolation like `"foo = {foo}, and bar = {bar}."`,
 /// the tokenizer needs to keep track of where it currently is, because we allow
 /// for (almost) arbitrary expressions inside the {…} part.
+#[cfg_attr(debug_assertions, derive(Debug))]
 enum InterpolationState {
     /// We are not inside curly braces.
     Outside,
@@ -232,6 +233,7 @@ impl InterpolationState {
     }
 }
 
+#[cfg_attr(debug_assertions, derive(Debug))]
 struct Tokenizer {
     current: SourceCodePositition,
     last: SourceCodePositition,
@@ -435,7 +437,7 @@ impl Tokenizer {
         let current_char = self.advance(input);
 
         let code_source_id = self.code_source_id;
-        let tokenizer_error = |position: &SourceCodePositition, kind| -> Result<Option<Token>> {
+        let tokenizer_error = |position: SourceCodePositition, kind| -> Result<Option<Token>> {
             Err(TokenizerError {
                 kind,
                 span: position.single_character_span(code_source_id),
@@ -474,7 +476,7 @@ impl Tokenizer {
                 // If the first character is not a digits, that's an error.
                 if !self.peek(input).map(&is_digit_in_base).unwrap_or(false) {
                     return tokenizer_error(
-                        &self.current,
+                        self.current,
                         TokenizerErrorKind::ExpectedDigitInBase {
                             base,
                             character: self.peek(input),
@@ -501,7 +503,7 @@ impl Tokenizer {
                         .unwrap_or(false)
                 {
                     return tokenizer_error(
-                        &self.current,
+                        self.current,
                         TokenizerErrorKind::ExpectedDigitInBase {
                             base,
                             character: self.peek(input),
@@ -567,7 +569,7 @@ impl Tokenizer {
                     TokenKind::UnicodeExponent
                 } else {
                     return tokenizer_error(
-                        &self.current,
+                        self.current,
                         TokenizerErrorKind::UnexpectedCharacterInNegativeExponent { character: c },
                     );
                 }
@@ -684,7 +686,7 @@ impl Tokenizer {
                         .unwrap_or(true)
                 {
                     return tokenizer_error(
-                        &self.current,
+                        self.current,
                         TokenizerErrorKind::UnexpectedCharacterInIdentifier(
                             self.peek(input).unwrap(),
                         ),
@@ -701,7 +703,7 @@ impl Tokenizer {
             ':' => TokenKind::Colon,
             c => {
                 return tokenizer_error(
-                    &self.token_start,
+                    self.token_start,
                     TokenizerErrorKind::UnexpectedCharacter { character: c },
                 );
             }
@@ -717,35 +719,27 @@ impl Tokenizer {
             },
         });
 
-        if kind == TokenKind::Newline {
-            self.current.line += 1;
-            self.current.position = 1;
-        }
-
         Ok(token)
     }
 
     fn lexeme<'a>(&self, input: &'a str) -> &'a str {
-        &input[self.token_start.byte as usize..self.current.byte as usize]
+        &input[self.token_start.as_usize()..self.current.as_usize()]
     }
 
     fn advance(&mut self, input: &str) -> char {
-        let c = char_at(input, self.current.byte as usize).unwrap();
+        let c = char_at(input, self.current.as_usize()).unwrap();
         self.last = self.current;
-        self.current.byte += c.len_utf8() as u32;
-        self.current.position += 1;
+        self.current += c.len_utf8() as u32;
         c
     }
 
     fn peek(&self, input: &str) -> Option<char> {
-        char_at(input, self.current.byte as usize)
+        char_at(input, self.current.as_usize())
     }
 
     fn peek2(&self, input: &str) -> Option<char> {
         let next_char = self.peek(input)?;
-        input[self.current.byte as usize + next_char.len_utf8()..]
-            .chars()
-            .next()
+        char_at(input, self.current.as_usize() + next_char.len_utf8())
     }
 
     fn match_char(&mut self, input: &str, c: char) -> bool {
@@ -758,7 +752,7 @@ impl Tokenizer {
     }
 
     fn at_end(&self, input: &str) -> bool {
-        self.current.byte as usize >= input.len()
+        self.current.as_usize() >= input.len()
     }
 }
 
@@ -768,22 +762,11 @@ pub fn tokenize(input: &str, code_source_id: usize) -> Result<Vec<Token>> {
 }
 
 #[cfg(test)]
-fn tokenize_reduced(input: &str) -> Result<Vec<(String, TokenKind, (u32, u32))>, String> {
+fn tokenize_reduced(input: &str) -> Result<Vec<(&str, TokenKind, SourceCodePositition)>, String> {
     Ok(tokenize(input, 0)
-        .map_err(|e| {
-            format!(
-                "Error at {:?}: `{e}`",
-                (e.span.start.line, e.span.start.position)
-            )
-        })?
+        .map_err(|e| format!("Error at index {:?}: `{e}`", e.span.start.0))?
         .iter()
-        .map(|token| {
-            (
-                token.lexeme.to_string(),
-                token.kind,
-                (token.span.start.line, token.span.start.position),
-            )
-        })
+        .map(|token| (token.lexeme, token.kind, token.span.start))
         .collect())
 }
 
@@ -792,7 +775,7 @@ fn tokenize_reduced_pretty(input: &str) -> Result<String, String> {
     use std::fmt::Write;
     let mut ret = String::new();
     for (lexeme, kind, pos) in tokenize_reduced(input)? {
-        writeln!(ret, "{lexeme:?}, {kind:?}, {pos:?}").unwrap();
+        writeln!(ret, "{lexeme:?}, {kind:?}, {:?}", pos.0).unwrap();
     }
     Ok(ret)
 }
@@ -804,96 +787,99 @@ fn test_tokenize_basic() {
     assert_eq!(
         tokenize_reduced("  12 + 34  ").unwrap(),
         [
-            ("12".to_string(), Number, (1, 3)),
-            ("+".to_string(), Plus, (1, 6)),
-            ("34".to_string(), Number, (1, 8)),
-            ("".to_string(), Eof, (1, 12))
+            ("12", Number, SourceCodePositition(2)),
+            ("+", Plus, SourceCodePositition(5)),
+            ("34", Number, SourceCodePositition(7)),
+            ("", Eof, SourceCodePositition(11))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("1 2").unwrap(),
         [
-            ("1".to_string(), Number, (1, 1)),
-            ("2".to_string(), Number, (1, 3)),
-            ("".to_string(), Eof, (1, 4))
+            ("1", Number, SourceCodePositition(0)),
+            ("2", Number, SourceCodePositition(2)),
+            ("", Eof, SourceCodePositition(3))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("12 × (3 - 4)").unwrap(),
         [
-            ("12".to_string(), Number, (1, 1)),
-            ("×".to_string(), Multiply, (1, 4)),
-            ("(".to_string(), LeftParen, (1, 6)),
-            ("3".to_string(), Number, (1, 7)),
-            ("-".to_string(), Minus, (1, 9)),
-            ("4".to_string(), Number, (1, 11)),
-            (")".to_string(), RightParen, (1, 12)),
-            ("".to_string(), Eof, (1, 13))
+            ("12", Number, SourceCodePositition(0)),
+            // 2 bytes: std::str::from_utf8(b"\xc3\x97") == Ok("×")
+            ("×", Multiply, SourceCodePositition(3)),
+            ("(", LeftParen, SourceCodePositition(6)),
+            ("3", Number, SourceCodePositition(7)),
+            ("-", Minus, SourceCodePositition(9)),
+            ("4", Number, SourceCodePositition(11)),
+            (")", RightParen, SourceCodePositition(12)),
+            ("", Eof, SourceCodePositition(13))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("foo to bar").unwrap(),
         [
-            ("foo".to_string(), Identifier, (1, 1)),
-            ("to".to_string(), To, (1, 5)),
-            ("bar".to_string(), Identifier, (1, 8)),
-            ("".to_string(), Eof, (1, 11))
+            ("foo", Identifier, SourceCodePositition(0)),
+            ("to", To, SourceCodePositition(4)),
+            ("bar", Identifier, SourceCodePositition(7)),
+            ("", Eof, SourceCodePositition(10))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("1 -> 2").unwrap(),
         [
-            ("1".to_string(), Number, (1, 1)),
-            ("->".to_string(), Arrow, (1, 3)),
-            ("2".to_string(), Number, (1, 6)),
-            ("".to_string(), Eof, (1, 7))
+            ("1", Number, SourceCodePositition(0)),
+            ("->", Arrow, SourceCodePositition(2)),
+            ("2", Number, SourceCodePositition(5)),
+            ("", Eof, SourceCodePositition(6))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("45°").unwrap(),
         [
-            ("45".to_string(), Number, (1, 1)),
-            ("°".to_string(), Identifier, (1, 3)),
-            ("".to_string(), Eof, (1, 4))
+            ("45", Number, SourceCodePositition(0)),
+            // 2 bytes: std::str::from_utf8(b"\xc2\xb0") == Ok("°")
+            ("°", Identifier, SourceCodePositition(2)),
+            ("", Eof, SourceCodePositition(4))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("1+2\n42").unwrap(),
         [
-            ("1".to_string(), Number, (1, 1)),
-            ("+".to_string(), Plus, (1, 2)),
-            ("2".to_string(), Number, (1, 3)),
-            ("\n".to_string(), Newline, (1, 4)),
-            ("42".to_string(), Number, (2, 1)),
-            ("".to_string(), Eof, (2, 3))
+            ("1", Number, SourceCodePositition(0)),
+            ("+", Plus, SourceCodePositition(1)),
+            ("2", Number, SourceCodePositition(2)),
+            ("\n", Newline, SourceCodePositition(3)),
+            ("42", Number, SourceCodePositition(4)),
+            ("", Eof, SourceCodePositition(6))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("…").unwrap(),
         [
-            ("…".to_string(), Ellipsis, (1, 1)),
-            ("".to_string(), Eof, (1, 2))
+            // 3 bytes: std::str::from_utf8(b"\xe2\x80\xa6") == Ok("…")
+            ("…", Ellipsis, SourceCodePositition(0)),
+            ("", Eof, SourceCodePositition(3))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("...").unwrap(),
         [
-            ("...".to_string(), Ellipsis, (1, 1)),
-            ("".to_string(), Eof, (1, 4))
+            ("...", Ellipsis, SourceCodePositition(0)),
+            ("", Eof, SourceCodePositition(3))
         ]
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("~").unwrap_err(),
-    @"Error at (1, 1): `Unexpected character: '~'`");
+    @"Error at index 0: `Unexpected character: '~'`");
 }
 
 #[test]
@@ -903,174 +889,174 @@ fn test_tokenize_numbers() {
     insta::assert_snapshot!(
         tokenize_reduced_pretty("12").unwrap(),
         @r###"
-    "12", Number, (1, 1)
-    "", Eof, (1, 3)
+    "12", Number, 0
+    "", Eof, 2
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1_2").unwrap(),
         @r###"
-    "1_2", Number, (1, 1)
-    "", Eof, (1, 4)
+    "1_2", Number, 0
+    "", Eof, 3
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1.").unwrap(),
         @r###"
-    "1.", Number, (1, 1)
-    "", Eof, (1, 3)
+    "1.", Number, 0
+    "", Eof, 2
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1.2").unwrap(),
         @r###"
-    "1.2", Number, (1, 1)
-    "", Eof, (1, 4)
+    "1.2", Number, 0
+    "", Eof, 3
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1_1.2_2").unwrap(),
         @r###"
-    "1_1.2_2", Number, (1, 1)
-    "", Eof, (1, 8)
+    "1_1.2_2", Number, 0
+    "", Eof, 7
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b01").unwrap(),
         @r###"
-    "0b01", IntegerWithBase(2), (1, 1)
-    "", Eof, (1, 5)
+    "0b01", IntegerWithBase(2), 0
+    "", Eof, 4
     "###
     );
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b1_0").unwrap(),
         @r###"
-    "0b1_0", IntegerWithBase(2), (1, 1)
-    "", Eof, (1, 6)
+    "0b1_0", IntegerWithBase(2), 0
+    "", Eof, 5
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o01234567").unwrap(),
         @r###"
-    "0o01234567", IntegerWithBase(8), (1, 1)
-    "", Eof, (1, 11)
+    "0o01234567", IntegerWithBase(8), 0
+    "", Eof, 10
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o1_2").unwrap(),
         @r###"
-    "0o1_2", IntegerWithBase(8), (1, 1)
-    "", Eof, (1, 6)
+    "0o1_2", IntegerWithBase(8), 0
+    "", Eof, 5
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x1234567890abcdef").unwrap(),
         @r###"
-    "0x1234567890abcdef", IntegerWithBase(16), (1, 1)
-    "", Eof, (1, 19)
+    "0x1234567890abcdef", IntegerWithBase(16), 0
+    "", Eof, 18
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x1_2").unwrap(),
         @r###"
-    "0x1_2", IntegerWithBase(16), (1, 1)
-    "", Eof, (1, 6)
+    "0x1_2", IntegerWithBase(16), 0
+    "", Eof, 5
     "###
     );
 
     // Failing queries
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1_.2").unwrap_err(),
-        @"Error at (1, 2): `Unexpected character in number literal: '_'`"
+        @"Error at index 1: `Unexpected character in number literal: '_'`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("1.2_").unwrap_err(),
-        @"Error at (1, 4): `Unexpected character in number literal: '_'`"
+        @"Error at index 3: `Unexpected character in number literal: '_'`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b012").unwrap_err(),
-        @"Error at (1, 5): `Expected base-2 digit`"
+        @"Error at index 4: `Expected base-2 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b").unwrap_err(),
-        @"Error at (1, 3): `Expected base-2 digit`"
+        @"Error at index 2: `Expected base-2 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b_").unwrap_err(),
-        @"Error at (1, 3): `Expected base-2 digit`"
+        @"Error at index 2: `Expected base-2 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b_1").unwrap_err(),
-        @"Error at (1, 3): `Expected base-2 digit`"
+        @"Error at index 2: `Expected base-2 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0b1_").unwrap_err(),
-        @"Error at (1, 5): `Expected base-2 digit`"
+        @"Error at index 4: `Expected base-2 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o012345678").unwrap_err(),
-        @"Error at (1, 11): `Expected base-8 digit`"
+        @"Error at index 10: `Expected base-8 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o").unwrap_err(),
-        @"Error at (1, 3): `Expected base-8 digit`"
+        @"Error at index 2: `Expected base-8 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o_").unwrap_err(),
-        @"Error at (1, 3): `Expected base-8 digit`"
+        @"Error at index 2: `Expected base-8 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o_1").unwrap_err(),
-        @"Error at (1, 3): `Expected base-8 digit`"
+        @"Error at index 2: `Expected base-8 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0o1_").unwrap_err(),
-        @"Error at (1, 5): `Expected base-8 digit`"
+        @"Error at index 4: `Expected base-8 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x1234567890abcdefg").unwrap_err(),
-        @"Error at (1, 19): `Expected base-16 digit`"
+        @"Error at index 18: `Expected base-16 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x").unwrap_err(),
-        @"Error at (1, 3): `Expected base-16 digit`"
+        @"Error at index 2: `Expected base-16 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x_").unwrap_err(),
-        @"Error at (1, 3): `Expected base-16 digit`"
+        @"Error at index 2: `Expected base-16 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x_1").unwrap_err(),
-        @"Error at (1, 3): `Expected base-16 digit`"
+        @"Error at index 2: `Expected base-16 digit`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("0x1_").unwrap_err(),
-        @"Error at (1, 5): `Expected base-16 digit`"
+        @"Error at index 4: `Expected base-16 digit`"
     );
 }
 
@@ -1081,46 +1067,58 @@ fn test_tokenize_string() {
     assert_eq!(
         tokenize_reduced("\"foo\"").unwrap(),
         [
-            ("\"foo\"".to_string(), StringFixed, (1, 1)),
-            ("".to_string(), Eof, (1, 6))
+            ("\"foo\"", StringFixed, SourceCodePositition(0)),
+            ("", Eof, SourceCodePositition(5))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("\"foo = {foo}\"").unwrap(),
         [
-            ("\"foo = {".to_string(), StringInterpolationStart, (1, 1)),
-            ("foo".to_string(), Identifier, (1, 9)),
-            ("}\"".to_string(), StringInterpolationEnd, (1, 12)),
-            ("".to_string(), Eof, (1, 14))
+            (
+                "\"foo = {",
+                StringInterpolationStart,
+                SourceCodePositition(0)
+            ),
+            ("foo", Identifier, SourceCodePositition(8)),
+            ("}\"", StringInterpolationEnd, SourceCodePositition(11)),
+            ("", Eof, SourceCodePositition(13))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("\"foo = {foo}, and bar = {bar}\"").unwrap(),
         [
-            ("\"foo = {".to_string(), StringInterpolationStart, (1, 1)),
-            ("foo".to_string(), Identifier, (1, 9)),
             (
-                "}, and bar = {".to_string(),
-                StringInterpolationMiddle,
-                (1, 12)
+                "\"foo = {",
+                StringInterpolationStart,
+                SourceCodePositition(0)
             ),
-            ("bar".to_string(), Identifier, (1, 26)),
-            ("}\"".to_string(), StringInterpolationEnd, (1, 29)),
-            ("".to_string(), Eof, (1, 31))
+            ("foo", Identifier, SourceCodePositition(8)),
+            (
+                "}, and bar = {",
+                StringInterpolationMiddle,
+                SourceCodePositition(11)
+            ),
+            ("bar", Identifier, SourceCodePositition(25)),
+            ("}\"", StringInterpolationEnd, SourceCodePositition(28)),
+            ("", Eof, SourceCodePositition(30))
         ]
     );
 
     assert_eq!(
         tokenize_reduced("\"1 + 2 = {1 + 2}\"").unwrap(),
         [
-            ("\"1 + 2 = {".to_string(), StringInterpolationStart, (1, 1)),
-            ("1".to_string(), Number, (1, 11)),
-            ("+".to_string(), Plus, (1, 13)),
-            ("2".to_string(), Number, (1, 15)),
-            ("}\"".to_string(), StringInterpolationEnd, (1, 16)),
-            ("".to_string(), Eof, (1, 18))
+            (
+                "\"1 + 2 = {",
+                StringInterpolationStart,
+                SourceCodePositition(0)
+            ),
+            ("1", Number, SourceCodePositition(10)),
+            ("+", Plus, SourceCodePositition(12)),
+            ("2", Number, SourceCodePositition(14)),
+            ("}\"", StringInterpolationEnd, SourceCodePositition(15)),
+            ("", Eof, SourceCodePositition(17))
         ]
     );
 
@@ -1144,26 +1142,26 @@ fn test_tokenize_string() {
     insta::assert_snapshot!(
         tokenize_reduced_pretty(r#""start \"inner\" end""#).unwrap(),
         @r###"
-    "\"start \\\"inner\\\" end\"", StringFixed, (1, 1)
-    "", Eof, (1, 22)
+    "\"start \\\"inner\\\" end\"", StringFixed, 0
+    "", Eof, 21
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty(r#""start \{inner\} end""#).unwrap(),
         @r###"
-    "\"start \\{inner\\} end\"", StringFixed, (1, 1)
-    "", Eof, (1, 22)
+    "\"start \\{inner\\} end\"", StringFixed, 0
+    "", Eof, 21
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty(r#""start {1} \"inner\" end""#).unwrap(),
         @r###"
-    "\"start {", StringInterpolationStart, (1, 1)
-    "1", Number, (1, 9)
-    "} \\\"inner\\\" end\"", StringInterpolationEnd, (1, 10)
-    "", Eof, (1, 26)
+    "\"start {", StringInterpolationStart, 0
+    "1", Number, 8
+    "} \\\"inner\\\" end\"", StringInterpolationEnd, 9
+    "", Eof, 25
     "###
     );
 }
@@ -1173,31 +1171,31 @@ fn test_logical_operators() {
     insta::assert_snapshot!(
         tokenize_reduced_pretty("true || false").unwrap(),
         @r###"
-    "true", True, (1, 1)
-    "||", LogicalOr, (1, 6)
-    "false", False, (1, 9)
-    "", Eof, (1, 14)
+    "true", True, 0
+    "||", LogicalOr, 5
+    "false", False, 8
+    "", Eof, 13
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("true && false").unwrap(),
         @r###"
-    "true", True, (1, 1)
-    "&&", LogicalAnd, (1, 6)
-    "false", False, (1, 9)
-    "", Eof, (1, 14)
+    "true", True, 0
+    "&&", LogicalAnd, 5
+    "false", False, 8
+    "", Eof, 13
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("true | false").unwrap_err(),
-        @"Error at (1, 6): `Unexpected character: '|'`"
+        @"Error at index 5: `Unexpected character: '|'`"
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("true & false").unwrap_err(),
-        @"Error at (1, 6): `Unexpected character: '&'`"
+        @"Error at index 5: `Unexpected character: '&'`"
     );
 }
 
@@ -1227,38 +1225,38 @@ fn test_field_access() {
     insta::assert_snapshot!(
         tokenize_reduced_pretty("instance2.field").unwrap(),
         @r###"
-    "instance2", Identifier, (1, 1)
-    ".", Period, (1, 10)
-    "field", Identifier, (1, 11)
-    "", Eof, (1, 16)
+    "instance2", Identifier, 0
+    ".", Period, 9
+    "field", Identifier, 10
+    "", Eof, 15
     "###
     );
 
     insta::assert_snapshot!(
         tokenize_reduced_pretty("function().field").unwrap(),
         @r###"
-    "function", Identifier, (1, 1)
-    "(", LeftParen, (1, 9)
-    ")", RightParen, (1, 10)
-    ".", Period, (1, 11)
-    "field", Identifier, (1, 12)
-    "", Eof, (1, 17)
+    "function", Identifier, 0
+    "(", LeftParen, 8
+    ")", RightParen, 9
+    ".", Period, 10
+    "field", Identifier, 11
+    "", Eof, 16
     "###
     );
 
     insta::assert_snapshot!(
     tokenize_reduced_pretty("instance.0").unwrap_err(),
-        @"Error at (1, 9): `Unexpected character in identifier: '.'`"
+        @"Error at index 8: `Unexpected character in identifier: '.'`"
     );
 
     insta::assert_snapshot!(
     tokenize_reduced_pretty("instance..field").unwrap_err(),
-        @"Error at (1, 9): `Unexpected character in identifier: '.'`"
+        @"Error at index 8: `Unexpected character in identifier: '.'`"
     );
 
     insta::assert_snapshot!(
     tokenize_reduced_pretty("instance . field").unwrap_err(),
-        @"Error at (1, 11): `Expected digit`"
+        @"Error at index 10: `Expected digit`"
     );
 }
 
@@ -1267,14 +1265,14 @@ fn test_lists() {
     insta::assert_snapshot!(
         tokenize_reduced_pretty("[1, 2.3, 4]").unwrap(),
         @r###"
-    "[", LeftBracket, (1, 1)
-    "1", Number, (1, 2)
-    ",", Comma, (1, 3)
-    "2.3", Number, (1, 5)
-    ",", Comma, (1, 8)
-    "4", Number, (1, 10)
-    "]", RightBracket, (1, 11)
-    "", Eof, (1, 12)
+    "[", LeftBracket, 0
+    "1", Number, 1
+    ",", Comma, 2
+    "2.3", Number, 4
+    ",", Comma, 7
+    "4", Number, 9
+    "]", RightBracket, 10
+    "", Eof, 11
     "###
     );
 }

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -253,13 +253,13 @@ fn char_at(s: &str, byte_index: usize) -> Option<char> {
 impl Tokenizer {
     fn new(code_source_id: usize) -> Self {
         Tokenizer {
-            current: ByteIndex::start(),
-            last: ByteIndex::start(),
-            token_start: ByteIndex::start(),
+            current: ByteIndex(0),
+            last: ByteIndex(0),
+            token_start: ByteIndex(0),
 
             code_source_id,
-            string_start: ByteIndex::start(),
-            interpolation_start: ByteIndex::start(),
+            string_start: ByteIndex(0),
+            interpolation_start: ByteIndex(0),
             interpolation_state: InterpolationState::Outside,
         }
     }


### PR DESCRIPTION
Span is now 16 bytes instead of 32 (on a 64 bit machine) due to the removal of fields `line` and `position` from `SourceCodePositition` [sic]. Related: #559

This was a remarkably simple change. I was surprised to find that none of the error reporting actually relied on `line` and `position`; it was all just byte-based. Those fields were only used in tests. If later desired, we can hang onto cumulative line lengths and convert byte index into line + position as needed. (But apparently that is not currently needed.)

One thing to note is that tests that were formerly based on `position` are now based on `byte`, which means they're off by 1 (position `n` became byte `n-1`).