### PR TITLE
Add (unit) list utillity functions

### DIFF
--- a/book/src/list-functions-lists.md
+++ b/book/src/list-functions-lists.md
@@ -300,6 +300,45 @@ fn sort<D: Dim>(xs: List<D>) -> List<D>
 
 </details>
 
+### `contains`
+looks for an element in a list. Returns true if the element is in the list.
+
+```nbt
+fn contains<A>(x: A, xs: List<A>) -> Bool
+```
+
+<details>
+<summary>Examples</summary>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%5B3%2C%202%2C%207%2C%208%2C%20%2D4%2C%200%2C%20%2D5%5D%20%7C%3E%20contains%280%29')""></button></div><code class="language-nbt hljs numbat">>>> [3, 2, 7, 8, -4, 0, -5] |> contains(0)
+
+    = true    [Bool]
+</code></pre>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%5B3%2C%202%2C%207%2C%208%2C%20%2D4%2C%200%2C%20%2D5%5D%20%7C%3E%20contains%281%29')""></button></div><code class="language-nbt hljs numbat">>>> [3, 2, 7, 8, -4, 0, -5] |> contains(1)
+
+    = false    [Bool]
+</code></pre>
+
+</details>
+
+### `unique`
+Remove duplicates, ensuring every value is unique.
+
+```nbt
+fn unique<A>(xs: List<A>) -> List<A>
+```
+
+<details>
+<summary>Examples</summary>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=unique%28%5B1%2C%202%2C%202%2C%203%2C%203%2C%203%5D%29')""></button></div><code class="language-nbt hljs numbat">>>> unique([1, 2, 2, 3, 3, 3])
+
+    = [1, 2, 3]    [List<Scalar>]
+</code></pre>
+
+</details>
+
 ### `intersperse`
 Add an element between each pair of elements in a list.
 

--- a/book/src/list-functions-lists.md
+++ b/book/src/list-functions-lists.md
@@ -284,7 +284,7 @@ sort_by_key(last_digit, [701, 313, 9999, 4])
 </details>
 
 ### `sort`
-Sort a list of quantities.
+Sort a list of quantities in ascending order.
 
 ```nbt
 fn sort<D: Dim>(xs: List<D>) -> List<D>
@@ -296,6 +296,23 @@ fn sort<D: Dim>(xs: List<D>) -> List<D>
 <pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=sort%28%5B3%2C%202%2C%207%2C%208%2C%20%2D4%2C%200%2C%20%2D5%5D%29')""></button></div><code class="language-nbt hljs numbat">>>> sort([3, 2, 7, 8, -4, 0, -5])
 
     = [-5, -4, 0, 2, 3, 7, 8]    [List<Scalar>]
+</code></pre>
+
+</details>
+
+### `sort_descending`
+Sort a list of quantities in descending order.
+
+```nbt
+fn sort_descending<D: Dim>(xs: List<D>) -> List<D>
+```
+
+<details>
+<summary>Examples</summary>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=sort%5Fdescending%28%5B3%2C%202%2C%207%2C%208%2C%20%2D4%2C%200%2C%20%2D5%5D%29')""></button></div><code class="language-nbt hljs numbat">>>> sort_descending([3, 2, 7, 8, -4, 0, -5])
+
+    = [8, 7, 3, 2, 0, -4, -5]    [List<Scalar>]
 </code></pre>
 
 </details>

--- a/book/src/list-functions-lists.md
+++ b/book/src/list-functions-lists.md
@@ -300,25 +300,8 @@ fn sort<D: Dim>(xs: List<D>) -> List<D>
 
 </details>
 
-### `sort_descending`
-Sort a list of quantities in descending order.
-
-```nbt
-fn sort_descending<D: Dim>(xs: List<D>) -> List<D>
-```
-
-<details>
-<summary>Examples</summary>
-
-<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=sort%5Fdescending%28%5B3%2C%202%2C%207%2C%208%2C%20%2D4%2C%200%2C%20%2D5%5D%29')""></button></div><code class="language-nbt hljs numbat">>>> sort_descending([3, 2, 7, 8, -4, 0, -5])
-
-    = [8, 7, 3, 2, 0, -4, -5]    [List<Scalar>]
-</code></pre>
-
-</details>
-
 ### `contains`
-looks for an element in a list. Returns true if the element is in the list.
+Returns true if the element `x` is in the list `xs`.
 
 ```nbt
 fn contains<A>(x: A, xs: List<A>) -> Bool
