### PR TITLE
Add edit mode option

### DIFF
--- a/book/src/cli-customization.md
+++ b/book/src/cli-customization.md
@@ -59,6 +59,9 @@ prompt = ">>> "
 # only in interactive mode.
 pretty-print = "auto"
 
+# Controls the edit mode. Can be "emacs", or "vi".
+edit-mode = "emacs"
+
 [exchange-rates]
 # When and if to load exchange rates from the European Central Bank for
 # currency conversions. Can be "on-startup" to always fetch exchange rates

--- a/numbat-cli/src/config.rs
+++ b/numbat-cli/src/config.rs
@@ -49,6 +49,14 @@ pub enum ColorMode {
     Auto,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Default, Debug, Clone, Copy, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum EditMode {
+    #[default]
+    Emacs,
+    Vi,
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
@@ -56,6 +64,7 @@ pub struct Config {
     pub prompt: CompactString,
     pub pretty_print: PrettyPrintMode,
     pub color: ColorMode,
+    pub edit_mode: EditMode,
 
     #[serde(skip)]
     pub enter_repl: bool,
@@ -75,6 +84,7 @@ impl Default for Config {
             intro_banner: IntroBanner::default(),
             pretty_print: PrettyPrintMode::Auto,
             color: ColorMode::default(),
+            edit_mode: EditMode::default(),
             load_prelude: true,
             load_user_init: true,
             exchange_rates: Default::default(),

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -6,7 +6,9 @@ mod highlighter;
 use ansi_formatter::ansi_format;
 use colored::control::SHOULD_COLORIZE;
 use completer::NumbatCompleter;
-use config::{ColorMode, Config, ExchangeRateFetchingPolicy, IntroBanner, PrettyPrintMode};
+use config::{
+    ColorMode, Config, EditMode, ExchangeRateFetchingPolicy, IntroBanner, PrettyPrintMode,
+};
 use highlighter::NumbatHighlighter;
 
 use itertools::Itertools;
@@ -299,6 +301,10 @@ impl Cli {
         let history_path = self.get_history_path()?;
 
         let mut rl = Editor::<NumbatHelper, DefaultHistory>::new()?;
+        rl.set_edit_mode(match self.config.edit_mode {
+            EditMode::Emacs => rustyline::EditMode::Emacs,
+            EditMode::Vi => rustyline::EditMode::Vi,
+        });
         rl.set_max_history_size(1000)
             .context("Error while configuring history size")?;
         rl.set_completion_type(rustyline::CompletionType::List);


### PR DESCRIPTION
Adds a config option `edit-mode` to control the rustyline edit mode.
Supports `"emacs"`, and `"vi"`. Defaults to `"emacs"`.

Fixes #365.
