### PR TITLE
Replaced `Box<dyn Fn(Args) -> ...>` with `fn(Args) -> ...` in ffi functions

### DIFF
--- a/numbat/src/ffi/functions.rs
+++ b/numbat/src/ffi/functions.rs
@@ -27,7 +27,7 @@ pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
                     ForeignFunction {
                         name: $fn_name,
                         arity: $arity,
-                        callable: Callable::Function(Box::new($callable)),
+                        callable: Callable::Function($callable),
                     },
                 );
             };

--- a/numbat/src/ffi/mod.rs
+++ b/numbat/src/ffi/mod.rs
@@ -24,10 +24,8 @@ type Result<T> = std::result::Result<T, RuntimeError>;
 
 pub(crate) type Args = VecDeque<Value>;
 
-type BoxedFunction = Box<dyn Fn(Args) -> Result<Value> + Send + Sync>;
-
 pub(crate) enum Callable {
-    Function(BoxedFunction),
+    Function(fn(Args) -> Result<Value>),
     Procedure(fn(&mut ExecutionContext, Args, Vec<Span>) -> ControlFlow),
 }
 


### PR DESCRIPTION
`cargo bench` shows a consistent 3.5% improvement