### PR TITLE
Made `proper_function_call` static and moved `get_proper_function_reference` to `Environment` to prove to the compiler that mutable references don't overlap

### DIFF
--- a/numbat/src/typechecker/constraints.rs
+++ b/numbat/src/typechecker/constraints.rs
@@ -68,6 +68,14 @@ impl ConstraintSet {
         result
     }
 
+    pub(crate) fn add_equal_constraint(&mut self, lhs: &Type, rhs: &Type) -> TrivialResolution {
+        self.add(Constraint::Equal(lhs.clone(), rhs.clone()))
+    }
+
+    pub(crate) fn add_dtype_constraint(&mut self, type_: &Type) -> TrivialResolution {
+        self.add(Constraint::IsDType(type_.clone()))
+    }
+
     pub fn clear(&mut self) {
         self.constraints.clear();
     }

--- a/numbat/src/typechecker/environment.rs
+++ b/numbat/src/typechecker/environment.rs
@@ -183,6 +183,18 @@ impl Environment {
             }
         }
     }
+
+    pub(crate) fn get_proper_function_reference<'a>(
+        &self,
+        expr: &crate::ast::Expression<'a>,
+    ) -> Option<(&'a str, &FunctionSignature)> {
+        match expr {
+            crate::ast::Expression::Identifier(_, name) => self
+                .get_function_info(name)
+                .map(|(signature, _)| (*name, signature)),
+            _ => None,
+        }
+    }
 }
 
 impl ApplySubstitution for Environment {


### PR DESCRIPTION
Alternative implementation of #606