@@ -340,7 +323,7 @@ fn contains<A>(x: A, xs: List<A>) -> Bool
 </details>
 
 ### `unique`
-Remove duplicates, ensuring every value is unique.
+Remove duplicates from a given list.
 
 ```nbt
 fn unique<A>(xs: List<A>) -> List<A>

--- a/book/src/list-functions-other.md
+++ b/book/src/list-functions-other.md
@@ -107,22 +107,22 @@ fn is_zero<D: Dim>(value: D) -> Bool
 
 </details>
 
-### `is_not_zero`
-Returns true if the input is anything other than 0 (zero).
+### `is_nonzero`
+Returns true unless the input is 0 (zero).
 
 ```nbt
-fn is_not_zero<D: Dim>(value: D) -> Bool
+fn is_nonzero<D: Dim>(value: D) -> Bool
 ```
 
 <details>
 <summary>Examples</summary>
 
-<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnot%5Fzero%2837%29')""></button></div><code class="language-nbt hljs numbat">>>> is_not_zero(37)
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnonzero%2837%29')""></button></div><code class="language-nbt hljs numbat">>>> is_nonzero(37)
 
     = true    [Bool]
 </code></pre>
 
-<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnot%5Fzero%280%29')""></button></div><code class="language-nbt hljs numbat">>>> is_not_zero(0)
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnonzero%280%29')""></button></div><code class="language-nbt hljs numbat">>>> is_nonzero(0)
 
     = false    [Bool]
 </code></pre>

--- a/book/src/list-functions-other.md
+++ b/book/src/list-functions-other.md
@@ -85,6 +85,50 @@ fn is_finite<T: Dim>(n: T) -> Bool
 
 </details>
 
+### `is_zero`
+Returns true if the input is 0 (zero).
+
+```nbt
+fn is_zero<D: Dim>(value: D) -> Bool
+```
+
+<details>
+<summary>Examples</summary>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fzero%2837%29')""></button></div><code class="language-nbt hljs numbat">>>> is_zero(37)
+
+    = false    [Bool]
+</code></pre>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fzero%280%29')""></button></div><code class="language-nbt hljs numbat">>>> is_zero(0)
+
+    = true    [Bool]
+</code></pre>
+
+</details>
+
+### `is_not_zero`
+Returns true if the input is anything other than 0 (zero).
+
+```nbt
+fn is_not_zero<D: Dim>(value: D) -> Bool
+```
+
+<details>
+<summary>Examples</summary>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnot%5Fzero%2837%29')""></button></div><code class="language-nbt hljs numbat">>>> is_not_zero(37)
+
+    = true    [Bool]
+</code></pre>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=is%5Fnot%5Fzero%280%29')""></button></div><code class="language-nbt hljs numbat">>>> is_not_zero(0)
+
+    = false    [Bool]
+</code></pre>
+
+</details>
+
 ## Quantities
 
 Defined in: `core::quantities`

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -87,7 +87,31 @@ assert_eq(sort_descending([3, 2, 1]), [3, 2, 1])
 
 assert_eq(sort_descending([3, 2, 7, 8, -4, 0, -5]), (reverse(sort([3, 2, 7, 8, -4, 0, -5]))))
 
+# contains:
+assert_eq(contains(1, []), false)
 
+assert(contains(1, [1]))
+
+assert(contains(1, [1, 2, 3]))
+assert(contains(1, [3, 2, 1]))
+assert(contains(1, [3, 1, 2]))
+
+assert_eq(contains(10, [1, 2, 3]), false)
+
+assert(contains("1", ["1", "2", "3"]))
+
+# unique:
+assert_eq(unique([]), [])
+
+assert_eq(unique([1, 2, 3]), [1, 2, 3])
+
+assert_eq(unique([1, 2, 2, 3, 3, 3]), [1, 2, 3])
+assert_eq(unique([3, 3, 3, 2, 2, 1]), [3, 2, 1])
+assert_eq(unique([1, 3, 2, 3, 2, 3]), [1, 3, 2])
+
+assert_eq(unique([1, 3, 2, 3, 2, 3]), unique(unique([1, 3, 2, 3, 2, 3,])))
+
+# intersperse:
 assert_eq(intersperse(0, []), [])
 assert_eq(intersperse(0, [1]), [1])
 assert_eq(intersperse(0, [1, 2, 3]), [1, 0, 2, 0, 3])

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -70,6 +70,24 @@ fn negate(x) = -x
 assert_eq(sort_by_key(negate, [1, 2, 3]), [3, 2, 1])
 assert_eq(sort_by_key(str_length, ["aa", "", "aaaa", "aaa"]), ["", "aa", "aaa", "aaaa"])
 
+# sort_descending:
+assert_eq(sort_descending([]), [])
+
+assert_eq(sort_descending([1]), [1])
+
+assert_eq(sort_descending([1, 2]), [2, 1])
+assert_eq(sort_descending([2, 1]), [2, 1])
+
+assert_eq(sort_descending([1, 2, 3]), [3, 2, 1])
+assert_eq(sort_descending([1, 3, 2]), [3, 2, 1])
+assert_eq(sort_descending([2, 1, 3]), [3, 2, 1])
+assert_eq(sort_descending([2, 3, 1]), [3, 2, 1])
+assert_eq(sort_descending([3, 1, 2]), [3, 2, 1])
+assert_eq(sort_descending([3, 2, 1]), [3, 2, 1])
+
+assert_eq(sort_descending([3, 2, 7, 8, -4, 0, -5]), (reverse(sort([3, 2, 7, 8, -4, 0, -5]))))
+
+
 assert_eq(intersperse(0, []), [])
 assert_eq(intersperse(0, [1]), [1])
 assert_eq(intersperse(0, [1, 2, 3]), [1, 0, 2, 0, 3])

--- a/examples/tests/lists.nbt
+++ b/examples/tests/lists.nbt
@@ -70,33 +70,14 @@ fn negate(x) = -x
 assert_eq(sort_by_key(negate, [1, 2, 3]), [3, 2, 1])
 assert_eq(sort_by_key(str_length, ["aa", "", "aaaa", "aaa"]), ["", "aa", "aaa", "aaaa"])
 
-# sort_descending:
-assert_eq(sort_descending([]), [])
-
-assert_eq(sort_descending([1]), [1])
-
-assert_eq(sort_descending([1, 2]), [2, 1])
-assert_eq(sort_descending([2, 1]), [2, 1])
-
-assert_eq(sort_descending([1, 2, 3]), [3, 2, 1])
-assert_eq(sort_descending([1, 3, 2]), [3, 2, 1])
-assert_eq(sort_descending([2, 1, 3]), [3, 2, 1])
-assert_eq(sort_descending([2, 3, 1]), [3, 2, 1])
-assert_eq(sort_descending([3, 1, 2]), [3, 2, 1])
-assert_eq(sort_descending([3, 2, 1]), [3, 2, 1])
-
-assert_eq(sort_descending([3, 2, 7, 8, -4, 0, -5]), (reverse(sort([3, 2, 7, 8, -4, 0, -5]))))
-
 # contains:
-assert_eq(contains(1, []), false)
-
 assert(contains(1, [1]))
 
 assert(contains(1, [1, 2, 3]))
 assert(contains(1, [3, 2, 1]))
 assert(contains(1, [3, 1, 2]))
 
-assert_eq(contains(10, [1, 2, 3]), false)
+assert(!contains(10, [1, 2, 3]))
 
 assert(contains("1", ["1", "2", "3"]))
 

--- a/examples/tests/mixed_units.nbt
+++ b/examples/tests/mixed_units.nbt
@@ -47,17 +47,3 @@ let test2 = 12 degree + 34 arcminute + 5 arcsec
 assert_eq(test2 |> unit_list([degree]) |> head, test2)
 assert_eq(test2 |> unit_list([degree, arcmin]) |> sum, test2)
 assert_eq(test2 |> unit_list([degree, arcmin, arcsec]) |> sum, test2)
-
-
-# round_mixed_in
-
-assert_eq(round_mixed_in(seconds, [1 h, 29 min, 30 sec]), [1 h, 29 min, 30 sec])
-assert_eq(round_mixed_in(minutes, [1 h, 29 min, 30 sec]), [1 h, 30 min,  0 sec])
-assert_eq(round_mixed_in(hours,   [1 h, 29 min, 30 sec]), [1 h,  0 min,  0 sec])
-
-assert_eq(round_mixed_in(mm,   [1 m, 29 cm]), [1 m, 29 cm, 0 mm])
-
-assert_eq(round_mixed_in(m,   round_mixed_in(cm, [1 m, 49 cm, 50 mm])), [2 m,  0 cm])
-
-let units = [m, cm, mm]
-assert_eq(unit_list(units, 123456 mm) |> round_mixed_in(cm), round_in(cm, 123456 mm) |> unit_list(units))

--- a/examples/tests/mixed_units.nbt
+++ b/examples/tests/mixed_units.nbt
@@ -49,3 +49,15 @@ assert_eq(test2 |> unit_list([degree, arcmin]) |> sum, test2)
 assert_eq(test2 |> unit_list([degree, arcmin, arcsec]) |> sum, test2)
 
 
+# round_mixed_in
+
+assert_eq(round_mixed_in(seconds, [1 h, 29 min, 30 sec]), [1 h, 29 min, 30 sec])
+assert_eq(round_mixed_in(minutes, [1 h, 29 min, 30 sec]), [1 h, 30 min,  0 sec])
+assert_eq(round_mixed_in(hours,   [1 h, 29 min, 30 sec]), [1 h,  0 min,  0 sec])
+
+assert_eq(round_mixed_in(mm,   [1 m, 29 cm]), [1 m, 29 cm, 0 mm])
+
+assert_eq(round_mixed_in(m,   round_mixed_in(cm, [1 m, 49 cm, 50 mm])), [2 m,  0 cm])
+
+let units = [m, cm, mm]
+assert_eq(unit_list(units, 123456 mm) |> round_mixed_in(cm), round_in(cm, 123456 mm) |> unit_list(units))

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -114,9 +114,15 @@ fn sort_by_key<A, D: Dim>(key: Fn[(A) -> D], xs: List<A>) -> List<A> =
                   sort_by_key(key, drop(floor(len(xs) / 2), xs)),
                   key)
 
-@description("Sort a list of quantities")
+@description("Sort a list of quantities in ascending order")
 @example("sort([3, 2, 7, 8, -4, 0, -5])")
 fn sort<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(id, xs)
+
+fn _negate<D: Dim>(x: D) = -x
+
+@description("Sort a list of quantities in descending order")
+@example("sort([3, 2, 7, 8, -4, 0, -5])")
+fn sort_descending<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(_negate, xs)
 
 @description("looks for an element in a list. Returns true if the element is in the list.")
 @example("[3, 2, 7, 8, -4, 0, -5] |> contains(0)")

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -118,6 +118,29 @@ fn sort_by_key<A, D: Dim>(key: Fn[(A) -> D], xs: List<A>) -> List<A> =
 @example("sort([3, 2, 7, 8, -4, 0, -5])")
 fn sort<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(id, xs)
 
+@description("looks for an element in a list. Returns true if the element is in the list.")
+@example("[3, 2, 7, 8, -4, 0, -5] |> contains(0)")
+@example("[3, 2, 7, 8, -4, 0, -5] |> contains(1)")
+fn contains<A>(x: A, xs: List<A>) -> Bool = 
+  if is_empty(xs)
+    then false
+    else if x == head(xs)
+      then true
+      else contains(x, tail(xs))
+
+fn _unique<A>(acc: List<A>, xs: List<A>) -> List<A> = 
+  if is_empty(xs)
+    then acc
+    else if is_empty(acc)
+      then _unique([head(xs)], tail(xs))
+      else if (acc |> contains(head(xs)))
+        then _unique(acc, tail(xs))
+        else _unique((cons_end(head(xs), acc)), tail(xs))
+
+@description("Remove duplicates, ensuring every value is unique")
+@example("unique([1, 2, 2, 3, 3, 3])")
+fn unique<A>(xs: List<A>) -> List<A> = xs |> _unique([])
+
 @description("Add an element between each pair of elements in a list")
 @example("intersperse(0, [1, 1, 1, 1])")
 fn intersperse<A>(sep: A, xs: List<A>) -> List<A> =

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -121,7 +121,7 @@ fn sort<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(id, xs)
 fn _negate<D: Dim>(x: D) = -x
 
 @description("Sort a list of quantities in descending order")
-@example("sort([3, 2, 7, 8, -4, 0, -5])")
+@example("sort_descending([3, 2, 7, 8, -4, 0, -5])")
 fn sort_descending<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(_negate, xs)
 
 @description("looks for an element in a list. Returns true if the element is in the list.")

--- a/numbat/modules/core/lists.nbt
+++ b/numbat/modules/core/lists.nbt
@@ -118,13 +118,7 @@ fn sort_by_key<A, D: Dim>(key: Fn[(A) -> D], xs: List<A>) -> List<A> =
 @example("sort([3, 2, 7, 8, -4, 0, -5])")
 fn sort<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(id, xs)
 
-fn _negate<D: Dim>(x: D) = -x
-
-@description("Sort a list of quantities in descending order")
-@example("sort_descending([3, 2, 7, 8, -4, 0, -5])")
-fn sort_descending<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(_negate, xs)
-
-@description("looks for an element in a list. Returns true if the element is in the list.")
+@description("Returns true if the element `x` is in the list `xs`.")
 @example("[3, 2, 7, 8, -4, 0, -5] |> contains(0)")
 @example("[3, 2, 7, 8, -4, 0, -5] |> contains(1)")
 fn contains<A>(x: A, xs: List<A>) -> Bool = 
@@ -143,7 +137,7 @@ fn _unique<A>(acc: List<A>, xs: List<A>) -> List<A> =
         then _unique(acc, tail(xs))
         else _unique((cons_end(head(xs), acc)), tail(xs))
 
-@description("Remove duplicates, ensuring every value is unique")
+@description("Remove duplicates from a given list.")
 @example("unique([1, 2, 2, 3, 3, 3])")
 fn unique<A>(xs: List<A>) -> List<A> = xs |> _unique([])
 

--- a/numbat/modules/core/mixed_units.nbt
+++ b/numbat/modules/core/mixed_units.nbt
@@ -18,13 +18,10 @@ fn _mixed_unit_list<D: Dim>(val: D, units: List<D>, acc: List<D>) -> List<D> =
       then (val |> trunc_in(head(units)))
       else error("Units list cannot be empty")
   
+fn _negate<D: Dim>(x: D) = -x
 
-fn _clean_units<D: Dim>(units: List<D>) -> List<D> = units |> unique() |> sort_descending()
+fn _sort_descending<D: Dim>(xs: List<D>) -> List<D> = sort_by_key(_negate, xs)
+
+fn _clean_units<D: Dim>(units: List<D>) -> List<D> = units |> unique() |> _sort_descending()
 
 fn _unit_list<D: Dim>(units: List<D>, value: D) -> List<D> = _mixed_unit_list(value, _clean_units(units), [])
-
-@description("Round a mixed unit number to the nearest multiple of `base`.")
-@example("[0 days, 12 hours, 0 minutes, 30 seconds] |> round_mixed_in(minutes)")
-@example("[0 days, 12 hours, 29 minutes, 30 seconds] |> round_mixed_in(hours)")
-fn round_mixed_in<D: Dim>(base: D, value: List<D>) -> List<D> = value |> sum |> round_in(base) |> _unit_list(units)
-  where units = value |> filter(is_not_zero) |> map(unit_of) |> cons(base)

--- a/numbat/modules/core/mixed_units.nbt
+++ b/numbat/modules/core/mixed_units.nbt
@@ -19,7 +19,7 @@ fn _mixed_unit_list<D: Dim>(val: D, units: List<D>, acc: List<D>) -> List<D> =
       else error("Units list cannot be empty")
   
 
-fn _clean_units<D: Dim>(units: List<D>) -> List<D> = units |> unique() |> sort() |> reverse()
+fn _clean_units<D: Dim>(units: List<D>) -> List<D> = units |> unique() |> sort_descending()
 
 fn _unit_list<D: Dim>(units: List<D>, value: D) -> List<D> = _mixed_unit_list(value, _clean_units(units), [])
 

--- a/numbat/modules/core/mixed_units.nbt
+++ b/numbat/modules/core/mixed_units.nbt
@@ -1,5 +1,7 @@
 use core::strings
 use core::lists
+use core::numbers
+use core::quantities
 
 # Helper functions for mixed-unit conversions. See units::mixed for more.
 
@@ -15,3 +17,14 @@ fn _mixed_unit_list<D: Dim>(val: D, units: List<D>, acc: List<D>) -> List<D> =
     if (len(units) > 0)
       then (val |> trunc_in(head(units)))
       else error("Units list cannot be empty")
+  
+
+fn _clean_units<D: Dim>(units: List<D>) -> List<D> = units |> unique() |> sort() |> reverse()
+
+fn _unit_list<D: Dim>(units: List<D>, value: D) -> List<D> = _mixed_unit_list(value, _clean_units(units), [])
+
+@description("Round a mixed unit number to the nearest multiple of `base`.")
+@example("[0 days, 12 hours, 0 minutes, 30 seconds] |> round_mixed_in(minutes)")
+@example("[0 days, 12 hours, 29 minutes, 30 seconds] |> round_mixed_in(hours)")
+fn round_mixed_in<D: Dim>(base: D, value: List<D>) -> List<D> = value |> sum |> round_in(base) |> _unit_list(units)
+  where units = value |> filter(is_not_zero) |> map(unit_of) |> cons(base)

--- a/numbat/modules/core/numbers.nbt
+++ b/numbat/modules/core/numbers.nbt
@@ -20,7 +20,7 @@ fn is_finite<T: Dim>(n: T) -> Bool = !is_nan(n) && !is_infinite(n)
 @example("is_zero(0)")
 fn is_zero<D: Dim>(value: D) -> Bool = value == 0
 
-@description("Returns true if the input is anything other than 0 (zero).")
-@example("is_not_zero(37)")
-@example("is_not_zero(0)")
-fn is_not_zero<D: Dim>(value: D) -> Bool = !is_zero(value)
+@description("Returns true unless the input is 0 (zero).")
+@example("is_nonzero(37)")
+@example("is_nonzero(0)")
+fn is_nonzero<D: Dim>(value: D) -> Bool = !is_zero(value)

--- a/numbat/modules/core/numbers.nbt
+++ b/numbat/modules/core/numbers.nbt
@@ -14,3 +14,13 @@ fn is_infinite<T: Dim>(n: T) -> Bool
 @example("is_finite(37)")
 @example("is_finite(-inf)")
 fn is_finite<T: Dim>(n: T) -> Bool = !is_nan(n) && !is_infinite(n)
+
+@description("Returns true if the input is 0 (zero).")
+@example("is_zero(37)")
+@example("is_zero(0)")
+fn is_zero<D: Dim>(value: D) -> Bool = value == 0
+
+@description("Returns true if the input is anything other than 0 (zero).")
+@example("is_not_zero(37)")
+@example("is_not_zero(0)")
+fn is_not_zero<D: Dim>(value: D) -> Bool = !is_zero(value)

--- a/numbat/modules/prelude.nbt
+++ b/numbat/modules/prelude.nbt
@@ -7,6 +7,7 @@ use core::strings
 use core::error
 use core::random
 use core::numbers
+use core::mixed_units
 
 use math::constants
 use math::transcendental

--- a/numbat/modules/units/mixed.nbt
+++ b/numbat/modules/units/mixed.nbt
@@ -5,7 +5,7 @@ use units::imperial
 @name("Unit list")
 @description("Convert a value to a mixed representation using the provided units.")
 @example("5500 m |> unit_list([miles, yards, feet, inches])")
-fn unit_list<D: Dim>(units: List<D>, value: D) -> List<D> = _mixed_unit_list(value, units, [])
+fn unit_list<D: Dim>(units: List<D>, value: D) -> List<D> = _unit_list(units, value)
 
 @name("Degrees, minutes, seconds")
 @description("Convert an angle to a mixed degrees, (arc)minutes, and (arc)seconds representation. Also called sexagesimal degree notation.")
@@ -34,4 +34,3 @@ fn feet_and_inches(length: Length) -> List<Length> =
 @example("1 kg -> pounds_and_ounces")
 fn pounds_and_ounces(mass: Mass) -> List<Mass> =
   unit_list([pound, ounce], mass)
-


### PR DESCRIPTION
I found I needed some more functions to work with lists and unit_lists's for my human implementation to be more reliable. This PR contains those added functions as I feel like those changes are important on their own.

I've added the following utility functions: 
- _core::list_
  - contains
  - unique
  - sort_descending
- _core::numbers_
  - is_zero
  - is_not_zero
- _core::mixed_units_
  - round_mixed_in

I also changed the implementation of unit_list slightly to ignore the order of units in the list (always sorted in largest to smallest unit) and to remove duplicates. I was uncertain if this was desirable, but as no other configuration of units make sense for unit_list, I feel like this is a reasonable change. 