### PR TITLE
Make logical operators short-circuit where possible

### DIFF
--- a/numbat/src/value.rs
+++ b/numbat/src/value.rs
@@ -52,9 +52,9 @@ impl Value {
     }
 
     #[track_caller]
-    pub fn unsafe_as_bool(self) -> bool {
+    pub fn unsafe_as_bool(&self) -> bool {
         if let Value::Boolean(b) = self {
-            b
+            *b
         } else {
             panic!("Expected value to be a bool");
         }

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -650,6 +650,12 @@ fn test_logical() {
     expect_output("true && false", "false");
     expect_output("true && true", "true");
 
+    // short-circuiting
+    expect_output("false && head([])", "false");
+    expect_output("true || head([])", "true");
+    insta::assert_snapshot!(fail("true && head([])"), @"Empty list");
+    insta::assert_snapshot!(fail("false || head([])"), @"Empty list");
+
     // priority
     expect_output("false || true && false", "false");
     expect_output("false || true && !false", "true");


### PR DESCRIPTION
More efficient but also in line with most other languages out there.
