### PR TITLE
Low hanging fruite lint do-over.

### DIFF
--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -36,27 +36,25 @@ pub enum BinaryOperator {
 
 impl PrettyPrint for BinaryOperator {
     fn pretty_print(&self) -> Markup {
-        use BinaryOperator::*;
-
         let operator = m::operator(match self {
-            Add => "+",
-            Sub => "-",
-            Mul => "×",
-            Div => "/",
-            Power => "^",
-            ConvertTo => "➞",
-            LessThan => "<",
-            GreaterThan => ">",
-            LessOrEqual => "≤",
-            GreaterOrEqual => "≥",
-            Equal => "==",
-            NotEqual => "≠",
-            LogicalAnd => "&&",
-            LogicalOr => "||",
+            BinaryOperator::Add => "+",
+            BinaryOperator::Sub => "-",
+            BinaryOperator::Mul => "×",
+            BinaryOperator::Div => "/",
+            BinaryOperator::Power => "^",
+            BinaryOperator::ConvertTo => "➞",
+            BinaryOperator::LessThan => "<",
+            BinaryOperator::GreaterThan => ">",
+            BinaryOperator::LessOrEqual => "≤",
+            BinaryOperator::GreaterOrEqual => "≥",
+            BinaryOperator::Equal => "==",
+            BinaryOperator::NotEqual => "≠",
+            BinaryOperator::LogicalAnd => "&&",
+            BinaryOperator::LogicalOr => "||",
         });
 
         match self {
-            Power => operator,
+            BinaryOperator::Power => operator,
             _ => m::space() + operator + m::space(),
         }
     }
@@ -111,9 +109,13 @@ pub enum Expression<'a> {
 impl Expression<'_> {
     pub fn full_span(&self) -> Span {
         match self {
-            Expression::Scalar(span, _) => *span,
-            Expression::Identifier(span, _) => *span,
-            Expression::UnitIdentifier(span, _, _, _) => *span,
+            Expression::Scalar(span, _)
+            | Expression::Identifier(span, _)
+            | Expression::UnitIdentifier(span, _, _, _)
+            | Expression::Boolean(span, _)
+            | Expression::String(span, _)
+            | Expression::List(span, _)
+            | Expression::TypedHole(span) => *span,
             Expression::UnaryOperator {
                 op: _,
                 expr,
@@ -132,15 +134,11 @@ impl Expression<'_> {
                 span
             }
             Expression::FunctionCall(_identifier_span, full_span, _, _) => *full_span,
-            Expression::Boolean(span, _) => *span,
             Expression::Condition(span_if, _, _, then_expr) => {
                 span_if.extend(&then_expr.full_span())
             }
-            Expression::String(span, _) => *span,
             Expression::InstantiateStruct { full_span, .. } => *full_span,
             Expression::AccessField(full_span, _ident_span, _, _) => *full_span,
-            Expression::List(span, _) => *span,
-            Expression::TypedHole(span) => *span,
         }
     }
 }
@@ -282,11 +280,11 @@ impl TypeAnnotation {
     pub fn full_span(&self) -> Span {
         match self {
             TypeAnnotation::TypeExpression(d) => d.full_span(),
-            TypeAnnotation::Bool(span) => *span,
-            TypeAnnotation::String(span) => *span,
-            TypeAnnotation::DateTime(span) => *span,
-            TypeAnnotation::Fn(span, _, _) => *span,
-            TypeAnnotation::List(span, _) => *span,
+            TypeAnnotation::Bool(span)
+            | TypeAnnotation::String(span)
+            | TypeAnnotation::DateTime(span)
+            | TypeAnnotation::Fn(span, _, _)
+            | TypeAnnotation::List(span, _) => *span,
         }
     }
 }
@@ -341,12 +339,9 @@ pub enum TypeExpression {
 impl TypeExpression {
     pub fn full_span(&self) -> Span {
         match self {
-            TypeExpression::Unity(s) => *s,
-            TypeExpression::TypeIdentifier(s, _) => *s,
-            TypeExpression::Multiply(span_op, lhs, rhs) => {
-                span_op.extend(&lhs.full_span()).extend(&rhs.full_span())
-            }
-            TypeExpression::Divide(span_op, lhs, rhs) => {
+            TypeExpression::Unity(s) | TypeExpression::TypeIdentifier(s, _) => *s,
+            TypeExpression::Multiply(span_op, lhs, rhs)
+            | TypeExpression::Divide(span_op, lhs, rhs) => {
                 span_op.extend(&lhs.full_span()).extend(&rhs.full_span())
             }
             TypeExpression::Power(span_op, lhs, span_exponent, _exp) => match span_op {

--- a/numbat/src/column_formatter.rs
+++ b/numbat/src/column_formatter.rs
@@ -59,7 +59,7 @@ impl ColumnFormatter {
                 let column_widths: Vec<usize> = (0..num_columns)
                     .map(|c| {
                         (0..num_rows)
-                            .map(|r| table[r][c].map(|e| e.width()).unwrap_or(0))
+                            .map(|r| table[r][c].map_or(0, |e| e.width()))
                             .max()
                             .unwrap_or(0)
                             + self.padding

--- a/numbat/src/command.rs
+++ b/numbat/src/command.rs
@@ -32,15 +32,14 @@ impl FromStr for CommandKind {
     type Err = ();
 
     fn from_str(word: &str) -> Result<Self, Self::Err> {
-        use CommandKind::*;
         Ok(match word {
-            "help" | "?" => Help,
-            "info" => Info,
-            "list" => List,
-            "clear" => Clear,
-            "save" => Save,
-            "quit" => Quit(QuitAlias::Quit),
-            "exit" => Quit(QuitAlias::Exit),
+            "help" | "?" => CommandKind::Help,
+            "info" => CommandKind::Info,
+            "list" => CommandKind::List,
+            "clear" => CommandKind::Clear,
+            "save" => CommandKind::Save,
+            "quit" => CommandKind::Quit(QuitAlias::Quit),
+            "exit" => CommandKind::Quit(QuitAlias::Exit),
             _ => return Err(()),
         })
     }

--- a/numbat/src/currency.rs
+++ b/numbat/src/currency.rs
@@ -25,7 +25,7 @@ impl ExchangeRatesCache {
                 ExchangeRates::Real(er) => er.get(currency),
                 ExchangeRates::TestRates => Some(&1.0),
             })
-            .cloned()
+            .copied()
     }
 
     pub fn set_from_xml(xml_content: &str) {

--- a/numbat/src/diagnostic.rs
+++ b/numbat/src/diagnostic.rs
@@ -130,12 +130,11 @@ impl ErrorDiagnostic for TypeCheckError {
                     .diagnostic_label(LabelStyle::Primary)
                     .with_message(format!("{type_}"))])
                 .with_notes(vec![inner_error]),
-            TypeCheckError::UnsupportedConstEvalExpression(span, _) => d.with_labels(vec![span
-                .diagnostic_label(LabelStyle::Primary)
-                .with_message(inner_error)]),
-            TypeCheckError::DivisionByZeroInConstEvalExpression(span) => d.with_labels(vec![span
-                .diagnostic_label(LabelStyle::Primary)
-                .with_message(inner_error)]),
+            TypeCheckError::UnsupportedConstEvalExpression(span, _)
+            | TypeCheckError::DivisionByZeroInConstEvalExpression(span) => d
+                .with_labels(vec![span
+                    .diagnostic_label(LabelStyle::Primary)
+                    .with_message(inner_error)]),
             TypeCheckError::RegistryError(re) => match re {
                 crate::registry::RegistryError::EntryExists(_) => d.with_notes(vec![inner_error]),
                 crate::registry::RegistryError::UnknownEntry(name, suggestion) => {
@@ -144,7 +143,7 @@ impl ErrorDiagnostic for TypeCheckError {
                         maybe_suggestion = if let Some(suggestion) = suggestion {
                             format!(" did you mean '{suggestion}'?")
                         } else {
-                            "".into()
+                            String::new()
                         }
                     )])
                 }

--- a/numbat/src/ffi/currency.rs
+++ b/numbat/src/ffi/currency.rs
@@ -1,4 +1,4 @@
-use super::macros::*;
+use super::macros::{arg, return_scalar, string_arg};
 use super::Args;
 use super::Result;
 use crate::currency::ExchangeRatesCache;

--- a/numbat/src/ffi/lookup.rs
+++ b/numbat/src/ffi/lookup.rs
@@ -96,48 +96,35 @@ pub fn _get_chemical_element_data_raw(mut args: Args) -> Result<Value> {
                         .group()
                         .map_or(f64::NAN, |g| g.group_number() as f64),
                 )),
-                Value::String(
-                    element
-                        .group()
-                        .map(|g| g.group_name().unwrap_or("unknown").into())
-                        .unwrap_or("unknown".into()),
-                ),
+                Value::String(element.group().map_or("unknown".into(), |g| {
+                    g.group_name().unwrap_or("unknown").into()
+                })),
                 Value::Quantity(Quantity::from_scalar(element.period() as f64)),
                 Value::Quantity(Quantity::from_scalar(
-                    element
-                        .melting_point()
-                        .map(|Kelvin(k)| k)
-                        .unwrap_or(f64::NAN),
+                    element.melting_point().map_or(f64::NAN, |Kelvin(k)| k),
                 )),
                 Value::Quantity(Quantity::from_scalar(
-                    element
-                        .boiling_point()
-                        .map(|Kelvin(k)| k)
-                        .unwrap_or(f64::NAN),
+                    element.boiling_point().map_or(f64::NAN, |Kelvin(k)| k),
                 )),
                 Value::Quantity(Quantity::from_scalar(
                     element
                         .density()
-                        .map(|GramPerCubicCentimeter(d)| d)
-                        .unwrap_or(f64::NAN),
+                        .map_or(f64::NAN, |GramPerCubicCentimeter(d)| d),
                 )),
                 Value::Quantity(Quantity::from_scalar(
                     element
                         .electron_affinity()
-                        .map(|Electronvolt(e)| e)
-                        .unwrap_or(f64::NAN),
+                        .map_or(f64::NAN, |Electronvolt(e)| e),
                 )),
                 Value::Quantity(Quantity::from_scalar(
                     element
                         .ionization_energy()
-                        .map(|Electronvolt(e)| e)
-                        .unwrap_or(f64::NAN),
+                        .map_or(f64::NAN, |Electronvolt(e)| e),
                 )),
                 Value::Quantity(Quantity::from_scalar(
                     element
                         .evaporation_heat()
-                        .map(|KiloJoulePerMole(e)| e)
-                        .unwrap_or(f64::NAN),
+                        .map_or(f64::NAN, |KiloJoulePerMole(e)| e),
                 )),
             ],
         ))

--- a/numbat/src/ffi/plot.rs
+++ b/numbat/src/ffi/plot.rs
@@ -19,7 +19,7 @@ fn line_plot(mut args: Args) -> Plot {
     let x_label = format!(
         "{x_label}{x_unit}",
         x_unit = if x_unit.is_empty() {
-            "".into()
+            String::new()
         } else {
             format!(" [{}]", x_unit)
         }
@@ -27,7 +27,7 @@ fn line_plot(mut args: Args) -> Plot {
     let y_label = format!(
         "{y_label}{y_unit}",
         y_unit = if y_unit.is_empty() {
-            "".into()
+            String::new()
         } else {
             format!(" [{}]", y_unit)
         }
@@ -72,7 +72,7 @@ fn bar_chart(mut args: Args) -> Plot {
     let value_label = format!(
         "{value_label}{value_unit}",
         value_unit = if value_unit.is_empty() {
-            "".into()
+            String::new()
         } else {
             format!(" [{}]", value_unit)
         }

--- a/numbat/src/ffi/procedures.rs
+++ b/numbat/src/ffi/procedures.rs
@@ -56,7 +56,7 @@ fn print(ctx: &mut ExecutionContext, mut args: Args, _: Vec<Span>) -> ControlFlo
     assert!(args.len() <= 1);
 
     if args.is_empty() {
-        (ctx.print_fn)(&crate::markup::text(""))
+        (ctx.print_fn)(&crate::markup::text(""));
     } else {
         match arg!(args) {
             Value::String(string) => (ctx.print_fn)(&crate::markup::text(string)), // print string without quotes

--- a/numbat/src/html_formatter.rs
+++ b/numbat/src/html_formatter.rs
@@ -26,10 +26,9 @@ impl Formatter for HtmlFormatter {
         FormattedString(_output_type, format_type, s): &FormattedString,
     ) -> CompactString {
         let css_class = match format_type {
-            FormatType::Whitespace => None,
+            FormatType::Whitespace | FormatType::Text => None,
             FormatType::Emphasized => Some("emphasized"),
             FormatType::Dimmed => Some("dimmed"),
-            FormatType::Text => None,
             FormatType::String => Some("string"),
             FormatType::Keyword => Some("keyword"),
             FormatType::Value => Some("value"),

--- a/numbat/src/interpreter/mod.rs
+++ b/numbat/src/interpreter/mod.rs
@@ -235,7 +235,7 @@ mod tests {
 
     #[track_caller]
     fn assert_evaluates_to_scalar(input: &str, expected: f64) {
-        assert_evaluates_to(input, Quantity::from_scalar(expected))
+        assert_evaluates_to(input, Quantity::from_scalar(expected));
     }
 
     #[track_caller]

--- a/numbat/src/list.rs
+++ b/numbat/src/list.rs
@@ -21,8 +21,8 @@ pub struct NumbatList<T> {
 impl<T> Default for NumbatList<T> {
     fn default() -> Self {
         Self {
-            alloc: Default::default(),
-            view: Default::default(),
+            alloc: Arc::default(),
+            view: None,
         }
     }
 }

--- a/numbat/src/markup.rs
+++ b/numbat/src/markup.rs
@@ -91,7 +91,7 @@ impl std::ops::Add for Markup {
 
 impl std::ops::AddAssign for Markup {
     fn add_assign(&mut self, rhs: Self) {
-        self.0.extend(rhs.0)
+        self.0.extend(rhs.0);
     }
 }
 

--- a/numbat/src/name_resolution.rs
+++ b/numbat/src/name_resolution.rs
@@ -8,7 +8,7 @@ pub const LAST_RESULT_IDENTIFIERS: &[&str] = &["ans", "_"];
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum NameResolutionError {
     #[error("Identifier is already in use{}: '{conflicting_identifier}'.",
-            if let Some(t) = .original_item_type { format!(" by the {t}") } else { "".to_owned() })]
+            if let Some(t) = .original_item_type { format!(" by the {t}") } else { String::new() })]
     IdentifierClash {
         conflicting_identifier: String,
         conflict_span: Span,
@@ -27,11 +27,11 @@ pub struct Namespace {
 
 impl Namespace {
     pub(crate) fn save(&mut self) {
-        self.seen.save()
+        self.seen.save();
     }
 
     pub(crate) fn restore(&mut self) {
-        self.seen.restore()
+        self.seen.restore();
     }
 
     pub fn add_identifier_allow_override(

--- a/numbat/src/number.rs
+++ b/numbat/src/number.rs
@@ -171,27 +171,27 @@ fn test_pretty_print() {
 
     assert_eq!(Number::from_f64(1234.).pretty_print(), "1234");
     assert_eq!(Number::from_f64(12345.).pretty_print(), "12345");
-    assert_eq!(Number::from_f64(123456.).pretty_print(), "123_456");
+    assert_eq!(Number::from_f64(123_456.).pretty_print(), "123_456");
     assert_eq!(
-        Number::from_f64(1234567890.).pretty_print(),
+        Number::from_f64(1_234_567_890.).pretty_print(),
         "1_234_567_890"
     );
     assert_eq!(
-        Number::from_f64(1234567890000000.).pretty_print(),
+        Number::from_f64(1_234_567_890_000_000.).pretty_print(),
         "1.23457e+15"
     );
 
-    assert_eq!(Number::from_f64(1.23456789).pretty_print(), "1.23457");
+    assert_eq!(Number::from_f64(1.234_567_89).pretty_print(), "1.23457");
     assert_eq!(
-        Number::from_f64(1234567890000.1).pretty_print(),
+        Number::from_f64(1_234_567_890_000.1).pretty_print(),
         "1.23457e+12"
     );
 
     assert_eq!(Number::from_f64(100.00001).pretty_print(), "100.0");
 
     assert_eq!(Number::from_f64(0.00001).pretty_print(), "0.00001");
-    assert_eq!(Number::from_f64(0.000001).pretty_print(), "0.000001");
-    assert_eq!(Number::from_f64(0.0000001).pretty_print(), "1.0e-7");
+    assert_eq!(Number::from_f64(0.000_001).pretty_print(), "0.000001");
+    assert_eq!(Number::from_f64(0.000_000_1).pretty_print(), "1.0e-7");
 }
 
 #[test]

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -358,7 +358,7 @@ impl<'a> Parser<'a> {
     fn recover_from_error(&mut self, tokens: &[Token]) {
         // Skip all the tokens until we encounter a newline or EoF.
         while !matches!(self.peek(tokens).kind, TokenKind::Newline | TokenKind::Eof) {
-            self.advance(tokens)
+            self.advance(tokens);
         }
     }
 
@@ -1379,7 +1379,7 @@ impl<'a> Parser<'a> {
                 let ident_span = self.last(tokens).unwrap().span;
                 let full_span = expr.full_span().extend(&ident_span);
 
-                expr = Expression::AccessField(full_span, ident_span, Box::new(expr), ident)
+                expr = Expression::AccessField(full_span, ident_span, Box::new(expr), ident);
             } else {
                 return Ok(expr);
             }
@@ -1626,16 +1626,12 @@ impl<'a> Parser<'a> {
                 ParseErrorKind::InlineProcedureUsage,
                 self.peek(tokens).span,
             ))
-        } else if self
-            .last(tokens)
-            .map(|t| {
-                matches!(
-                    t.kind,
-                    TokenKind::StringInterpolationStart | TokenKind::StringInterpolationMiddle
-                )
-            })
-            .unwrap_or(false)
-        {
+        } else if self.last(tokens).is_some_and(|t| {
+            matches!(
+                t.kind,
+                TokenKind::StringInterpolationStart | TokenKind::StringInterpolationMiddle
+            )
+        }) {
             let full_interpolation_end_span = self.peek(tokens).span;
             let closing_brace_span = full_interpolation_end_span
                 .start
@@ -2024,7 +2020,7 @@ fn strip_and_escape(s: &str) -> CompactString {
                     // We follow Python here, where an unknown escape sequence
                     // does not lead to an error, but is just passed through.
                     result.push('\\');
-                    result.push(c)
+                    result.push(c);
                 }
             }
             escaped = false;
@@ -2176,7 +2172,7 @@ mod tests {
     fn large_numbers() {
         parse_as_expression(
             &["1234567890000000", "1234567890000000.0"],
-            scalar!(1234567890000000.0),
+            scalar!(1_234_567_890_000_000.0),
         );
     }
 
@@ -2374,7 +2370,7 @@ mod tests {
             binop!(binop!(scalar!(5.0), Div, scalar!(3.0)), Mul, scalar!(2.0)),
         );
 
-        should_fail(&["3+*4", "3*/4", "(3+4", "3+4)", "3+(", "()", "(3+)4"])
+        should_fail(&["3+*4", "3*/4", "(3+4", "3+4)", "3+(", "()", "(3+)4"]);
     }
 
     #[test]

--- a/numbat/src/prefix.rs
+++ b/numbat/src/prefix.rs
@@ -88,12 +88,7 @@ impl Prefix {
     }
 
     pub fn is_none(&self) -> bool {
-        match self {
-            Prefix::Metric(0) => true,
-            Prefix::Binary(0) => true,
-            Prefix::Metric(_) => false,
-            Prefix::Binary(_) => false,
-        }
+        matches!(self, Prefix::Metric(0) | Prefix::Binary(0))
     }
 
     pub fn is_metric(&self) -> bool {

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -167,7 +167,7 @@ impl Transformer {
                 self.transform_expression(expr);
             }
             Statement::DefineVariable(define_variable) => {
-                self.transform_define_variable(define_variable)?
+                self.transform_define_variable(define_variable)?;
             }
             Statement::DefineFunction {
                 function_name_span,

--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -539,7 +539,7 @@ mod tests {
         }
         {
             let q = Quantity::new_f64(2.0, Unit::kilometer() / Unit::millimeter());
-            assert_eq!(q.full_simplify(), Quantity::from_scalar(2000000.0));
+            assert_eq!(q.full_simplify(), Quantity::from_scalar(2_000_000.0));
         }
         {
             let q = Quantity::new_f64(2.0, Unit::meter() / Unit::centimeter() * Unit::second());
@@ -563,7 +563,7 @@ mod tests {
         }
         {
             let q = Quantity::new_f64(2.0, Unit::kilometer() / Unit::millimeter());
-            assert_eq!(q.full_simplify(), Quantity::from_scalar(2000000.0));
+            assert_eq!(q.full_simplify(), Quantity::from_scalar(2_000_000.0));
         }
         {
             let q = Quantity::new_f64(1.0, Unit::meter() * Unit::gram() / Unit::centimeter());

--- a/numbat/src/resolver.rs
+++ b/numbat/src/resolver.rs
@@ -41,7 +41,7 @@ pub enum ResolverError {
     #[error("Unknown module '{1}'.")]
     UnknownModule(Span, ModulePath),
 
-    #[error("{}", .0.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("\n"))]
+    #[error("{}", .0.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n"))]
     ParseErrors(Vec<ParseError>),
 }
 
@@ -85,8 +85,7 @@ impl Resolver {
                 module_path = itertools::join(module_path.0.iter(), "::"),
                 path = path
                     .as_ref()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or("?".into()),
+                    .map_or("?".into(), |p| p.to_string_lossy().to_string()),
             ),
         };
 

--- a/numbat/src/session_history.rs
+++ b/numbat/src/session_history.rs
@@ -53,7 +53,7 @@ impl SessionHistory {
                 &item.input
             };
 
-            writeln!(w, "{input}").map_err(&err_fn)?
+            writeln!(w, "{input}").map_err(&err_fn)?;
         }
         Ok(())
     }
@@ -120,7 +120,7 @@ mod test {
         for (options, expected) in test_cases {
             let mut s = Cursor::new(Vec::<u8>::new());
             sh.save_inner(&mut s, options, |_| unreachable!()).unwrap();
-            assert_eq!(expected, String::from_utf8(s.into_inner()).unwrap())
+            assert_eq!(expected, String::from_utf8(s.into_inner()).unwrap());
         }
     }
 
@@ -135,6 +135,6 @@ mod test {
                     trim_lines: false
                 }
             )
-            .is_err())
+            .is_err());
     }
 }

--- a/numbat/src/typechecker/const_evaluation.rs
+++ b/numbat/src/typechecker/const_evaluation.rs
@@ -85,8 +85,8 @@ pub fn evaluate_const_expr(expr: &typed_ast::Expression) -> Result<Exponent> {
         }
         typed_ast::Expression::Identifier(..) => "variable",
         typed_ast::Expression::UnitIdentifier(..) => "unit identifier",
-        typed_ast::Expression::FunctionCall(_, _, _, _, _) => "function call",
-        typed_ast::Expression::CallableCall(_, _, _, _) => "function call",
+        typed_ast::Expression::FunctionCall(_, _, _, _, _)
+        | typed_ast::Expression::CallableCall(_, _, _, _) => "function call",
         typed_ast::Expression::Boolean(_, _) => "Boolean value",
         typed_ast::Expression::String(_, _) => "String",
         typed_ast::Expression::Condition(..) => "Conditional",

--- a/numbat/src/typechecker/environment.rs
+++ b/numbat/src/typechecker/environment.rs
@@ -86,8 +86,7 @@ pub enum IdentifierKind {
 impl IdentifierKind {
     fn get_type(&self) -> TypeScheme {
         match self {
-            IdentifierKind::Predefined(t) => t.clone(),
-            IdentifierKind::Normal(t, _, _) => t.clone(),
+            IdentifierKind::Predefined(t) | IdentifierKind::Normal(t, _, _) => t.clone(),
             IdentifierKind::Function(s, _) => s.fn_type.clone(),
         }
     }

--- a/numbat/src/typechecker/qualified_type.rs
+++ b/numbat/src/typechecker/qualified_type.rs
@@ -40,7 +40,7 @@ impl Bounds {
     pub fn is_dtype_bound(&self, tv: &TypeVariable) -> bool {
         self.0.iter().any(|b| match b {
             Bound::IsDim(Type::TVar(v)) => v == tv,
-            _ => false,
+            Bound::IsDim(_) => false,
         })
     }
 }

--- a/numbat/src/typechecker/substitutions.rs
+++ b/numbat/src/typechecker/substitutions.rs
@@ -69,9 +69,7 @@ impl ApplySubstitution for Type {
                 Ok(())
             }
             Type::Dimension(dtype) => dtype.apply(s),
-            Type::Boolean => Ok(()),
-            Type::String => Ok(()),
-            Type::DateTime => Ok(()),
+            Type::Boolean | Type::String | Type::DateTime => Ok(()),
             Type::Fn(param_types, return_type) => {
                 for param_type in param_types {
                     param_type.apply(s)?;
@@ -151,9 +149,10 @@ impl ApplySubstitution for StructInfo {
 impl ApplySubstitution for Expression<'_> {
     fn apply(&mut self, s: &Substitution) -> Result<(), SubstitutionError> {
         match self {
-            Expression::Scalar(_, _, type_) => type_.apply(s),
-            Expression::Identifier(_, _, type_) => type_.apply(s),
-            Expression::UnitIdentifier(_, _, _, _, type_) => type_.apply(s),
+            Expression::Scalar(_, _, type_)
+            | Expression::Identifier(_, _, type_)
+            | Expression::TypedHole(_, type_)
+            | Expression::UnitIdentifier(_, _, _, _, type_) => type_.apply(s),
             Expression::UnaryOperator(_, _, expr, type_) => {
                 expr.apply(s)?;
                 type_.apply(s)
@@ -181,13 +180,11 @@ impl ApplySubstitution for Expression<'_> {
                 }
                 return_type.apply(s)
             }
-            Expression::Boolean(_, _) => Ok(()),
             Expression::Condition(_, if_, then_, else_) => {
                 if_.apply(s)?;
                 then_.apply(s)?;
                 else_.apply(s)
             }
-            Expression::String(_, _) => Ok(()),
             Expression::InstantiateStruct(_, initializers, info) => {
                 for (_, expr) in initializers {
                     expr.apply(s)?;
@@ -205,7 +202,7 @@ impl ApplySubstitution for Expression<'_> {
                 }
                 element_type.apply(s)
             }
-            Expression::TypedHole(_, type_) => type_.apply(s),
+            Expression::Boolean(_, _) | Expression::String(_, _) => Ok(()),
         }
     }
 }

--- a/numbat/src/typechecker/type_scheme.rs
+++ b/numbat/src/typechecker/type_scheme.rs
@@ -147,7 +147,7 @@ impl TypeScheme {
     pub(crate) fn unsafe_as_concrete(&self) -> Type {
         match self {
             TypeScheme::Concrete(t) => t.clone(),
-            _ => unreachable!("Expected concrete type: {:#?}", self),
+            TypeScheme::Quantified(..) => unreachable!("Expected concrete type: {:#?}", self),
         }
     }
 

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -124,7 +124,7 @@ impl std::fmt::Display for Value {
                 "{} {{{}}}",
                 struct_info.name,
                 if values.is_empty() {
-                    "".to_owned()
+                    String::new()
                 } else {
                     format!(
                         " {} ",
@@ -142,7 +142,9 @@ impl std::fmt::Display for Value {
                 "[{}]",
                 elements
                     .iter()
-                    .map(|element| element.to_string())
+                    // TODO: zero-copi for this write. For now, just assume that the compiler
+                    // recognises that this can be zero-copy, and be on our way...
+                    .map(ToString::to_string)
                     .join(", ")
             ),
         }

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -362,7 +362,7 @@ impl Vm {
     pub fn add_op1(&mut self, op: Op, arg: u16) {
         let current_chunk = self.current_chunk_mut();
         current_chunk.push(op as u8);
-        Self::push_u16(current_chunk, arg)
+        Self::push_u16(current_chunk, arg);
     }
 
     pub(crate) fn add_op2(&mut self, op: Op, arg1: u16, arg2: u16) {
@@ -440,7 +440,7 @@ impl Vm {
 
     pub(crate) fn begin_function(&mut self, name: &str) {
         self.bytecode.push((name.into(), vec![]));
-        self.current_chunk_index = self.bytecode.len() - 1
+        self.current_chunk_index = self.bytecode.len() - 1;
     }
 
     pub(crate) fn end_function(&mut self) {
@@ -1076,7 +1076,7 @@ impl Vm {
             "Stack: [{}]",
             self.stack
                 .iter()
-                .map(|x| x.to_string())
+                .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join("] [")
         );


### PR DESCRIPTION
Apologies if this comes across as low-effort. On potentially new projects, I like to turn on pedantic lints, and go through what comes out and see what little chores I can help with. It gives me a chance to familiarise my self with the projects contribution work flow, as well as get a start at looking at the code base.

The bulk of the lints are merging of the match statements.

There is also (according to the lint) a minor performance gain when using an `&&str` type: `(*the_str).to_string()` is better than `the_str.to_string()`.

There are some other lints that promise to be minor micro-optimisations, but they change the interface (mostly about arguments being references vs owned).

If you want, I can also make changes to the private functions where clippy suggests these api changes.