### PR TITLE
Support Strings inside string interpolations

### DIFF
--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -3425,6 +3425,40 @@ mod tests {
             ),
         );
 
+        parse_as_expression(
+            &["\"{\"foo\"}\""],
+            Expression::String(
+                Span::dummy(),
+                vec![StringPart::Interpolation {
+                    span: Span::dummy(),
+                    expr: Box::new(Expression::String(Span::dummy(), vec![StringPart::Fixed("foo".into())])),
+                    format_specifiers: None,
+                }],
+            ),
+        );
+
+        parse_as_expression(
+            &["\"{\"foo {\"bar\"}\"}\""],
+            Expression::String(
+                Span::dummy(),
+                vec![StringPart::Interpolation {
+                    span: Span::dummy(),
+                    expr: Box::new(Expression::String(
+                        Span::dummy(), 
+                        vec![
+                            StringPart::Fixed("foo ".into()),
+                            StringPart::Interpolation { 
+                                span: Span::dummy(), 
+                                expr: Box::new(Expression::String(Span::dummy(), vec![StringPart::Fixed("bar".into())])), 
+                                format_specifiers: None 
+                            }
+                        ]
+                    )),
+                    format_specifiers: None,
+                }],
+            ),
+        );
+
         should_fail_with(&["\"test {1"], ParseErrorKind::UnterminatedString);
         should_fail_with(
             &[

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -3431,7 +3431,10 @@ mod tests {
                 Span::dummy(),
                 vec![StringPart::Interpolation {
                     span: Span::dummy(),
-                    expr: Box::new(Expression::String(Span::dummy(), vec![StringPart::Fixed("foo".into())])),
+                    expr: Box::new(Expression::String(
+                        Span::dummy(),
+                        vec![StringPart::Fixed("foo".into())],
+                    )),
                     format_specifiers: None,
                 }],
             ),
@@ -3444,15 +3447,18 @@ mod tests {
                 vec![StringPart::Interpolation {
                     span: Span::dummy(),
                     expr: Box::new(Expression::String(
-                        Span::dummy(), 
+                        Span::dummy(),
                         vec![
                             StringPart::Fixed("foo ".into()),
-                            StringPart::Interpolation { 
-                                span: Span::dummy(), 
-                                expr: Box::new(Expression::String(Span::dummy(), vec![StringPart::Fixed("bar".into())])), 
-                                format_specifiers: None 
-                            }
-                        ]
+                            StringPart::Interpolation {
+                                span: Span::dummy(),
+                                expr: Box::new(Expression::String(
+                                    Span::dummy(),
+                                    vec![StringPart::Fixed("bar".into())],
+                                )),
+                                format_specifiers: None,
+                            },
+                        ],
                     )),
                     format_specifiers: None,
                 }],

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -430,13 +430,13 @@ impl Tokenizer {
         }
     }
 
-    fn is_directly_inside(&mut self, scope_type: ScopeType) -> bool {
+    fn is_directly_inside(&self, scope_type: ScopeType) -> bool {
         self.scopes
             .last()
             .is_some_and(|scope| scope.scope_type == scope_type)
     }
 
-    fn is_inside_child_of(&mut self, scope_type: ScopeType) -> bool {
+    fn is_inside_child_of(&self, scope_type: ScopeType) -> bool {
         let Some(i) = self.scopes.len().checked_sub(2) else {
             return false;
         };
@@ -445,7 +445,7 @@ impl Tokenizer {
             .is_some_and(|scope| scope.scope_type == scope_type)
     }
 
-    fn scope_start(&mut self, scope_type: ScopeType) -> Option<ByteIndex> {
+    fn scope_start(&self, scope_type: ScopeType) -> Option<ByteIndex> {
         self.scopes
             .iter()
             .filter(|scope| scope.scope_type == scope_type)
@@ -453,7 +453,7 @@ impl Tokenizer {
             .map(|scope| scope.scope_start)
     }
 
-    fn is_inside_interpolation(&mut self) -> bool {
+    fn is_inside_interpolation(&self) -> bool {
         self.is_directly_inside(ScopeType::Curly) && self.is_inside_child_of(ScopeType::String)
     }
 

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -1199,6 +1199,30 @@ fn test_tokenize_string() {
     );
 
     assert_eq!(
+        tokenize_reduced("\"foo = {\"foo\"}, and bar = {\"bar\"}\"").unwrap(),
+        [
+            ("\"foo = {", StringInterpolationStart, ByteIndex(0)),
+            ("\"foo\"", StringFixed, ByteIndex(8)),
+            ("}, and bar = {", StringInterpolationMiddle, ByteIndex(13)),
+            ("\"bar\"", StringFixed, ByteIndex(27)),
+            ("}\"", StringInterpolationEnd, ByteIndex(32)),
+            ("", Eof, ByteIndex(34))
+        ]
+    );
+
+    assert_eq!(
+        tokenize_reduced("\"foo = {\"foo, and bar = {\"bar\"}\"}\"").unwrap(),
+        [
+            ("\"foo = {", StringInterpolationStart, ByteIndex(0)),
+            ("\"foo, and bar = {", StringInterpolationStart, ByteIndex(8)),
+            ("\"bar\"", StringFixed, ByteIndex(25)),
+            ("}\"", StringInterpolationEnd, ByteIndex(30)),
+            ("}\"", StringInterpolationEnd, ByteIndex(32)),
+            ("", Eof, ByteIndex(34))
+        ]
+    );
+
+    assert_eq!(
         tokenize("\"foo", 0).unwrap_err().kind,
         TokenizerErrorKind::UnterminatedString
     );
@@ -1207,7 +1231,23 @@ fn test_tokenize_string() {
         TokenizerErrorKind::UnterminatedStringInterpolation
     );
     assert_eq!(
+        tokenize("\"foobar = {\"foo{\"bar\"}\"\"", 0).unwrap_err().kind,
+        TokenizerErrorKind::UnterminatedStringInterpolation
+    );
+    assert_eq!(
         tokenize("\"foo = {foo}.", 0).unwrap_err().kind,
+        TokenizerErrorKind::UnterminatedString
+    );
+    assert_eq!(
+        tokenize("\"foo = {\"foo\"}.", 0).unwrap_err().kind,
+        TokenizerErrorKind::UnterminatedString
+    );
+    assert_eq!(
+        tokenize("\"foo = {\"foo}.\"", 0).unwrap_err().kind,
+        TokenizerErrorKind::UnterminatedString
+    );
+    assert_eq!(
+        tokenize("\"foobar = {\"foo{\"bar}\"}.\"", 0).unwrap_err().kind,
         TokenizerErrorKind::UnterminatedString
     );
 

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -235,8 +235,7 @@ fn is_identifier_continue(c: char) -> bool {
         && c != '⋅'
 }
 
-#[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScopeType {
     Curly,
     String,
@@ -245,8 +244,7 @@ pub enum ScopeType {
 /// When scanning a string interpolation like `"foo = {foo}, and bar = {bar}."`,
 /// the tokenizer needs to keep track of where it currently is, because we allow
 /// for (almost) arbitrary expressions inside the {…} part.
-#[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Scope {
     scope_type: ScopeType,
     scope_start: ByteIndex,
@@ -679,7 +677,9 @@ impl Tokenizer {
             '"' if self.is_inside_interpolation()
                 && matches!(
                     self.last_token,
-                    Some(TokenKind::StringFixed) | Some(TokenKind::StringInterpolationEnd)
+                    Some(TokenKind::StringFixed)
+                        | Some(TokenKind::StringInterpolationEnd)
+                        | Some(TokenKind::Identifier)
                 ) =>
             {
                 return Err(TokenizerError {


### PR DESCRIPTION
This PR aims at supporting arbitrary strings inside string interpolations. 

Progress on this so far:

- [X] Support fixed strings in interpolations
- [X] Support interpolated strings inside interpolations
- [x] Report errors with correct and intuitive spans 

I'm not sure if the errors are too bad, but I would like a second set of eyes on it if anyone are up for it. I'm having a bit of difficulty figuring out how it all connects to produce the errors and associated spans I get on a given invalid string.