### PR TITLE
Unicode formatting of non-ascii unexpected characters

### DIFF
--- a/numbat/src/tokenizer.rs
+++ b/numbat/src/tokenizer.rs
@@ -6,7 +6,15 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum TokenizerErrorKind {
-    #[error("Unexpected character: '{character}'")]
+    #[error("Unexpected character: {}",
+        if *character == '\'' {
+            r#""'""#.to_owned()
+        } else if character.is_ascii() {
+            format!("'{}'", character.escape_default())
+        } else {
+            format!("'{character}' (U+{:0>4X})", *character as u32)
+        }
+    )]
     UnexpectedCharacter { character: char },
 
     #[error("Unexpected character in negative exponent")]


### PR DESCRIPTION
Closes #725. Unexpected characters are now printed as:

* `"'"` for the single quote character
* `'c'` for any other ASCII character (backslash is still `'\\'`)
* `'c' (U+XXXX)` for a non-ASCII character

```
>>> 2 + 2

error: while parsing
  ┌─ <input:60>:1:2
  │
1 │ 2 + 2
  │  ^ Unexpected character: ' ' (U+00A0)
```

This leaves open the question of whether non-ASCII whitespace characters should count as ordinary whitespace.