### PR TITLE
Improved completion performance

### DIFF
--- a/numbat-cli/src/completer.rs
+++ b/numbat-cli/src/completer.rs
@@ -131,7 +131,7 @@ impl Completer for NumbatCompleter {
             candidates
                 .map(|w| Pair {
                     display: w.to_string(),
-                    replacement: w.to_string(),
+                    replacement: w,
                 })
                 .collect(),
         ))


### PR DESCRIPTION
Removed non-matching candidates from consideration earlier, obviating need to filter them out
Removed clones of candidates that didn't match (before: clone then check; after: check then clone)

Also removed pointless unnecessary work in `print_environment` (code that was replaced but then not deleted; kinda surprised clippy doesn't warn about pointless `sort` on a vector that'll never actually be used).