### PR TITLE
Change curly escape to align with python f-strings

### DIFF
--- a/book/src/list-functions-strings.md
+++ b/book/src/list-functions-strings.md
@@ -114,9 +114,14 @@ fn str_append(a: String, b: String) -> String
 <details>
 <summary>Examples</summary>
 
-<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%22Numbat%22%20%7C%3E%20str%5Fappend%28%22%21%22%29')""></button></div><code class="language-nbt hljs numbat">"Numbat" |> str_append("!")
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%22%21%22%20%7C%3E%20str%5Fappend%28%22Numbat%22%29')""></button></div><code class="language-nbt hljs numbat">"!" |> str_append("Numbat")
 
-    = "!Numbat"    [String]
+    = "Numbat!"    [String]
+</code></pre>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=str%5Fappend%28%22Numbat%22%2C%20%22%21%22%29')""></button></div><code class="language-nbt hljs numbat">str_append("Numbat", "!")
+
+    = "Numbat!"    [String]
 </code></pre>
 
 </details>
@@ -131,9 +136,14 @@ fn str_prepend(a: String, b: String) -> String
 <details>
 <summary>Examples</summary>
 
-<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%22%21%22%20%7C%3E%20str%5Fprepend%28%22Numbat%22%29')""></button></div><code class="language-nbt hljs numbat">"!" |> str_prepend("Numbat")
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=%22Numbat%22%20%7C%3E%20str%5Fprepend%28%22%21%22%29')""></button></div><code class="language-nbt hljs numbat">"Numbat" |> str_prepend("!")
 
-    = "!Numbat"    [String]
+    = "Numbat!"    [String]
+</code></pre>
+
+<pre><div class="buttons"><button class="fa fa-play play-button" title="Run this code" aria-label="Run this code"  onclick=" window.open('https://numbat.dev/?q=str%5Fprepend%28%22%21%22%2C%20%22Numbat%22%29')""></button></div><code class="language-nbt hljs numbat">str_prepend("!", "Numbat")
+
+    = "Numbat!"    [String]
 </code></pre>
 
 </details>

--- a/numbat/modules/core/functions.nbt
+++ b/numbat/modules/core/functions.nbt
@@ -12,13 +12,13 @@ fn id<A>(x: A) -> A = x
 fn abs<T: Dim>(x: T) -> T
 
 @name("Square root")
-@description("Return the square root $\\sqrt\{x\}$ of the input: `sqrt(121 m^2) = 11 m`.")
+@description("Return the square root $\\sqrt{{x}}$ of the input: `sqrt(121 m^2) = 11 m`.")
 @url("https://en.wikipedia.org/wiki/Square_root")
 @example("sqrt(4 are) -> m")
 fn sqrt<D: Dim>(x: D^2) -> D = x^(1/2)
 
 @name("Cube root")
-@description("Return the cube root $\\sqrt[3]\{x\}$ of the input: `cbrt(8 m^3) = 2 m`.")
+@description("Return the cube root $\\sqrt[3]{{x}}$ of the input: `cbrt(8 m^3) = 2 m`.")
 @url("https://en.wikipedia.org/wiki/Cube_root")
 @example("cbrt(8 L) -> cm")
 fn cbrt<D: Dim>(x: D^3) -> D = x^(1/3)

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -27,11 +27,13 @@ fn lowercase(s: String) -> String
 fn uppercase(s: String) -> String
 
 @description("Concatenate two strings")
-@example("\"Numbat\" |> str_append(\"!\")")
+@example("\"!\" |> str_append(\"Numbat\")")
+@example("str_append(\"Numbat\", \"!\")")
 fn str_append(a: String, b: String) -> String = "{a}{b}"
 
 @description("Concatenate two strings")
-@example("\"!\" |> str_prepend(\"Numbat\")")
+@example("\"Numbat\" |> str_prepend(\"!\")")
+@example("str_prepend(\"!\", \"Numbat\")")
 fn str_prepend(a: String, b: String) -> String = "{b}{a}"
 
 @description("Find the first occurrence of a substring in a string")

--- a/numbat/modules/math/combinatorics.nbt
+++ b/numbat/modules/math/combinatorics.nbt
@@ -35,7 +35,7 @@ fn binom(n: Scalar, k: Scalar) -> Scalar =
     falling_factorial(n, k) / k!
 
 @name("Fibonacci numbers")
