### PR TITLE
Raise DivisionByZero error in case of zero to negative power

### DIFF
--- a/numbat/src/vm.rs
+++ b/numbat/src/vm.rs
@@ -722,12 +722,10 @@ impl Vm {
                         Op::Divide => Ok(lhs
                             .checked_div(rhs)
                             .ok_or_else(|| self.runtime_error(RuntimeErrorKind::DivisionByZero))?),
-                        Op::Power => Ok(lhs.power(rhs).map_err(|e| match e {
-                            QuantityError::ZeroToNegativePower => {
-                                self.runtime_error(RuntimeErrorKind::DivisionByZero)
-                            }
-                            _ => self.runtime_error(RuntimeErrorKind::QuantityError(e)),
-                        })?),
+                        Op::Power => Ok(lhs
+                            .checked_power(rhs)
+                            .map_err(|e| self.runtime_error(RuntimeErrorKind::QuantityError(e)))?
+                            .ok_or_else(|| self.runtime_error(RuntimeErrorKind::DivisionByZero))?),
                         // If the user specifically converted the type of a unit, we should NOT simplify this value
                         // before any operations are applied to it
                         Op::ConvertTo => lhs.convert_to(rhs.unit()).map(Quantity::no_simplify),

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -247,6 +247,7 @@ fn test_exponentiation() {
 
     expect_failure("0^(-1)", "Division by zero");
     expect_failure("0^(-2)", "Division by zero");
+    expect_failure("(0m)^(-2)", "Division by zero");
 }
 
 #[test]


### PR DESCRIPTION
When raising zero to a negative power, `DivisionByZero` error is raised.

Fixes issue #684 in a similar manner to the failed PR #719.

- Added `QuantityError::ZeroToNegativePower`
- Added an if-else in the function `power` to return the new error in the right case
- Changed `run_without_cleanup` function
  - In `Op::Power` arm of the match case, the new error is caught and remapped to a `DivisionByZero` error
- Added 2 tests in `interpreter.rs`

As I am pretty new to rust, any recommendations on how to improve the code (maybe similarly to `checked_div` function), are welcome!