### PR TITLE
Dedupe vm constants

### DIFF
--- a/numbat/src/prefix_parser.rs
+++ b/numbat/src/prefix_parser.rs
@@ -17,7 +17,7 @@ pub enum PrefixParserResult<'a> {
 
 type Result<T> = std::result::Result<T, NameResolutionError>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AcceptsPrefix {
     pub short: bool,
     pub long: bool,

--- a/numbat/src/product.rs
+++ b/numbat/src/product.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::ops::{Div, Mul};
 
 use crate::arithmetic::{Exponent, Power};
@@ -232,6 +233,14 @@ impl<Factor: Clone + Ord + PartialEq + Canonicalize, const CANONICALIZE: bool> P
 {
     fn eq(&self, other: &Self) -> bool {
         self.canonicalized().factors == other.canonicalized().factors
+    }
+}
+
+impl<Factor: Clone + Ord + Hash + Canonicalize, const CANONICALIZE: bool> Hash
+    for Product<Factor, CANONICALIZE>
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.canonicalized().factors.hash(state);
     }
 }
 

--- a/numbat/src/unit.rs
+++ b/numbat/src/unit.rs
@@ -16,13 +16,13 @@ pub type ConversionFactor = Number;
 
 /// A unit can either be a base/fundamental unit or it is derived from another unit.
 /// In the latter case, a conversion factor to the defining unit has to be specified.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UnitKind {
     Base,
     Derived(ConversionFactor, Unit),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CanonicalName {
     pub name: CompactString,
     pub accepts_prefix: AcceptsPrefix,
@@ -37,7 +37,7 @@ impl CanonicalName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnitIdentifier {
     pub name: CompactString,
     pub canonical_name: CanonicalName,
@@ -166,7 +166,7 @@ impl Ord for UnitIdentifier {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnitFactor {
     pub unit_id: UnitIdentifier,
     pub prefix: Prefix,

--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -8,7 +8,7 @@ use crate::{
     list::NumbatList, pretty_print::PrettyPrint, quantity::Quantity, typed_ast::StructInfo,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FunctionReference {
     Foreign(CompactString),
     Normal(CompactString),

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -206,7 +206,7 @@ impl Op {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Constant {
     Scalar(f64),
     Unit(Unit),
@@ -391,7 +391,13 @@ impl Vm {
         chunk[offset + 1] = ((arg >> 8) & 0xff) as u8;
     }
 
-    pub fn add_constant(&mut self, constant: Constant) -> u16 {
+    pub fn add_constant(&mut self, constant: Constant, dedupe: bool) -> u16 {
+        if dedupe {
+            if let Some(idx) = self.constants.iter().position(|c| *c == constant) {
+                return idx as u16;
+            }
+        }
+
         self.constants.push(constant);
         assert!(self.constants.len() <= u16::MAX as usize);
         (self.constants.len() - 1) as u16 // TODO: this can overflow, see above
@@ -1098,8 +1104,8 @@ impl Vm {
 #[test]
 fn vm_basic() {
     let mut vm = Vm::new();
-    vm.add_constant(Constant::Scalar(42.0));
-    vm.add_constant(Constant::Scalar(1.0));
+    vm.add_constant(Constant::Scalar(42.0), true);
+    vm.add_constant(Constant::Scalar(1.0), true);
 
     vm.add_op1(Op::LoadConstant, 0);
     vm.add_op1(Op::LoadConstant, 1);

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -208,6 +208,9 @@ impl Op {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ConstantDummyValue(u64);
+
 static DUMMY_CURR_VALUE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -223,7 +226,7 @@ pub enum Constant {
     String(CompactString),
     FunctionReference(FunctionReference),
     FormatSpecifiers(Option<CompactString>),
-    Dummy(u64),
+    Dummy(ConstantDummyValue),
 }
 
 impl Constant {
@@ -233,7 +236,7 @@ impl Constant {
 
     pub(crate) fn new_dummy() -> Self {
         let value = DUMMY_CURR_VALUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Constant::Dummy(value)
+        Constant::Dummy(ConstantDummyValue(value))
     }
 
     fn to_value(&self) -> Value {
@@ -258,7 +261,7 @@ impl Display for Constant {
             Constant::String(val) => write!(f, "\"{val}\""),
             Constant::FunctionReference(inner) => write!(f, "{inner}"),
             Constant::FormatSpecifiers(_) => write!(f, "<format specfiers>"),
-            Constant::Dummy(n) => write!(f, "<dummy {n}>"),
+            Constant::Dummy(ConstantDummyValue(n)) => write!(f, "<dummy {n}>"),
         }
     }
 }


### PR DESCRIPTION
Builds on https://github.com/sharkdp/numbat/pull/712 by making `Constant: Hash` so that we can stick it in an `IndexSet`. Therefore all the deduplication logic can rest solely on the nature of an `IndexSet`.

This required quite a few changes. Most notably, `Number` is now opaque instead of providing access to its contained f64 via `.0` because it no longer contains an f64, but rather a u64, which is converted to and from an f64 with `f6::to_bits`/`f64::from_bits`. But also, we have a new `Dummy` variant in `Constant` that stores an auto-incremented value each time it's created. (This is of course necessary for the deduplication logic to work correctly; identical dummies would occupy the same slot in the map.)