### PR TITLE
Multi factorial

### DIFF
--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use crate::markup as m;
 use crate::resolver::ModulePathBorrowed;
 use crate::span::Span;
@@ -11,7 +13,7 @@ use num_traits::Signed;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOperator {
-    Factorial,
+    Factorial(NonZeroUsize),
     Negate,
     LogicalNeg,
 }
@@ -192,7 +194,7 @@ macro_rules! negate {
 macro_rules! factorial {
     ( $lhs:expr ) => {{
         crate::ast::Expression::UnaryOperator {
-            op: UnaryOperator::Factorial,
+            op: UnaryOperator::Factorial(NonZeroUsize::new(1).unwrap()),
             expr: Box::new($lhs),
             span_op: Span::dummy(),
         }

--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -192,9 +192,9 @@ macro_rules! negate {
 
 #[cfg(test)]
 macro_rules! factorial {
-    ( $lhs:expr ) => {{
+    ( $lhs:expr, $order:expr ) => {{
         crate::ast::Expression::UnaryOperator {
-            op: UnaryOperator::Factorial(NonZeroUsize::new(1).unwrap()),
+            op: UnaryOperator::Factorial(NonZeroUsize::new($order).unwrap()),
             expr: Box::new($lhs),
             span_op: Span::dummy(),
         }

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -102,9 +102,9 @@ impl BytecodeInterpreter {
                 self.compile_expression(rhs)?;
                 self.vm.add_op(Op::Negate);
             }
-            Expression::UnaryOperator(_span, UnaryOperator::Factorial, lhs, _type) => {
+            Expression::UnaryOperator(_span, UnaryOperator::Factorial(order), lhs, _type) => {
                 self.compile_expression(lhs)?;
-                self.vm.add_op(Op::Factorial);
+                self.vm.add_op1(Op::Factorial, order.get() as u16);
             }
             Expression::UnaryOperator(_span, UnaryOperator::LogicalNeg, lhs, _type) => {
                 self.compile_expression(lhs)?;

--- a/numbat/src/math.rs
+++ b/numbat/src/math.rs
@@ -2,13 +2,14 @@
 ///
 /// It is the caller's responsibility to ensure that the given `f64` is a
 /// non-negative integer.
-pub fn factorial(mut x: f64) -> f64 {
+pub fn factorial(mut x: f64, order: u16) -> f64 {
     debug_assert!(x >= 0.0);
+    debug_assert!(order >= 1);
     x = x.floor();
     let mut result = 1f64;
     while x >= 1. && result != f64::INFINITY {
         result *= x;
-        x -= 1.;
+        x -= order as f64;
     }
     result
 }

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -2212,25 +2212,27 @@ mod tests {
     fn factorials() {
         parse_as_expression(
             &["4!", "4.0!", "4 !", " 4 !", "(4)!"],
-            factorial!(scalar!(4.0)),
+            factorial!(scalar!(4.0), 1),
         );
         parse_as_expression(
             &["3!^3", "(3!)^3"],
-            binop!(factorial!(scalar!(3.0)), Power, scalar!(3.0)),
+            binop!(factorial!(scalar!(3.0), 1), Power, scalar!(3.0)),
         );
         parse_as_expression(
             &["3²!"],
-            factorial!(binop!(scalar!(3.0), Power, scalar!(2.0))),
+            factorial!(binop!(scalar!(3.0), Power, scalar!(2.0)), 1),
         );
         parse_as_expression(
             &["3^3!"],
-            binop!(scalar!(3.0), Power, factorial!(scalar!(3.0))),
+            binop!(scalar!(3.0), Power, factorial!(scalar!(3.0), 1)),
         );
         parse_as_expression(
             &["-5!", "-(5!)", "-(5)!"],
-            negate!(factorial!(scalar!(5.0))),
+            negate!(factorial!(scalar!(5.0), 1)),
         );
-        parse_as_expression(&["5!!", "(5!)!"], factorial!(factorial!(scalar!(5.0))));
+        parse_as_expression(&["(5!)!"], factorial!(factorial!(scalar!(5.0), 1), 1));
+        parse_as_expression(&["5!!", "(5!!)"], factorial!(scalar!(5.0), 2));
+        parse_as_expression(&["5!!!!!"], factorial!(scalar!(5.0), 5));
     }
 
     #[test]

--- a/numbat/src/typechecker/const_evaluation.rs
+++ b/numbat/src/typechecker/const_evaluation.rs
@@ -21,7 +21,9 @@ pub fn evaluate_const_expr(expr: &typed_ast::Expression) -> Result<Exponent> {
         typed_ast::Expression::UnaryOperator(_, ast::UnaryOperator::Negate, ref expr, _) => {
             return Ok(-evaluate_const_expr(expr)?)
         }
-        typed_ast::Expression::UnaryOperator(_, ast::UnaryOperator::Factorial, _, _) => "factorial",
+        typed_ast::Expression::UnaryOperator(_, ast::UnaryOperator::Factorial(_order), _, _) => {
+            "factorial"
+        }
         typed_ast::Expression::UnaryOperator(_, ast::UnaryOperator::LogicalNeg, _, _) => "logical",
 
         e @ typed_ast::Expression::BinaryOperator(_span_op, op, lhs_expr, rhs_expr, _) => {

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -357,7 +357,7 @@ impl TypeChecker {
                 let type_ = checked_expr.get_type();
 
                 match op {
-                    ast::UnaryOperator::Factorial => {
+                    ast::UnaryOperator::Factorial(_order) => {
                         if self
                             .add_equal_constraint(&type_, &Type::scalar())
                             .is_trivially_violated()

--- a/numbat/src/typed_ast.rs
+++ b/numbat/src/typed_ast.rs
@@ -1294,8 +1294,8 @@ impl PrettyPrint for Expression<'_> {
             UnaryOperator(_, self::UnaryOperator::Negate, expr, _type) => {
                 m::operator("-") + with_parens(expr)
             }
-            UnaryOperator(_, self::UnaryOperator::Factorial, expr, _type) => {
-                with_parens(expr) + m::operator("!")
+            UnaryOperator(_, self::UnaryOperator::Factorial(order), expr, _type) => {
+                with_parens(expr) + (0..order.get()).map(|_| m::operator("!")).sum()
             }
             UnaryOperator(_, self::UnaryOperator::LogicalNeg, expr, _type) => {
                 m::operator("!") + with_parens(expr)

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -819,13 +819,15 @@ impl Vm {
                         .expect("Expected factorial operand to be scalar")
                         .to_f64();
 
+                    let order = self.read_u16();
+
                     if lhs < 0. {
                         return Err(Box::new(RuntimeError::FactorialOfNegativeNumber));
                     } else if lhs.fract() != 0. {
                         return Err(Box::new(RuntimeError::FactorialOfNonInteger));
                     }
 
-                    self.push_quantity(Quantity::from_scalar(math::factorial(lhs)));
+                    self.push_quantity(Quantity::from_scalar(math::factorial(lhs, order)));
                 }
                 Op::JumpIfFalse => {
                     let offset = self.read_u16() as usize;

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -169,6 +169,12 @@ fn test_factorial() {
     expect_output("-5!", "-120");
     expect_output("-(5!)", "-120");
     expect_output("-(5)!", "-120");
+    expect_output("5!!", "15");
+    expect_output("5!!!", "10");
+    expect_output("5!!!!", "5");
+    expect_output("5!!!!!", "5");
+    expect_output("5!!!!!!", "5");
+    expect_output("(3!)!!!", "18");
 
     expect_failure(
         "(-1)!",


### PR DESCRIPTION
Hey, currently numbat doesn't handle multifactorial correctly, see the following screenshot:
![image](https://github.com/user-attachments/assets/d6d1cd65-2478-4b37-96f4-c9df4714fa21)

This should in fact returns (5 * 3 * 1): https://en.wikipedia.org/wiki/Double_factorial#Generalizations

This PR adds support for it, it's a breaking change though since numbat was already accepting the expression.