### PR TITLE
Added "M" alias to unit molar

### DIFF
--- a/numbat/modules/units/misc.nbt
+++ b/numbat/modules/units/misc.nbt
@@ -106,6 +106,7 @@ unit atmosphere: Pressure = 101_325 pascal
 @name("Molar")
 @url("https://en.wikipedia.org/wiki/Molar_concentration")
 @metric_prefixes
+@aliases(M: short)
 unit molar: Molarity = 1 mol / litre
 
 @name("Molal")


### PR DESCRIPTION
Commonly accepted abbreviation among chemists and biologists: https://en.wikipedia.org/wiki/Molar_concentration.