### PR TITLE
Add vsce ouput to publish artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
   vscode_extension_package:
     name: Package vscode extension
     runs-on: ubuntu-latest
+    outputs:
+      VSCE_PATH: ${{ steps.vsce-package.outputs.VSCE_PATH }}
     defaults:
       run:
         working-directory: ./vscode-extension
@@ -137,19 +139,20 @@ jobs:
           mkdir -p "${BASE_PATH}/out"
           npm run vscode:package -- --out="${VSCE_PATH}"
           echo "VSCE_NAME=${VSCE_NAME}" >> $GITHUB_OUTPUT
-          echo "VSCE_PATH=${VSCE_PATH}" >> $GITHUB_OUTPUT
+          echo "VSCE_PATH=./vscode-extension/${VSCE_PATH}" >> $GITHUB_OUTPUT
       
       - name: "Artifact upload: VSCode extension"
         uses: actions/upload-artifact@master
         with:
           name: ${{ steps.vsce-package.outputs.VSCE_NAME }}
-          path: ./vscode-extension/${{ steps.vsce-package.outputs.VSCE_PATH }}
+          path: ${{ steps.vsce-package.outputs.VSCE_PATH }}
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     needs: 
       - crate_metadata
+      - vscode_extension_package
     strategy:
       fail-fast: false
       matrix:
@@ -414,5 +417,6 @@ jobs:
         files: |
           ${{ steps.package.outputs.PKG_PATH }}
           ${{ steps.debian-package.outputs.DPKG_PATH }}
+          ${{ needs.vscode_extension_package.outputs.VSCE_PATH }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,24 @@ jobs:
     - name: Run tests
       run: cargo test --locked ${{ env.MSRV_FEATURES }}
 
+  release_check:
+    name: Release check 
+    runs-on: ubuntu-latest
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    steps:
+      - name: Check for release
+        id: is-release
+        shell: bash
+        run: |
+          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
+          echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
+
   vscode_extension_package:
     name: Package vscode extension
     runs-on: ubuntu-latest
-    outputs:
-      VSCE_PATH: ${{ steps.vsce-package.outputs.VSCE_PATH }}
+    needs: 
+      - release_check
     defaults:
       run:
         working-directory: ./vscode-extension
@@ -146,13 +159,22 @@ jobs:
         with:
           name: ${{ steps.vsce-package.outputs.VSCE_NAME }}
           path: ${{ steps.vsce-package.outputs.VSCE_PATH }}
+      
+      - name: Publish archives and packages
+        uses: softprops/action-gh-release@v1
+        if: needs.release_check.outputs.IS_RELEASE
+        with:
+          files: |
+            ${{ steps.vsce-package.outputs.VSCE_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     needs: 
       - crate_metadata
-      - vscode_extension_package
+      - release_check
     strategy:
       fail-fast: false
       matrix:
@@ -403,20 +425,12 @@ jobs:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
         path: ${{ steps.debian-package.outputs.DPKG_PATH }}
 
-    - name: Check for release
-      id: is-release
-      shell: bash
-      run: |
-        unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
-        echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
-
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
-      if: steps.is-release.outputs.IS_RELEASE
+      if: needs.release_check.outputs.IS_RELEASE
       with:
         files: |
           ${{ steps.package.outputs.PKG_PATH }}
           ${{ steps.debian-package.outputs.DPKG_PATH }}
-          ${{ needs.vscode_extension_package.outputs.VSCE_PATH }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A small change to the CI action to include the generated VSIX file in releases automatically.

~~This is a bit difficult to test, as I don't want unintended consequences to leak into the main repo. I have run the action locally in my own fork without creating a release. This should probably be tested using a beta release before being merged into master.~~

I have tested the changes on my fork, the the run of the action can be found [here](https://github.com/Goju-Ryu/numbat/actions/runs/13100504575) and the resulting release [here](https://github.com/Goju-Ryu/numbat/releases/tag/v1.17.0-beta02).