### PR TITLE
Stop cloning the whole list of DType factor when we don't need to

### DIFF
--- a/numbat/src/typechecker/constraints.rs
+++ b/numbat/src/typechecker/constraints.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use compact_str::{format_compact, CompactString};
 
@@ -308,7 +308,7 @@ impl Constraint {
             Constraint::EqualScalar(d) if d == &DType::scalar() => Some(Satisfied::trivially()),
             Constraint::EqualScalar(dtype) => match dtype.split_first_factor() {
                 Some(((DTypeFactor::TVar(tv), k), rest)) => {
-                    let result = DType::from_factors(Rc::new(
+                    let result = DType::from_factors(Arc::new(
                         rest.iter().map(|(f, j)| (f.clone(), -j / k)).collect(),
                     ));
                     Some(Satisfied::with_substitution(Substitution::single(

--- a/numbat/src/typechecker/constraints.rs
+++ b/numbat/src/typechecker/constraints.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use compact_str::{format_compact, CompactString};
 
 use super::substitutions::{ApplySubstitution, Substitution, SubstitutionError};
@@ -306,9 +308,9 @@ impl Constraint {
             Constraint::EqualScalar(d) if d == &DType::scalar() => Some(Satisfied::trivially()),
             Constraint::EqualScalar(dtype) => match dtype.split_first_factor() {
                 Some(((DTypeFactor::TVar(tv), k), rest)) => {
-                    let result = DType::from_factors(
+                    let result = DType::from_factors(Rc::new(
                         rest.iter().map(|(f, j)| (f.clone(), -j / k)).collect(),
-                    );
+                    ));
                     Some(Satisfied::with_substitution(Substitution::single(
                         tv.clone(),
                         Type::Dimension(result),

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -14,7 +14,7 @@ pub mod type_scheme;
 
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::arithmetic::Exponent;
 use crate::ast::{
@@ -252,7 +252,7 @@ impl TypeChecker {
                     .into_factors();
 
                 // Replace BaseDimension("D") with TVar("D") for all type parameters
-                for (factor, _) in Rc::make_mut(&mut factors) {
+                for (factor, _) in Arc::make_mut(&mut factors) {
                     *factor = match factor {
                         DTypeFactor::BaseDimension(ref n)
                             if self

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -14,6 +14,7 @@ pub mod type_scheme;
 
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::rc::Rc;
 
 use crate::arithmetic::Exponent;
 use crate::ast::{
@@ -251,7 +252,7 @@ impl TypeChecker {
                     .into_factors();
 
                 // Replace BaseDimension("D") with TVar("D") for all type parameters
-                for (factor, _) in &mut factors {
+                for (factor, _) in Rc::make_mut(&mut factors) {
                     *factor = match factor {
                         DTypeFactor::BaseDimension(ref n)
                             if self

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use compact_str::{format_compact, CompactString, ToCompactString};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -42,7 +44,7 @@ type DtypeFactorPower = (DTypeFactor, Exponent);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DType {
     // Always in canonical form
-    factors: Vec<DtypeFactorPower>,
+    factors: Rc<Vec<DtypeFactorPower>>,
 }
 
 impl DType {
@@ -50,18 +52,18 @@ impl DType {
         &self.factors
     }
 
-    pub fn into_factors(self) -> Vec<DtypeFactorPower> {
+    pub fn into_factors(self) -> Rc<Vec<DtypeFactorPower>> {
         self.factors
     }
 
-    pub fn from_factors(factors: Vec<DtypeFactorPower>) -> DType {
+    pub fn from_factors(factors: Rc<Vec<DtypeFactorPower>>) -> DType {
         let mut dtype = DType { factors };
         dtype.canonicalize();
         dtype
     }
 
     pub fn scalar() -> DType {
-        DType::from_factors(vec![])
+        DType::from_factors(Rc::new(vec![]))
     }
 
     pub fn is_scalar(&self) -> bool {
@@ -100,11 +102,17 @@ impl DType {
     }
 
     pub fn from_type_variable(v: TypeVariable) -> DType {
-        DType::from_factors(vec![(DTypeFactor::TVar(v), Exponent::from_integer(1))])
+        DType::from_factors(Rc::new(vec![(
+            DTypeFactor::TVar(v),
+            Exponent::from_integer(1),
+        )]))
     }
 
     pub fn from_type_parameter(name: CompactString) -> DType {
-        DType::from_factors(vec![(DTypeFactor::TPar(name), Exponent::from_integer(1))])
+        DType::from_factors(Rc::new(vec![(
+            DTypeFactor::TPar(name),
+            Exponent::from_integer(1),
+        )]))
     }
 
     pub fn deconstruct_as_single_type_variable(&self) -> Option<TypeVariable> {
@@ -117,22 +125,22 @@ impl DType {
     }
 
     pub fn from_tgen(i: usize) -> DType {
-        DType::from_factors(vec![(
+        DType::from_factors(Rc::new(vec![(
             DTypeFactor::TVar(TypeVariable::Quantified(i)),
             Exponent::from_integer(1),
-        )])
+        )]))
     }
 
     pub fn base_dimension(name: &str) -> DType {
-        DType::from_factors(vec![(
+        DType::from_factors(Rc::new(vec![(
             DTypeFactor::BaseDimension(name.into()),
             Exponent::from_integer(1),
-        )])
+        )]))
     }
 
     fn canonicalize(&mut self) {
         // Move all type-variable and tgen factors to the front, sort by name
-        self.factors.sort_by(|(f1, _), (f2, _)| match (f1, f2) {
+        Rc::make_mut(&mut self.factors).sort_by(|(f1, _), (f2, _)| match (f1, f2) {
             (DTypeFactor::TVar(v1), DTypeFactor::TVar(v2)) => v1.cmp(v2),
             (DTypeFactor::TVar(_), _) => std::cmp::Ordering::Less,
 
@@ -146,7 +154,7 @@ impl DType {
 
         // Merge powers of equal factors:
         let mut new_factors = Vec::new();
-        for (f, n) in &self.factors {
+        for (f, n) in self.factors.iter() {
             if let Some((last_f, last_n)) = new_factors.last_mut() {
                 if f == last_f {
                     *last_n += n;
@@ -155,16 +163,16 @@ impl DType {
             }
             new_factors.push((f.clone(), *n));
         }
-        self.factors = new_factors;
 
         // Remove factors with zero exponent:
-        self.factors
-            .retain(|(_, n)| *n != Exponent::from_integer(0));
+        new_factors.retain(|(_, n)| *n != Exponent::from_integer(0));
+
+        self.factors = Rc::new(new_factors);
     }
 
     pub fn multiply(&self, other: &DType) -> DType {
         let mut factors = self.factors.clone();
-        factors.extend(other.factors.clone());
+        Rc::make_mut(&mut factors).extend(other.factors.iter().cloned());
         DType::from_factors(factors)
     }
 
@@ -174,7 +182,7 @@ impl DType {
             .iter()
             .map(|(f, m)| (f.clone(), n * m))
             .collect();
-        DType::from_factors(factors)
+        DType::from_factors(Rc::new(factors))
     }
 
     pub fn inverse(&self) -> DType {
@@ -218,7 +226,7 @@ impl DType {
     fn instantiate(&self, type_variables: &[TypeVariable]) -> DType {
         let mut factors = Vec::new();
 
-        for (f, n) in &self.factors {
+        for (f, n) in self.factors.iter() {
             match f {
                 DTypeFactor::TVar(TypeVariable::Quantified(i)) => {
                     factors.push((DTypeFactor::TVar(type_variables[*i].clone()), *n));
@@ -228,12 +236,12 @@ impl DType {
                 }
             }
         }
-        Self::from_factors(factors)
+        Self::from_factors(Rc::new(factors))
     }
 
     pub fn to_base_representation(&self) -> BaseRepresentation {
         let mut factors = vec![];
-        for (f, n) in &self.factors {
+        for (f, n) in self.factors.iter() {
             match f {
                 DTypeFactor::BaseDimension(name) => {
                     factors.push(BaseRepresentationFactor(name.clone(), *n));
@@ -271,7 +279,7 @@ impl From<BaseRepresentation> for DType {
             .into_iter()
             .map(|BaseRepresentationFactor(name, exp)| (DTypeFactor::BaseDimension(name), exp))
             .collect();
-        DType::from_factors(factors)
+        DType::from_factors(Rc::new(factors))
     }
 }
 
@@ -729,9 +737,9 @@ impl Statement<'_> {
         let mut exponents = vec![];
         self.for_all_type_schemes(&mut |type_: &mut TypeScheme| {
             if let Type::Dimension(dtype) = type_.unsafe_as_concrete() {
-                for (factor, exp) in dtype.factors {
-                    if factor == DTypeFactor::TVar(tv.clone()) {
-                        exponents.push(exp)
+                for (factor, exp) in dtype.factors.iter() {
+                    if factor == &DTypeFactor::TVar(tv.clone()) {
+                        exponents.push(*exp)
                     }
                 }
             }


### PR DESCRIPTION
Hey,

Improves https://github.com/sharkdp/numbat/issues/525

I was profiling numbat once again, and this time, I noticed we had a lot of allocation around the list of types, which we don’t seem to update that much afterward.
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/679608e9-a9e0-41b5-8e01-d213f1e35469">

This trace is a bit hard to read (and it’s reversed), but basically, I found out that we were spending around ~5% of the execution time cloning a vector contained in the `DType::factors`.
I suspected that most of these clones were not necessary, so I tried to remove them with an `Arc<Vec<_>>` and then clone the vec when we _actually_ needed to own it.

As expected, numbat got faster by more than 4% (because I guess we also avoid a lot of drops and other stuff):
```
% hyperfine './numbat-master -e "1 + 1"' './numbat-with-type-rc -e "1 + 1"' --warmup 15 --min-runs 100
Benchmark 1: ./numbat-master -e "1 + 1"
  Time (mean ± σ):      42.8 ms ±   1.7 ms    [User: 31.0 ms, System: 10.7 ms]
  Range (min … max):    39.9 ms …  46.1 ms    100 runs
 
Benchmark 2: ./numbat-with-type-rc -e "1 + 1"
  Time (mean ± σ):      37.8 ms ±   1.2 ms    [User: 26.6 ms, System: 10.4 ms]
  Range (min … max):    36.0 ms …  41.2 ms    100 runs
 
Summary
  ./numbat-with-type-rc -e "1 + 1" ran
    1.13 ± 0.06 times faster than ./numbat-master -e "1 + 1"
```

----

We could merge this PR as-is, but I’m not super satisfied with it:
- We may make the same mistake in the future without noticing
- I think the same issue happens to most types, but this one was simply the most expensive one
- Do we really need to use `Arc` everywhere? Maybe we should use ref + `Cow` directly (it'll become a lifetime hell, though)

What do you think? Should we try to push further in this direction or call it a day and get the ~13% straight away