### PR TITLE
doc: add more references to _ and 'ans'

### DIFF
--- a/book/src/example-numbat_syntax.md
+++ b/book/src/example-numbat_syntax.md
@@ -58,6 +58,8 @@ pi/3 + pi |> cos  # Same, 'arg |> f' is equivalent to 'f(arg)'
                   # which makes it very useful for interactive
                   # terminals (press up-arrow, and add '|> f')
 
+_                 # Result of last calculation, also 'ans'
+
 # 4. Constants
 
 let n = 4                          # Simple numerical constant

--- a/examples/numbat_syntax.nbt
+++ b/examples/numbat_syntax.nbt
@@ -53,6 +53,8 @@ pi/3 + pi |> cos  # Same, 'arg |> f' is equivalent to 'f(arg)'
                   # which makes it very useful for interactive
                   # terminals (press up-arrow, and add '|> f')
 
+_                 # Result of last calculation, also 'ans'
+
 # 4. Constants
 
 let n = 4                          # Simple numerical constant


### PR DESCRIPTION
_/ans are only mentioned in the cli-usage page, this was hard to find so add it to the syntax overviews as well

------------
I actually found `_` after trying a lot of variations thinking there couldn't possibly not be such a keyword (I use `.` all the time in bc), and later found `ans` grepping for `_` in the doc... Having this here would have saved me 10 mins, so taking an extra few minutes to save anyone else the trouble.
Thanks for this and your other tool!