### PR TITLE
Separate env typechecker

### DIFF
--- a/numbat/src/interpreter/mod.rs
+++ b/numbat/src/interpreter/mod.rs
@@ -209,8 +209,9 @@ mod tests {
             .transform(statements)
             .expect("No name resolution errors for inputs in this test suite");
         let mut typechecker = crate::typechecker::TypeChecker::default();
+        let mut env = crate::Environment::default();
         let statements_typechecked = typechecker
-            .check(&statements_transformed)
+            .check(&mut env, &statements_transformed)
             .expect("No type check errors for inputs in this test suite");
         BytecodeInterpreter::new().interpret_statements(
             &mut InterpreterSettings::default(),

--- a/numbat/src/interpreter/mod.rs
+++ b/numbat/src/interpreter/mod.rs
@@ -209,9 +209,9 @@ mod tests {
             .transform(statements)
             .expect("No name resolution errors for inputs in this test suite");
         let mut typechecker = crate::typechecker::TypeChecker::default();
-        let mut env = crate::Environment::default();
+
         let statements_typechecked = typechecker
-            .check(&mut env, &statements_transformed)
+            .check(&mut crate::Environment::default(), &statements_transformed)
             .expect("No type check errors for inputs in this test suite");
         BytecodeInterpreter::new().interpret_statements(
             &mut InterpreterSettings::default(),

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -599,6 +599,7 @@ impl Context {
         let transformed_statements = result?;
 
         let typechecker_old = self.typechecker.clone();
+        let env_old = self.env.clone();
 
         let result = self
             .typechecker
@@ -618,6 +619,7 @@ impl Context {
             //
             self.prefix_transformer = prefix_transformer_old.clone();
             self.typechecker = typechecker_old.clone();
+            self.env = env_old.clone();
 
             if self.load_currency_module_on_demand {
                 if let Err(NumbatError::TypeCheckError(TypeCheckError::UnknownIdentifier(
@@ -838,6 +840,7 @@ impl Context {
             //
             self.prefix_transformer = prefix_transformer_old;
             self.typechecker = typechecker_old;
+            self.env = env_old;
             self.interpreter = interpreter_old;
         }
 

--- a/numbat/src/typechecker/environment.rs
+++ b/numbat/src/typechecker/environment.rs
@@ -1,4 +1,4 @@
-use crate::ast::{TypeAnnotation, TypeParameterBound};
+use crate::ast::{self, TypeAnnotation, TypeParameterBound};
 use crate::dimension::DimensionRegistry;
 use crate::pretty_print::PrettyPrint;
 use crate::span::Span;
@@ -164,6 +164,22 @@ impl Environment {
             Some(IdentifierKind::Function(signature, metadata)) => Some((signature, metadata)),
             _ => None,
         }
+    }
+
+    pub(crate) fn get_proper_function_reference<'a>(
+        &self,
+        expr: &ast::Expression<'a>,
+    ) -> Option<(&'a str, &FunctionSignature)> {
+        match expr {
+            ast::Expression::Identifier(_, name) => self
+                .get_function_info(name)
+                .map(|(signature, _)| (*name, signature)),
+            _ => None,
+        }
+    }
+
+    pub fn lookup_function(&self, name: &str) -> Option<(&FunctionSignature, &FunctionMetadata)> {
+        self.get_function_info(name)
     }
 
     pub(crate) fn generalize_types(&mut self, dtype_variables: &[TypeVariable]) {

--- a/numbat/src/typechecker/tests/mod.rs
+++ b/numbat/src/typechecker/tests/mod.rs
@@ -5,7 +5,7 @@ use crate::parser::parse;
 use crate::prefix_transformer::Transformer;
 use crate::typechecker::{Result, TypeCheckError};
 use crate::typed_ast::{self, DType};
-use crate::Statement;
+use crate::{Environment, Statement};
 
 use super::type_scheme::TypeScheme;
 use super::TypeChecker;
@@ -50,6 +50,8 @@ fn type_c() -> DType {
 }
 
 fn run_typecheck(input: &str) -> Result<typed_ast::Statement<'_>> {
+    let mut env = Environment::default();
+
     let statements = parse(TEST_PRELUDE, 0)
         .expect("No parse errors for inputs in this test suite")
         .into_iter()
@@ -60,7 +62,7 @@ fn run_typecheck(input: &str) -> Result<typed_ast::Statement<'_>> {
         .map_err(|err| Box::new(err.into()))?;
 
     TypeChecker::default()
-        .check(&transformed_statements)
+        .check(&mut env, &transformed_statements)
         .map(|mut statements_checked| statements_checked.pop().unwrap())
 }
 

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -1370,6 +1370,7 @@ mod tests {
     use crate::ast::ReplaceSpans;
     use crate::markup::{Formatter, PlainTextFormatter};
     use crate::prefix_transformer::Transformer;
+    use crate::Environment;
 
     fn parse(code: &str) -> Statement {
         let statements = crate::parser::parse(
@@ -1436,8 +1437,10 @@ mod tests {
         let mut transformer = Transformer::new();
         let transformed_statements = transformer.transform(statements).unwrap().replace_spans();
 
+        let mut env = Environment::default();
+
         crate::typechecker::TypeChecker::default()
-            .check(&transformed_statements)
+            .check(&mut env, &transformed_statements)
             .unwrap()
             .last()
             .unwrap()


### PR DESCRIPTION
This allows not cloning function signatures during elaboration (and I haven't checked, but may obviate other clones as well)