### PR TITLE
Switched to newer macOS GitHub Actions images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,8 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2019                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-12                      }
+          - { target: x86_64-apple-darwin         , os: macos-13                      }
+          - { target: aarch64-apple-darwin        , os: macos-15                      }
           #- { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }


### PR DESCRIPTION
Removed the obsolete macos-12, as GitHub no longer supports it 
Switched to macos-13 on x86 (Intel) and macos-15 on ARM64 (Apple Silicon)