### PR TITLE
Fix color=never on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "predicates",
  "rustyline",
  "serde",
+ "termcolor",
  "terminal_size",
  "toml",
 ]

--- a/numbat-cli/Cargo.toml
+++ b/numbat-cli/Cargo.toml
@@ -23,6 +23,7 @@ toml = { version = "0.8.8", features = ["parse"] }
 serde = { version = "1.0.195", features = ["derive"] }
 terminal_size = "0.4.2"
 jiff = "0.2"
+termcolor = "1.4.1"
 
 [dependencies.clap]
 version = "4"

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -815,14 +815,22 @@ impl Context {
         Ok((typed_statements, result))
     }
 
-    pub fn print_diagnostic(&self, error: impl ErrorDiagnostic) {
+    pub fn print_diagnostic(&self, error: impl ErrorDiagnostic, colorize: bool) {
         use codespan_reporting::term::{
             self,
             termcolor::{ColorChoice, StandardStream},
             Config,
         };
 
-        let writer = StandardStream::stderr(ColorChoice::Auto);
+        let color = if colorize {
+            // by leaving it in auto we makes sure it can still
+            // chose between true or ansi colors
+            ColorChoice::Auto
+        } else {
+            ColorChoice::Never
+        };
+
+        let writer = StandardStream::stderr(color);
         let config = Config::default();
 
         // we want to be sure no one can write between our diagnostics


### PR DESCRIPTION
It should work both in REPL and "CLI" mode 👍 

`termcolor` is added to `numbat-cli`, but was already being used by our diagnostics anyway.

Screenshot:

<img width="922" height="529" alt="image" src="https://github.com/user-attachments/assets/a96beb64-7573-4cea-be81-4929ba89b1b9" />
