### PR TITLE
feat: store history at NUMBAT_HISTORY if variable exists

### DIFF
--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -31,7 +31,7 @@ use rustyline::{EventHandler, Highlighter, KeyCode, KeyEvent, Modifiers};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::{fs, thread};
+use std::{env, fs, thread};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExitStatus {
@@ -570,6 +570,14 @@ impl Cli {
     }
 
     fn get_history_path(&self) -> Result<PathBuf> {
+        if let Ok(history) = env::var("NUMBAT_HISTORY") {
+            let history_path = PathBuf::from(history);
+            if let Some(parent) = history_path.parent() {
+                fs::create_dir_all(parent).ok();
+            }
+            return Ok(history_path);
+        }
+
         let data_dir = dirs::data_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("numbat");


### PR DESCRIPTION
Lots of REPLs and CLIs allow you to store the history of commands, for example:

`PYTHON_HISTORY`, for the python repl
`NODE_REPL_HISTORY`, for the node repl
`TS_NODE_REPL_HISTORY`, for the ts-node repl

After this PR, the history of commands run in `numbat` will be stored using the `NUMBAT_HISTORY` file, instead of using data_dir. data_dir is, though, used as a fallback.