### PR TITLE
Use IndexMap for Vm.ffi_callables for fast lookup by name

### DIFF
--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -404,6 +404,17 @@ pub enum ProcedureKind {
     Type,
 }
 
+impl ProcedureKind {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            ProcedureKind::Print => "print",
+            ProcedureKind::Assert => "assert",
+            ProcedureKind::AssertEq => "assert_eq",
+            ProcedureKind::Type => "type",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeParameterBound {
     Dim,

--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -20,7 +20,7 @@ use crate::unit::{CanonicalName, Unit};
 use crate::unit_registry::{UnitMetadata, UnitRegistry};
 use crate::value::{FunctionReference, Value};
 use crate::vm::{Constant, ExecutionContext, Op, Vm};
-use crate::{decorator, ffi, Type};
+use crate::{decorator, Type};
 
 #[derive(Debug, Clone, Default)]
 pub struct LocalMetadata {
@@ -475,7 +475,7 @@ impl BytecodeInterpreter {
                     self.compile_expression(arg)?;
                 }
 
-                let name = &ffi::procedures().get(kind).unwrap().name;
+                let name = kind.name();
 
                 let callable_idx = self.vm.get_ffi_callable_idx(name).unwrap();
 

--- a/numbat/src/ffi/functions.rs
+++ b/numbat/src/ffi/functions.rs
@@ -6,9 +6,9 @@ use crate::{quantity::Quantity, value::Value, RuntimeError};
 
 use super::{Callable, ForeignFunction, Result};
 
-static FFI_FUNCTIONS: OnceLock<HashMap<String, ForeignFunction>> = OnceLock::new();
+static FFI_FUNCTIONS: OnceLock<HashMap<&'static str, ForeignFunction>> = OnceLock::new();
 
-pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
+pub(crate) fn functions() -> &'static HashMap<&'static str, ForeignFunction> {
     use super::currency::*;
     use super::datetime::*;
     use super::lists::*;
@@ -23,9 +23,8 @@ pub(crate) fn functions() -> &'static HashMap<String, ForeignFunction> {
         macro_rules! insert_function {
             ($fn_name:expr, $callable:expr, $arity:expr) => {
                 m.insert(
-                    $fn_name.to_string(),
+                    $fn_name,
                     ForeignFunction {
-                        name: $fn_name,
                         arity: $arity,
                         callable: Callable::Function($callable),
                     },

--- a/numbat/src/ffi/mod.rs
+++ b/numbat/src/ffi/mod.rs
@@ -30,7 +30,6 @@ pub(crate) enum Callable {
 }
 
 pub(crate) struct ForeignFunction {
-    pub(crate) name: &'static str,
     pub(crate) arity: ArityRange,
     pub(crate) callable: Callable,
 }

--- a/numbat/src/ffi/procedures.rs
+++ b/numbat/src/ffi/procedures.rs
@@ -25,7 +25,6 @@ pub(crate) fn procedures() -> &'static HashMap<ProcedureKind, ForeignFunction> {
         m.insert(
             ProcedureKind::Print,
             ForeignFunction {
-                name: "print",
                 arity: 0..=1,
                 callable: Callable::Procedure(print),
             },
@@ -33,7 +32,6 @@ pub(crate) fn procedures() -> &'static HashMap<ProcedureKind, ForeignFunction> {
         m.insert(
             ProcedureKind::Assert,
             ForeignFunction {
-                name: "assert",
                 arity: 1..=1,
                 callable: Callable::Procedure(assert),
             },
@@ -41,7 +39,6 @@ pub(crate) fn procedures() -> &'static HashMap<ProcedureKind, ForeignFunction> {
         m.insert(
             ProcedureKind::AssertEq,
             ForeignFunction {
-                name: "assert_eq",
                 arity: 2..=3,
                 callable: Callable::Procedure(assert_eq),
             },

--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -1,3 +1,4 @@
+use crate::ast::ProcedureKind;
 use crate::span::{ByteIndex, Span};
 
 use std::collections::HashMap;
@@ -415,10 +416,10 @@ impl Tokenizer {
             m.insert("inf", TokenKind::Inf);
 
             // procedures
-            m.insert("print", TokenKind::ProcedurePrint);
-            m.insert("assert", TokenKind::ProcedureAssert);
-            m.insert("assert_eq", TokenKind::ProcedureAssertEq);
-            m.insert("type", TokenKind::ProcedureType);
+            m.insert(ProcedureKind::Print.name(), TokenKind::ProcedurePrint);
+            m.insert(ProcedureKind::Assert.name(), TokenKind::ProcedureAssert);
+            m.insert(ProcedureKind::AssertEq.name(), TokenKind::ProcedureAssertEq);
+            m.insert(ProcedureKind::Type.name(), TokenKind::ProcedureType);
 
             // type names
             m.insert("Bool", TokenKind::Bool);

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -292,7 +292,7 @@ impl TypeChecker {
                     .iter_identifiers()
                     .map(|k| k.as_str())
                     .chain(["true", "false"]) // These are parsed as keywords, but can act like identifiers
-                    .chain(ffi::procedures().values().map(|p| p.name)),
+                    .chain(ffi::procedures().keys().map(|p| p.name())),
                 name,
             );
             TypeCheckError::UnknownIdentifier(span, name.into(), suggestion)
@@ -1687,7 +1687,7 @@ impl TypeChecker {
                 if !procedure.arity.contains(&args.len()) {
                     return Err(Box::new(TypeCheckError::WrongArity {
                         callable_span: *span,
-                        callable_name: procedure.name.to_owned(),
+                        callable_name: kind.name().to_owned(),
                         callable_definition_span: None,
                         arity: procedure.arity.clone(),
                         num_args: args.len(),

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -473,7 +473,7 @@ impl Vm {
     }
 
     pub(crate) fn get_ffi_callable_idx(&self, name: &str) -> Option<u16> {
-        let position = self.ffi_callables.keys().position(|&n| n == name)?;
+        let position = self.ffi_callables.get_index_of(name)?;
         assert!(position <= u16::MAX as usize);
         Some(position as u16)
     }


### PR DESCRIPTION
To facilitate this, removed `ForeignFunction`’s `name` field (since it's the key of the map) 

Correspondingly, made `ProcedureKind` itself aware of its own name, rather than relying on the `ForeignFunction` to provide it