### PR TITLE
Remove unused field in Vm `unit_information`

### DIFF
--- a/numbat/src/bytecode_interpreter.rs
+++ b/numbat/src/bytecode_interpreter.rs
@@ -430,9 +430,6 @@ impl BytecodeInterpreter {
                 ))); // TODO: dummy is just a temp. value until the SetUnitConstant op runs
                 let unit_information_idx = self.vm.add_unit_information(
                     unit_name,
-                    Some(
-                        &crate::decorator::get_canonical_unit_name(unit_name, &decorators[..]).name,
-                    ),
                     UnitMetadata {
                         type_: type_.to_concrete_type(), // We guarantee that derived-unit definitions do not contain generics, so no TGen(..)s can escape
                         readable_type: annotation

--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -294,7 +294,6 @@ pub struct Vm {
 
     /// Meta information about derived units:
     /// - Unit name
-    /// - Canonical name
     /// - Metadata
     unit_information: Vec<(CompactString, UnitMetadata)>,
 


### PR DESCRIPTION
The canonical name field in `unit_information` was never actually used.