### PR TITLE
Cache `help` output and preinitialize it for speedier first access

### DIFF
--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -309,6 +309,8 @@ impl Cli {
         );
         rl.load_history(&history_path).ok();
 
+        std::thread::spawn(help_markup);
+
         if interactive {
             match self.config.intro_banner {
                 IntroBanner::Long => {
@@ -371,7 +373,7 @@ impl Cli {
                                 Ok(command) => match command {
                                     command::Command::Help => {
                                         let help = help_markup();
-                                        print!("{}", ansi_format(&help, true));
+                                        print!("{}", ansi_format(help, true));
                                         // currently, the ansi formatter adds indents
                                         // _after_ each newline and so we need to manually
                                         // add an extra blank line to absorb this indent

--- a/numbat/src/help.rs
+++ b/numbat/src/help.rs
@@ -6,6 +6,7 @@ use crate::resolver::CodeSource;
 use crate::Context;
 use crate::InterpreterSettings;
 
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 
 fn evaluate_example(context: &mut Context, input: &str) -> m::Markup {
@@ -39,31 +40,38 @@ fn evaluate_example(context: &mut Context, input: &str) -> m::Markup {
     markup
 }
 
-pub fn help_markup() -> m::Markup {
-    let mut output = m::nl()
-        + m::text("Numbat is a statically typed programming language for scientific computations")
-        + m::nl()
-        + m::text("with first class support for physical dimensions and units. Please refer to")
-        + m::nl()
-        + m::text("the full documentation online at ")
-        + m::string("https://numbat.dev/doc/")
-        + m::text(" or try one of these ")
-        + m::nl()
-        + m::text("examples:")
-        + m::nl()
-        + m::nl();
+static HELP_MARKUP: OnceLock<m::Markup> = OnceLock::new();
+pub fn help_markup() -> &'static m::Markup {
+    HELP_MARKUP.get_or_init(|| {
+        let mut output = m::nl()
+            + m::text(
+                "Numbat is a statically typed programming language for scientific computations",
+            )
+            + m::nl()
+            + m::text(
+                "with first class support for physical dimensions and units. Please refer to",
+            )
+            + m::nl()
+            + m::text("the full documentation online at ")
+            + m::string("https://numbat.dev/doc/")
+            + m::text(" or try one of these ")
+            + m::nl()
+            + m::text("examples:")
+            + m::nl()
+            + m::nl();
 
-    let examples = [
-        "8 km / (1 h + 25 min)",
-        "atan2(30 cm, 1 m) -> deg",
-        "let ω = 2 π c / 660 nm",
-        r#"print("Energy of red photons: {ℏ ω -> eV}")"#,
-    ];
-    let mut example_context = Context::new(BuiltinModuleImporter::default());
-    let _use_prelude_output = evaluate_example(&mut example_context, "use prelude");
-    for example in examples.iter() {
-        output += m::text(">>> ") + m::text(*example) + m::nl();
-        output += evaluate_example(&mut example_context, example) + m::nl();
-    }
-    output
+        let examples = [
+            "8 km / (1 h + 25 min)",
+            "atan2(30 cm, 1 m) -> deg",
+            "let ω = 2 π c / 660 nm",
+            r#"print("Energy of red photons: {ℏ ω -> eV}")"#,
+        ];
+        let mut example_context = Context::new(BuiltinModuleImporter::default());
+        let _use_prelude_output = evaluate_example(&mut example_context, "use prelude");
+        for example in examples.iter() {
+            output += m::text(">>> ") + m::text(*example) + m::nl();
+            output += evaluate_example(&mut example_context, example) + m::nl();
+        }
+        output
+    })
 }


### PR DESCRIPTION
It bothered me that 1. `help` took a noticeable amount of time to print (due to spinning up a whole context and evaluating in it) and 2. it did this every time it was invoked. Since the `help` markup doesn't change, we might as well cache it. And since it takes time to generate, we might as well precompute it in a separate thread (in the CLI crate) before the user even has a chance to invoke it. This makes the `help` output appear immediately each time (assuming you invoke it for the first time at least a few tenths of a second after numbat starts up) without delaying program startup.

We could in theory even cache the call to `ansi_format(help, true)`, but this would require the parent `numbat` crate to hold the `ANSIFormatter` machinery (since `help_markup()` lives in crate `numbat`), which is probably not worth it.