### PR TITLE
Massively improve `str_find` performance

### DIFF
--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -34,18 +34,19 @@ fn str_append(a: String, b: String) -> String = "{a}{b}"
 @example("\"!\" |> str_prepend(\"Numbat\")")
 fn str_prepend(a: String, b: String) -> String = "{b}{a}"
 
-@description("Find the first occurrence of a substring in a string")
-@example("str_find(\"typed\", \"Numbat is a statically typed programming language.\")")
-fn str_find(needle: String, haystack: String) -> Scalar =
+fn _str_find(needle: String, index: Scalar, haystack: String) -> Scalar =
   if len_haystack == 0
     then -1
     else if str_slice(0, str_length(needle), haystack) == needle
-      then 0
-      else if str_find(needle, tail_haystack) == -1
-        then -1
-        else 1 + str_find(needle, tail_haystack)
+      then index
+      else _str_find(needle, index + 1, tail_haystack)
   where len_haystack = str_length(haystack)
     and tail_haystack = str_slice(1, len_haystack, haystack)
+
+@description("Find the first occurrence of a substring in a string")
+@example("str_find(\"typed\", \"Numbat is a statically typed programming language.\")")
+fn str_find(needle: String, haystack: String) -> Scalar = 
+  _str_find(needle, 0, haystack)
 
 @description("Check if a string contains a substring")
 @example("str_contains(\"typed\", \"Numbat is a statically typed programming language.\")")


### PR DESCRIPTION
I recently discovered that `str_find` had very poor performance. This PR fixes it by altering it's implementation such that it goes from having a time complexity of $O(2^n)$ where $n$ is the length of the haystack to $O(n)$.  

Here is a video demonstrating the speedup using the example from the documentation:
![strings nbt](https://github.com/user-attachments/assets/f4b1a908-d3f8-4a46-982b-acfffbbb9840)

_Note:_
This also improves the `str_contains` function as it is implemented using `str_find`.