-@description("The nth Fibonacci number, where n is a nonnegative integer. The Fibonacci sequence is given by $F_0=0$, $F_1=1$, and $F_n=F_\{n-1\}+F_\{n-2\}$ for $n≥2$. The first several elements, starting with $n=0$, are $0, 1, 1, 2, 3, 5, 8, 13$.")
+@description("The nth Fibonacci number, where n is a nonnegative integer. The Fibonacci sequence is given by $F_0=0$, $F_1=1$, and $F_n=F_{{n-1}}+F_{{n-2}}$ for $n≥2$. The first several elements, starting with $n=0$, are $0, 1, 1, 2, 3, 5, 8, 13$.")
 @url("https://en.wikipedia.org/wiki/Fibonacci_sequence")
 @example("fibonacci(5)")
 fn fibonacci(n: Scalar) -> Scalar =
@@ -47,7 +47,7 @@ fn fibonacci(n: Scalar) -> Scalar =
       where phi = (1+sqrt(5))/2
 
 @name("Lucas numbers")
-@description("The nth Lucas number, where n is a nonnegative integer. The Lucas sequence is given by $L_0=2$, $L_1=1$, and $L_n=L_\{n-1\}+L_\{n-2\}$ for $n≥2$. The first several elements, starting with $n=0$, are $2, 1, 3, 4, 7, 11, 18, 29$.")
+@description("The nth Lucas number, where n is a nonnegative integer. The Lucas sequence is given by $L_0=2$, $L_1=1$, and $L_n=L_{{n-1}}+L_{{n-2}}$ for $n≥2$. The first several elements, starting with $n=0$, are $2, 1, 3, 4, 7, 11, 18, 29$.")
 @url("https://en.wikipedia.org/wiki/Lucas_number")
 @example("lucas(5)")
 fn lucas(n: Scalar) -> Scalar =
@@ -59,7 +59,7 @@ fn lucas(n: Scalar) -> Scalar =
       where phi = (1+sqrt(5))/2
 
 @name("Catalan numbers")
-@description("The nth Catalan number, where n is a nonnegative integer. The Catalan sequence is given by $C_n=\frac\{1\}\{n+1\}\binom\{2n\}\{n\}=\binom\{2n\}\{n\}-\binom\{2n\}\{n+1\}$. The first several elements, starting with $n=0$, are $1, 1, 2, 5, 14, 42, 132, 429$.")
+@description("The nth Catalan number, where n is a nonnegative integer. The Catalan sequence is given by $C_n=\frac{{1}}{{n+1}}\binom{{2n}}{{n}}=\binom{{2n}}{{n}}-\binom{{2n}}{{n+1}}$. The first several elements, starting with $n=0$, are $1, 1, 2, 5, 14, 42, 132, 429$.")
 @url("https://en.wikipedia.org/wiki/Catalan_number")
 @example("catalan(5)")
 fn catalan(n: Scalar) -> Scalar =

--- a/numbat/modules/math/geometry.nbt
+++ b/numbat/modules/math/geometry.nbt
@@ -1,11 +1,11 @@
 use core::functions
 use math::constants
 
-@description("The length of the hypotenuse of a right-angled triangle $\\sqrt\{x^2+y^2\}$.")
+@description("The length of the hypotenuse of a right-angled triangle $\\sqrt{{x^2+y^2}}$.")
 @example("hypot2(3 m, 4 m)")
 fn hypot2<T: Dim>(x: T, y: T) -> T = sqrt(x^2 + y^2)
 
-@description("The Euclidean norm of a 3D vector $\\sqrt\{x^2+y^2+z^2\}$.")
+@description("The Euclidean norm of a 3D vector $\\sqrt{{x^2+y^2+z^2}}$.")
 @example("hypot3(8, 9, 12)")
 fn hypot3<T: Dim>(x: T, y: T, z: T) -> T = sqrt(x^2 + y^2 + z^2)
 
@@ -22,5 +22,5 @@ fn circle_circumference<L: Dim>(radius: L) -> L = 2 π × radius
 @description("The surface area of a sphere, $4\\pi r^2$.")
 fn sphere_area<L: Dim>(radius: L) -> L^2 = 4 π × radius^2
 
-@description("The volume of a sphere, $\\frac\{4\}\{3\}\\pi r^3$.")
+@description("The volume of a sphere, $\\frac{{4}}{{3}}\\pi r^3$.")
 fn sphere_volume<L: Dim>(radius: L) -> L^3 = 4/3 × π × radius^3

