### PR TITLE
Deduplicate VM constants

### DIFF
--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -206,7 +206,7 @@ impl Op {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Constant {
     Scalar(f64),
     Unit(Unit),
@@ -391,7 +391,13 @@ impl Vm {
         chunk[offset + 1] = ((arg >> 8) & 0xff) as u8;
     }
 
-    pub fn add_constant(&mut self, constant: Constant) -> u16 {
+    pub fn add_constant(&mut self, constant: Constant, dedupe: bool) -> u16 {
+        if dedupe {
+            if let Some(idx) = self.constants.iter().position(|c| *c == constant) {
+                return idx as u16;
+            }
+        }
+
         self.constants.push(constant);
         assert!(self.constants.len() <= u16::MAX as usize);
         (self.constants.len() - 1) as u16 // TODO: this can overflow, see above
@@ -1098,8 +1104,8 @@ impl Vm {
 #[test]
 fn vm_basic() {
     let mut vm = Vm::new();
-    vm.add_constant(Constant::Scalar(42.0));
-    vm.add_constant(Constant::Scalar(1.0));
+    vm.add_constant(Constant::Scalar(42.0), true);
+    vm.add_constant(Constant::Scalar(1.0), true);
 
     vm.add_op1(Op::LoadConstant, 0);
     vm.add_op1(Op::LoadConstant, 1);


### PR DESCRIPTION
(except when defining derived unit constants, as initially identical but temporary values)

Don't see any real performance changes from this (if anything it's probably a minor slowdown due to the added dupe check in `add_constant`). However, it does reduce the number of constants generated from the prelude from ~730 to \~320, a reduction of 56%. This in theory allows for larger Numbat programs as it's now harder to hit the \~65k constants ceiling. Worth it? I don't know :)
