### PR TITLE
Copy to clipboard (not complete as of submission)

### DIFF
--- a/numbat-cli/src/config.rs
+++ b/numbat-cli/src/config.rs
@@ -1,3 +1,4 @@
+use crate::copy_to_clipboard::NumericDisplayConfig;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
@@ -65,6 +66,8 @@ pub struct Config {
     #[serde(skip_serializing)]
     pub load_user_init: bool,
     pub exchange_rates: ExchangeRateConfig,
+
+    pub copy_output_config: NumericDisplayConfig,
 }
 
 impl Default for Config {
@@ -78,6 +81,7 @@ impl Default for Config {
             load_user_init: true,
             exchange_rates: Default::default(),
             enter_repl: true,
+            copy_output_config: Default::default(),
         }
     }
 }

--- a/numbat-cli/src/copy_to_clipboard.rs
+++ b/numbat-cli/src/copy_to_clipboard.rs
@@ -1,0 +1,153 @@
+use numbat::{
+    markup::Markup, num_format::CustomFormat, num_format::Grouping, pretty_dtoa::FmtFloatConfig,
+    pretty_print::PrettyPrint, value::Value, FloatDisplayConfigSource, RuntimeError,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Default, Debug, Clone)]
+#[serde(remote = "Grouping", rename_all = "kebab-case")]
+pub enum IntGroupingConfig {
+    #[default]
+    Standard,
+    Indian,
+    #[serde(rename = "none")]
+    Posix,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct IntDisplayConfig {
+    #[serde(with = "IntGroupingConfig")]
+    pub grouping: Grouping,
+    pub separator: String,
+    pub minus_sign: String,
+}
+
+impl Default for IntDisplayConfig {
+    fn default() -> Self {
+        Self {
+            grouping: Grouping::Standard,
+            separator: ",".into(),
+            minus_sign: "-".into(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct FloatDisplayConfig {
+    /// 0 means this value will be ignored
+    pub max_sig_digits: u8,
+    /// 0 means this value will be ignored
+    pub min_sig_digits: u8,
+    /// 0 means this value will be ignored
+    pub max_width: u8,
+    pub decimal: char,
+    pub capitalize_e: bool,
+}
+
+impl Default for FloatDisplayConfig {
+    fn default() -> Self {
+        Self {
+            max_sig_digits: 0,
+            min_sig_digits: 0,
+            max_width: 0,
+            decimal: '.',
+            capitalize_e: false,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Default, Debug, Clone)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct NumericDisplayConfig {
+    #[serde(serialize_with = "serialize_option_config")]
+    pub int_config: Option<IntDisplayConfig>,
+    #[serde(serialize_with = "serialize_option_config")]
+    pub float_config: Option<FloatDisplayConfig>,
+}
+
+fn serialize_option_config<S, T: Serialize + Default>(
+    value: &Option<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        Some(o) => o.serialize(serializer),
+        None => T::default().serialize(serializer),
+    }
+}
+
+pub(crate) fn pretty_print_value(
+    v: &Value,
+    config: &NumericDisplayConfig,
+) -> Result<Markup, Box<RuntimeError>> {
+    Ok(match &v {
+        Value::Quantity(q) => {
+            let NumericDisplayConfig {
+                int_config,
+                float_config,
+            } = config;
+
+            let float_options = float_config.as_ref().map(|c| {
+                let FloatDisplayConfig {
+                    max_sig_digits,
+                    min_sig_digits,
+                    max_width,
+                    decimal,
+                    capitalize_e,
+                } = *c;
+
+                let mut opts = FmtFloatConfig::default()
+                    .radix_point(decimal)
+                    .capitalize_e(capitalize_e);
+                if max_sig_digits > 0 {
+                    opts = opts.max_significant_digits(max_sig_digits);
+                }
+                if min_sig_digits > 0 {
+                    opts = opts.min_significant_digits(min_sig_digits);
+                }
+                if max_width > 0 {
+                    opts = opts.max_width(max_width);
+                }
+
+                opts
+            });
+
+            let int_options = int_config
+                .as_ref()
+                .map(|c| {
+                    let int_config @ IntDisplayConfig {
+                        grouping,
+                        separator,
+                        minus_sign,
+                    } = c;
+
+                    CustomFormat::builder()
+                        .grouping(*grouping)
+                        .separator(separator)
+                        .minus_sign(minus_sign)
+                        .build()
+                        .map_err(|err| {
+                            Box::new(RuntimeError::IntegerDisplayConfig(
+                                format!("{int_config:?}"),
+                                err.to_string(),
+                            ))
+                        })
+                })
+                .transpose()?;
+
+            q.pretty_print_with_options(
+                match float_options {
+                    Some(o) => FloatDisplayConfigSource::UserConfig(o),
+                    None => FloatDisplayConfigSource::Numbat(None),
+                },
+                int_options,
+            )
+        }
+
+        v => v.pretty_print(),
+    })
+}

--- a/numbat/src/arithmetic.rs
+++ b/numbat/src/arithmetic.rs
@@ -24,9 +24,9 @@ pub fn pretty_exponent(e: &Exponent) -> String {
         "³".into()
     } else if e == &Ratio::from_integer(2) {
         "²".into()
-    } else if e == &Ratio::from_integer(1) {
-        "".into()
-    } else if e == &Ratio::from_integer(-1) {
+    }
+    // 1 handled by ugly exponent
+    else if e == &Ratio::from_integer(-1) {
         "⁻¹".into()
     } else if e == &Ratio::from_integer(-2) {
         "⁻²".into()
@@ -36,9 +36,19 @@ pub fn pretty_exponent(e: &Exponent) -> String {
         "⁻⁴".into()
     } else if e == &Ratio::from_integer(-5) {
         "⁻⁵".into()
+    } else {
+        ugly_exponent(e)
+    }
+}
+
+pub fn ugly_exponent(e: &Exponent) -> String {
+    if e == &Ratio::from_integer(1) {
+        "".into()
     } else if e.is_positive() && e.is_integer() {
         format!("^{e}")
     } else {
         format!("^({e})")
     }
 }
+
+// pub trait

--- a/numbat/src/command.rs
+++ b/numbat/src/command.rs
@@ -23,6 +23,7 @@ enum CommandKind {
     Help,
     Info,
     List,
+    Copy,
     Clear,
     Save,
     Quit(QuitAlias),
@@ -37,6 +38,7 @@ impl FromStr for CommandKind {
             "help" | "?" => Help,
             "info" => Info,
             "list" => List,
+            "copy" => Copy,
             "clear" => Clear,
             "save" => Save,
             "quit" => Quit(QuitAlias::Quit),
@@ -51,6 +53,7 @@ pub enum Command<'a> {
     Help,
     Info { item: &'a str },
     List { items: Option<ListItems> },
+    Copy,
     Clear,
     Save { dst: &'a str },
     Quit,
@@ -212,6 +215,10 @@ impl<'a> CommandParser<'a> {
 
                 Command::Quit
             }
+            CommandKind::Copy => {
+                self.ensure_zero_args("copy", "")?;
+                Command::Copy
+            }
             CommandKind::Info => {
                 let err_msg = "`info` requires exactly one argument, the item to get info on";
                 let Some(item) = self.inner.args.next() else {
@@ -248,6 +255,7 @@ impl<'a> CommandParser<'a> {
 
                 Command::List { items }
             }
+
             CommandKind::Save => {
                 let Some(dst) = self.inner.args.next() else {
                     return Ok(Command::Save { dst: "history.nbt" });

--- a/numbat/src/interpreter/mod.rs
+++ b/numbat/src/interpreter/mod.rs
@@ -63,6 +63,9 @@ pub enum RuntimeError {
 
     #[error("Could not write to file: {0:?}")]
     FileWrite(std::path::PathBuf),
+
+    #[error("Invalid integer display config: {0}. Originated from: {1}")]
+    IntegerDisplayConfig(String, String),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -82,6 +82,11 @@ use unit_registry::UnitMetadata;
 use crate::prefix_parser::PrefixParserResult;
 use crate::unicode_input::UNICODE_INPUT;
 
+pub use number::FloatDisplayConfigSource;
+
+pub use num_format;
+pub use pretty_dtoa;
+
 #[derive(Debug, Clone, Error)]
 pub enum NumbatError {
     #[error("{0}")]

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -77,12 +77,14 @@ pub use registry::BaseRepresentationFactor;
 pub use typed_ast::Statement;
 pub use typed_ast::Type;
 use unit::BaseUnitAndFactor;
+use unit::UnitFactor;
 use unit_registry::UnitMetadata;
 
 use crate::prefix_parser::PrefixParserResult;
 use crate::unicode_input::UNICODE_INPUT;
 
 pub use number::FloatDisplayConfigSource;
+pub use quantity::UnitDisplayOptions;
 
 pub use num_format;
 pub use pretty_dtoa;
@@ -409,6 +411,7 @@ impl Context {
                                 'x',
                                 '/',
                                 true,
+                                None::<fn(&UnitFactor) -> String>,
                                 Some(m::FormatType::Unit),
                             );
                     } else {

--- a/numbat/src/product.rs
+++ b/numbat/src/product.rs
@@ -34,6 +34,7 @@ impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: b
         times_separator: char,
         over_separator: char,
         separator_padding: bool,
+        factor_to_string: Option<impl Fn(&Factor) -> String>,
         format_type: Option<m::FormatType>,
     ) -> m::Markup
     where
@@ -54,7 +55,11 @@ impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: b
                     + m::Markup::from(m::FormattedString(
                         m::OutputType::Normal,
                         format_type,
-                        factor.to_string(),
+                        if let Some(factor_to_string) = &factor_to_string {
+                            factor_to_string(factor)
+                        } else {
+                            factor.to_string()
+                        },
                     ))
                     + if i == num_factors - 1 {
                         m::empty()
@@ -117,6 +122,7 @@ impl<Factor: Power + Clone + Canonicalize + Ord + Display, const CANONICALIZE: b
                 times_separator,
                 over_separator,
                 separator_padding,
+                None::<fn(&Factor) -> String>, // need to specify type
                 None,
             ),
             false,

--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -1,4 +1,5 @@
 use crate::arithmetic::{Exponent, Power, Rational};
+use crate::markup::{Formatter, PlainTextFormatter};
 use crate::number::Number;
 use crate::pretty_print::PrettyPrint;
 use crate::unit::{is_multiple_of, Unit, UnitFactor};
@@ -342,7 +343,7 @@ impl PartialOrd for Quantity {
 
 impl PrettyPrint for Quantity {
     fn pretty_print(&self) -> crate::markup::Markup {
-        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(None), None)
+        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(None), None, None)
     }
 }
 
@@ -353,6 +354,7 @@ impl Quantity {
         &self,
         float_options: FloatDisplayConfigSource,
         int_options: Option<num_format::CustomFormat>,
+        unit_options: Option<UnitDisplayOptions>,
     ) -> crate::markup::Markup {
         use crate::markup;
 
@@ -360,7 +362,32 @@ impl Quantity {
             .unsafe_value()
             .pretty_print_with_options(float_options, int_options);
 
-        let unit_str = format!("{}", self.unit());
+        let unit_str = if let Some(UnitDisplayOptions {
+            fancy_exponents,
+            multiplication_operator,
+            division_operator,
+            space_btwn_operators,
+        }) = unit_options
+        {
+            let m = self.unit().pretty_print_with(
+                |f| f.exponent,
+                multiplication_operator,
+                division_operator,
+                space_btwn_operators,
+                Some(|unit: &UnitFactor| {
+                    if fancy_exponents {
+                        unit.to_string()
+                    } else {
+                        unit.to_ugly_string()
+                    }
+                }),
+                None,
+            );
+
+            PlainTextFormatter.format(&m, false)
+        } else {
+            format!("{}", self.unit())
+        };
 
         markup::value(formatted_number)
             + if unit_str == "°" || unit_str == "′" || unit_str == "″" || unit_str.is_empty() {
@@ -380,7 +407,7 @@ impl Quantity {
             .add_point_zero(false)
             .force_no_e_notation()
             .round();
-        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(Some(options)), None)
+        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(Some(options)), None, None)
     }
 
     pub fn unsafe_value_as_string(&self) -> String {
@@ -396,6 +423,13 @@ impl std::fmt::Display for Quantity {
         let formatter = PlainTextFormatter {};
         write!(f, "{}", formatter.format(&markup, false).trim())
     }
+}
+
+pub struct UnitDisplayOptions {
+    pub fancy_exponents: bool,
+    pub multiplication_operator: char,
+    pub division_operator: char,
+    pub space_btwn_operators: bool,
 }
 
 #[cfg(test)]

--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -2,6 +2,7 @@ use crate::arithmetic::{Exponent, Power, Rational};
 use crate::number::Number;
 use crate::pretty_print::PrettyPrint;
 use crate::unit::{is_multiple_of, Unit, UnitFactor};
+use crate::FloatDisplayConfigSource;
 
 use itertools::Itertools;
 use num_rational::Ratio;
@@ -341,17 +342,23 @@ impl PartialOrd for Quantity {
 
 impl PrettyPrint for Quantity {
     fn pretty_print(&self) -> crate::markup::Markup {
-        self.pretty_print_with_options(None)
+        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(None), None)
     }
 }
 
 impl Quantity {
     /// Pretty prints with the given options.
     /// If options is None, default options will be used.
-    fn pretty_print_with_options(&self, options: Option<FmtFloatConfig>) -> crate::markup::Markup {
+    pub fn pretty_print_with_options(
+        &self,
+        float_options: FloatDisplayConfigSource,
+        int_options: Option<num_format::CustomFormat>,
+    ) -> crate::markup::Markup {
         use crate::markup;
 
-        let formatted_number = self.unsafe_value().pretty_print_with_options(options);
+        let formatted_number = self
+            .unsafe_value()
+            .pretty_print_with_options(float_options, int_options);
 
         let unit_str = format!("{}", self.unit());
 
@@ -373,7 +380,7 @@ impl Quantity {
             .add_point_zero(false)
             .force_no_e_notation()
             .round();
-        self.pretty_print_with_options(Some(options))
+        self.pretty_print_with_options(FloatDisplayConfigSource::Numbat(Some(options)), None)
     }
 
     pub fn unsafe_value_as_string(&self) -> String {

--- a/numbat/src/registry.rs
+++ b/numbat/src/registry.rs
@@ -77,7 +77,14 @@ impl PrettyPrint for BaseRepresentation {
         if self.iter().count() == 0 {
             crate::markup::type_identifier("Scalar")
         } else {
-            self.pretty_print_with(|f| f.1, '×', '/', true, None)
+            self.pretty_print_with(
+                |f| f.1,
+                '×',
+                '/',
+                true,
+                None::<fn(&BaseRepresentationFactor) -> String>,
+                None,
+            )
         }
     }
 }

--- a/numbat/src/unit.rs
+++ b/numbat/src/unit.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use num_traits::{ToPrimitive, Zero};
 
 use crate::{
-    arithmetic::{pretty_exponent, Exponent, Power, Rational},
+    arithmetic::{pretty_exponent, ugly_exponent, Exponent, Power, Rational},
     number::Number,
     prefix::Prefix,
     prefix_parser::AcceptsPrefix,
@@ -170,6 +170,26 @@ pub struct UnitFactor {
     pub unit_id: UnitIdentifier,
     pub prefix: Prefix,
     pub exponent: Exponent,
+}
+
+impl UnitFactor {
+    // TODO: unify this implementation with `Display::fmt` (they're nearly identical)
+    /// Get this unit as a String, but without fancy Unicode formatting of exponents.
+    /// All exponents look like `^1`, `^-2`, etc.
+    pub fn to_ugly_string(&self) -> String {
+        let prefix = if self.unit_id.canonical_name.accepts_prefix.short {
+            self.prefix.as_string_short()
+        } else {
+            self.prefix.as_string_long()
+        };
+
+        format!(
+            "{}{}{}",
+            prefix,
+            self.unit_id.canonical_name.name,
+            ugly_exponent(&self.exponent)
+        )
+    }
 }
 
 impl Canonicalize for UnitFactor {


### PR DESCRIPTION
This is preliminary work on the copy-to-clipboard functionality that was mentioned in #394. Currently the `copy` command does not actually copy, but merely prints what would be copied (once I add that). In general I try to fall back to Numbat’s own defaults with user configuration where it makes sense. Here is the default config for this:

```toml
[copy-output-config.int-config]
grouping = "standard"
separator = ","
minus-sign = "-"

[copy-output-config.float-config]
max-sig-digits = 0
min-sig-digits = 0
max-width = 0
decimal = "."
capitalize-e = false

[copy-output-config.unit-config]
fancy-exponents = false
multiplication-operator = "·"
division-operator = "/"
space-btwn-operators = false
```

Please bike-shed away on these configuration options — names, default values, anything extraneous or missing...

With the above config (generated by `numbat --generate-config`), you'd get this kind of output:

```text
>>> copy  # first command in the session
error: no value to copy
>>> 1e12

  1.0e+12

    = 1.0e+12

>>> copy
1,000,000,000,000
>>> 1kg m^2/s^2

  1 kilogram × metre² / second²

    = 1 kg·m²/s²    [Energy or Torque]

>>> copy
1 kg·m^2/s^2
>>> 
```

Once I do a little more work investigating what's a good clipboard crate these days I can finish this up.