--- a/numbat/src/pretty_print.rs
+++ b/numbat/src/pretty_print.rs
@@ -17,14 +17,16 @@ pub fn escape_numbat_string(s: &str) -> CompactString {
     let mut out = CompactString::const_new("");
     for c in s.chars() {
         let replacement = match c {
-            '\\' => r"\\",
             '\n' => r"\n",
             '\r' => r"\r",
             '\t' => r"\t",
             '"' => r#"\""#,
             '\0' => r"\0",
-            '{' => r"\{",
-            '}' => r"\}",
+            '{' | '}' | '\\' => {
+                out.push(c);
+                out.push(c);
+                continue;
+            }
             _ => {
                 out.push(c);
                 continue;

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -363,8 +363,16 @@ impl Tokenizer {
                     break;
                 }
                 Some('\\') if !escaped => true,
-                Some('"') | Some('{') if !escaped => {
+                Some('"') if !escaped => {
                     break;
+                }
+                c @ (Some('{') | Some('}')) if c != self.peek2(input) => {
+                    break;
+                }
+                Some('{') | Some('}') => {
+                    // extra advance to skip both curly's making up the escape sequence
+                    self.advance(input);
+                    false
                 }
                 Some(_) => false,
             };
@@ -1138,9 +1146,9 @@ fn test_tokenize_string() {
     );
 
     insta::assert_snapshot!(
-        tokenize_reduced_pretty(r#""start \{inner\} end""#).unwrap(),
+        tokenize_reduced_pretty(r#""start {{inner}} end""#).unwrap(),
         @r###"
-    "\"start \\{inner\\} end\"", StringFixed, 0
+    "\"start {{inner}} end\"", StringFixed, 0
     "", Eof, 21
     "###
     );

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
-    "name": "numbat",
-    "version": "0.1.0",
+    "name": "numbat-vscode-extension",
+    "version": "0.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "numbat",
-            "version": "0.1.0",
+            "name": "numbat-vscode-extension",
+            "version": "0.1.1",
             "license": "(MIT OR Apache-2.0)",
             "devDependencies": {
-                "@vscode/vsce": "3.2.1"
+                "@vscode/vsce": "3.3.2"
             },
             "engines": {
                 "vscode": "^1.71.0"
@@ -193,9 +193,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.2.1.tgz",
-            "integrity": "sha512-AY9vBjwExakK1c0cI/3NN2Ey0EgiKLBye/fxl/ue+o4q6RZ7N+xzd1jAD6eI6eBeMVANi617+V2rxIAkDPco2Q==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.3.2.tgz",
+            "integrity": "sha512-XQ4IhctYalSTMwLnMS8+nUaGbU7v99Qm2sOoGfIEf2QC7jpiLXZZMh7NwArEFsKX4gHTJLx0/GqAUlCdC3gKCw==",
             "dev": true,
             "dependencies": {
                 "@azure/identity": "^4.1.0",
@@ -204,7 +204,7 @@
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.9",
                 "cockatiel": "^3.1.2",
-                "commander": "^6.2.1",
+                "commander": "^12.1.0",
                 "form-data": "^4.0.0",
                 "glob": "^11.0.0",
                 "hosted-git-info": "^4.0.2",
@@ -647,12 +647,12 @@
             }
         },
         "node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "engines": {
-                "node": ">= 6"
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
     "name": "numbat-vscode-extension",
     "displayName": "Numbat",
     "description": "Syntax highlighting for the Numbat programming language",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "license": "(MIT OR Apache-2.0)",
     "icon": "./assets/numbat-256x256.png",
     "engines": {
@@ -38,7 +38,7 @@
         "vscode:package": "vsce package"
     },
     "devDependencies": {
-        "@vscode/vsce": "3.2.1"
+        "@vscode/vsce": "3.3.2"
     },
     "vsce": {
         "skipLicense": true

--- a/vscode-extension/syntaxes/numbat.tmLanguage.json
+++ b/vscode-extension/syntaxes/numbat.tmLanguage.json
@@ -86,13 +86,17 @@
         },
         "strings": {
             "name": "string.quoted.double",
-            "begin": "\"",
-            "end": "\"",
+            "begin": "(?<!\\\\)\"",
+            "end": "(?<!\\\\)\"",
             "patterns": [
                 {
                     "name": "constant.character.escape",
-                    "begin": "{",
-                    "end": "}",
+                    "match": "\\\\\\S|{{|}}"
+                },
+                {
+                    "name": "constant.character.escape",
+                    "begin": "(?<!{){(?!{)",
+                    "end": "(?<!})}(?!})",
                     "patterns": [
                         {
                             "include": "$base"


### PR DESCRIPTION
Following a discussion in the Discord it was decided to move towards aligning string escape sequences with python f-strings. This PR is a step in that direction by following the python curly escape notation.

This PR handles:
- The compiler handling of escaping curlys
- Updating existing modules to use the new escape syntax
- Updating the vs-code extension to correctly show escaped characters in the following formats:
  - `{{`
  - `}}`
  - `\<c>` where `<c>` is any non white space character