### PR TITLE
Pragmatic implementation of °C and °F (including conversions)

### DIFF
--- a/book/src/basics/conversions.md
+++ b/book/src/basics/conversions.md
@@ -91,8 +91,8 @@ fit into 6 hours, you can write:
 
     ``` numbat
     > let concorde_speed = 2180 km/h
-    > concorde_speed -> speed_of_sound(from_celsius(-60))
-      
+    > concorde_speed -> speed_of_sound(-60 °C)
+
       = 2.06885 × 292.701 m/s    [Velocity]
     ```
 
@@ -106,6 +106,38 @@ If you want to convert a quantity to the *same unit as another quantity*, you ca
   10.8 km/h    [Velocity]
 ```
 
+### Temperature conversions
+
+Temperature units like °C (degree Celsius) and °F (degree Fahrenheit) are special because they are not just scaled versions of the base unit (Kelvin), but also have an offset.
+In Numbat, only the base unit Kelvin (`K`, `kelvin`) is an actual unit of type `Temperature`. The other temperature units can only be used to *enter* temperature values, and as
+the target of a *conversion*. When you enter an expression like `25 °C`, it is immediately converted to `298.15 K`, and when `°C` and `°F` are used on the right hand side of a
+unit conversion, you will only get the plain number as a result (without the unit). You can still do useful computations and conversions with these units. For example:
+
+``` numbat
+> 25 °C
+
+    = 298.15 K    [Temperature]
+
+> 25 °C -> °F
+
+    = 77
+
+>>> element("Fe").melting_point -> °C
+
+    = 1538
+```
+
+If your keyboard layout does contain the `°` symbol, you can also use `celsius`/`fahrenheit` or `degree_celsius`/`degree_fahrenheit` instead of `°C`/`°F`.
+Alternatively, you can also use Numbat's Unicode input feature and type `\degree<tab>` to get the `°` symbol.
+
+!!! warning "Computations with °C and °F"
+
+    You need to be extra careful when doing computations with °C and °F. Numbat does currently not prevent you from
+    doing something like `10 °C + 1 °C`, even if the result is probably *not* what you expect. Since each of these
+    values will be converted to Kelvin before the addition, the result will be `557.3 K` (or `284.15 °C`), and not
+    `11 °C`. If you really want to add two temperatures, one of them should be a *temperature difference* expressed
+    in `K` (e.g. `10 °C + 1 K`). *Subtracting* two temperatures is always fine, since any offsets will cancel out.
+    For example, `20 °C - 10 °C` will correctly give a result of `10 K`.
 
 ## Conversion functions
 

--- a/book/src/basics/unit-notation.md
+++ b/book/src/basics/unit-notation.md
@@ -22,12 +22,14 @@ The following snippet shows various styles of entering units:
 sin(30°)
 50 mph
 6 MiB
+25 °C
 
 2 minutes + 1 second
 150 centimeters
 sin(30 degrees)
 50 miles per hour
 6 mebibyte
+25 degree_celsius
 ```
 
 Note that Numbat also allows you to [define new units](../advanced/unit-definitions.md).
@@ -50,7 +52,7 @@ Note that Numbat also allows you to [define new units](../advanced/unit-definiti
 
     let c_water = 1 cal / g K
 
-    let ΔT = from_fahrenheit(212) - from_fahrenheit(70)
+    let ΔT = 212 °F - 70 °F
 
     let heat = mass_water × c_water × ΔT
 
@@ -60,4 +62,4 @@ Note that Numbat also allows you to [define new units](../advanced/unit-definiti
     print("  {heat -> kWh}")
     ```
 
-    [:material-play-circle: Run this example](https://numbat.dev/?q=let+density_water+%3D+1+kg+%2F+L++%23+at+sea+level%0Alet+mass_water+%3D+1+gallon+%C3%97+density_water%0A%0Alet+c_water+%3D+1+cal+%2F+g+K%0A%0Alet+%CE%94T+%3D+from_fahrenheit%28212%29+-+from_fahrenheit%2870%29%0A%0Alet+heat+%3D+mass_water+%C3%97+c_water+%C3%97+%CE%94T%0A%0Aprint%28%22Energy+to+boil+1+gallon+of+room-temperature+water%3A%22%29%0Aprint%28%22++%7Bheat+-%3E+kJ%7D%22%29%0Aprint%28%22++%7Bheat+-%3E+BTU%7D%22%29%0Aprint%28%22++%7Bheat+-%3E+kWh%7D%22%29%E2%8F%8E){ .md-button .md-button--primary }
+    [:material-play-circle: Run this example](https://numbat.dev/?q=let+density_water+%3D+1+kg+%2F+L++%23+at+sea+level%0Alet+mass_water+%3D+1+gallon+%C3%97+density_water%0A%0Alet+c_water+%3D+1+cal+%2F+g+K%0A%0Alet+%CE%94T+%3D+212+%C2%B0F+-+70+%C2%B0F%0A%0Alet+heat+%3D+mass_water+%C3%97+c_water+%C3%97+%CE%94T%0A%0Aprint%28%22Energy+to+boil+1+gallon+of+room-temperature+water%3A%22%29%0Aprint%28%22++%7Bheat+-%3E+kJ%7D%22%29%0Aprint%28%22++%7Bheat+-%3E+BTU%7D%22%29%0Aprint%28%22++%7Bheat+-%3E+kWh%7D%22%29%E2%8F%8E){ .md-button .md-button--primary }

--- a/book/src/prelude/functions/other.md
+++ b/book/src/prelude/functions/other.md
@@ -452,68 +452,92 @@ fn pounds_and_ounces(mass: Mass) -> List<Mass>
 Defined in: `physics::temperature_conversion`
 
 ### `from_celsius`
-Converts from degree Celsius (°C) to Kelvin.
-More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
 
 ```nbt
 fn from_celsius(t_celsius: Scalar) -> Temperature
 ```
 
-!!! example "300 °C in Kelvin."
-    ```nbt
-    from_celsius(300)
+### `°C`
+Converts from Kelvin to degree Celsius (°C). Can be used on the right hand side of a conversion operator.
+More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
 
-        = 573.15 K    [Temperature]
+```nbt
+fn °C(t_kelvin: Temperature) -> Scalar
+```
+
+!!! example "Convert 300 K to degree Celsius."
+    ```nbt
+    300 K -> °C
+
+        = 26.85
     ```
-    [:material-play-circle: Run this example](https://numbat.dev/?q=from%5Fcelsius%28300%29){ .md-button }
+    [:material-play-circle: Run this example](https://numbat.dev/?q=300%20K%20%2D%3E%20%C2%B0C){ .md-button }
+
+!!! example "Convert 55 °F to degree Celsius."
+    ```nbt
+    55 °F -> °C
+
+        = 12.7778
+    ```
+    [:material-play-circle: Run this example](https://numbat.dev/?q=55%20%C2%B0F%20%2D%3E%20%C2%B0C){ .md-button }
 
 ### `celsius`
-Converts from Kelvin to degree Celcius (°C). This can be used on the right hand side of a conversion operator: `200 K -> celsius`.
-More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
+An alias for `°C`.
 
 ```nbt
 fn celsius(t_kelvin: Temperature) -> Scalar
 ```
 
-!!! example "300 K in degree Celsius."
-    ```nbt
-    300K -> celsius
+### `degree_celsius`
+An alias for `°C`.
 
-        = 26.85
-    ```
-    [:material-play-circle: Run this example](https://numbat.dev/?q=300K%20%2D%3E%20celsius){ .md-button }
+```nbt
+fn degree_celsius(t_kelvin: Temperature) -> Scalar
+```
 
 ### `from_fahrenheit`
-Converts from degree Fahrenheit (°F) to Kelvin.
-More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
 
 ```nbt
 fn from_fahrenheit(t_fahrenheit: Scalar) -> Temperature
 ```
 
-!!! example "300 °F in Kelvin."
-    ```nbt
-    from_fahrenheit(300)
+### `°F`
+Converts from Kelvin to degree Fahrenheit (°F). Can be used on the right hand side of a conversion operator.
+More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
 
-        = 422.039 K    [Temperature]
+```nbt
+fn °F(t_kelvin: Temperature) -> Scalar
+```
+
+!!! example "Convert 300 K to degree Fahrenheit."
+    ```nbt
+    300 K -> °F
+
+        = 80.33
     ```
-    [:material-play-circle: Run this example](https://numbat.dev/?q=from%5Ffahrenheit%28300%29){ .md-button }
+    [:material-play-circle: Run this example](https://numbat.dev/?q=300%20K%20%2D%3E%20%C2%B0F){ .md-button }
+
+!!! example "Convert 25 °C to degree Fahrenheit."
+    ```nbt
+    25 °C -> °F
+
+        = 77
+    ```
+    [:material-play-circle: Run this example](https://numbat.dev/?q=25%20%C2%B0C%20%2D%3E%20%C2%B0F){ .md-button }
 
 ### `fahrenheit`
-Converts from Kelvin to degree Fahrenheit (°F). This can be used on the right hand side of a conversion operator: `200 K -> fahrenheit`.
-More information [here](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature).
+An alias for `°F`.
 
 ```nbt
 fn fahrenheit(t_kelvin: Temperature) -> Scalar
 ```
 
-!!! example "300 K in degree Fahrenheit."
-    ```nbt
-    300K -> fahrenheit
+### `degree_fahrenheit`
+An alias for `°F`.
 
-        = 80.33
-    ```
-    [:material-play-circle: Run this example](https://numbat.dev/?q=300K%20%2D%3E%20fahrenheit){ .md-button }
+```nbt
+fn degree_fahrenheit(t_kelvin: Temperature) -> Scalar
+```
 
 ## Speed of sound
 
@@ -529,11 +553,11 @@ fn speed_of_sound(T_air: Temperature) -> Velocity
 
 !!! example "Example"
     ```nbt
-    speed_of_sound(from_celsius(20))
+    speed_of_sound(20 °C)
 
         = 343.263 m/s    [Velocity]
     ```
-    [:material-play-circle: Run this example](https://numbat.dev/?q=speed%5Fof%5Fsound%28from%5Fcelsius%2820%29%29){ .md-button }
+    [:material-play-circle: Run this example](https://numbat.dev/?q=speed%5Fof%5Fsound%2820%20%C2%B0C%29){ .md-button }
 
 ## Color format conversion
 

--- a/examples/boil.nbt
+++ b/examples/boil.nbt
@@ -13,7 +13,7 @@ let mass_water = 1 gallon × density_water
 
 let c_water = 1 cal / g K
 
-let ΔT = from_fahrenheit(212) - from_fahrenheit(70)
+let ΔT = 212 °F - 70 °F
 
 let heat = mass_water × c_water × ΔT
 

--- a/examples/tests/speed_of_sound.nbt
+++ b/examples/tests/speed_of_sound.nbt
@@ -1,5 +1,5 @@
 # Reference values from https://en.wikipedia.org/wiki/Speed_of_sound#Tables
 
-assert_eq(speed_of_sound(from_celsius(-20)), 318.9 m / s, 0.1 m / s)
-assert_eq(speed_of_sound(from_celsius(0)), 331.3 m / s, 0.1 m / s)
-assert_eq(speed_of_sound(from_celsius(20)), 343.2 m / s, 0.1 m / s)
+assert_eq(speed_of_sound(-20 °C), 318.9 m / s, 0.1 m / s)
+assert_eq(speed_of_sound(0 °C), 331.3 m / s, 0.1 m / s)
+assert_eq(speed_of_sound(20 °C), 343.2 m / s, 0.1 m / s)

--- a/examples/thermal_conductivity.nbt
+++ b/examples/thermal_conductivity.nbt
@@ -9,4 +9,4 @@ fn heat_transfer(λ: ThermalConductivity,
 
 let λ_concrete: ThermalConductivity = 0.92 W / (m · K)
 
-print(heat_transfer(λ_concrete, 3 m × 2 m, 20 cm, from_celsius(20), from_celsius(0)))
+print(heat_transfer(λ_concrete, 3 m × 2 m, 20 cm, 20 °C, 0 °C))

--- a/numbat/modules/physics/speed_of_sound.nbt
+++ b/numbat/modules/physics/speed_of_sound.nbt
@@ -4,7 +4,7 @@ use physics::temperature_conversion
 
 @name("Speed of sound in dry air")
 @description("Calculate the speed of sound in dry air as a function of air temperature.")
-@example("speed_of_sound(from_celsius(20))")
+@example("speed_of_sound(20 °C)")
 @url("https://en.wikipedia.org/wiki/Speed_of_sound#Speed_of_sound_in_ideal_gases_and_air")
 fn speed_of_sound(T_air: Temperature) -> Velocity =
     sqrt(γ_air R T_air / M_air) -> m / s

--- a/numbat/modules/physics/temperature_conversion.nbt
+++ b/numbat/modules/physics/temperature_conversion.nbt
@@ -4,25 +4,35 @@ use units::si
 
 let _offset_celsius = 273.15
 
-@description("Converts from degree Celsius (°C) to Kelvin.")
-@example("from_celsius(300)", "300 °C in Kelvin.")
-@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
+# Note: from_celsius is used internally by the `… °C` syntax
 fn from_celsius(t_celsius: Scalar) -> Temperature = (t_celsius + _offset_celsius) kelvin
 
-@description("Converts from Kelvin to degree Celcius (°C). This can be used on the right hand side of a conversion operator: `200 K -> celsius`.")
-@example("300K -> celsius", "300 K in degree Celsius.")
+@description("Converts from Kelvin to degree Celsius (°C). Can be used on the right hand side of a conversion operator.")
+@example("300 K -> °C", "Convert 300 K to degree Celsius.")
+@example("55 °F -> °C", "Convert 55 °F to degree Celsius.")
 @url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
-fn celsius(t_kelvin: Temperature) -> Scalar = t_kelvin / kelvin - _offset_celsius
+fn °C(t_kelvin: Temperature) -> Scalar = t_kelvin / kelvin - _offset_celsius
+
+@description("An alias for `°C`.")
+fn celsius(t_kelvin: Temperature) -> Scalar = °C(t_kelvin)
+
+@description("An alias for `°C`.")
+fn degree_celsius(t_kelvin: Temperature) -> Scalar = °C(t_kelvin)
 
 let _offset_fahrenheit = 459.67
 let _scale_fahrenheit = 5 / 9
 
-@description("Converts from degree Fahrenheit (°F) to Kelvin.")
-@example("from_fahrenheit(300)", "300 °F in Kelvin.")
-@url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
+# Note: from_fahrenheit is used internally by the `… °F` syntax
 fn from_fahrenheit(t_fahrenheit: Scalar) -> Temperature = ((t_fahrenheit + _offset_fahrenheit) × _scale_fahrenheit) kelvin
 
-@description("Converts from Kelvin to degree Fahrenheit (°F). This can be used on the right hand side of a conversion operator: `200 K -> fahrenheit`.")
-@example("300K -> fahrenheit", "300 K in degree Fahrenheit.")
+@description("Converts from Kelvin to degree Fahrenheit (°F). Can be used on the right hand side of a conversion operator.")
+@example("300 K -> °F", "Convert 300 K to degree Fahrenheit.")
+@example("25 °C -> °F", "Convert 25 °C to degree Fahrenheit.")
 @url("https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature")
-fn fahrenheit(t_kelvin: Temperature) -> Scalar = (t_kelvin / kelvin) / _scale_fahrenheit - _offset_fahrenheit
+fn °F(t_kelvin: Temperature) -> Scalar = (t_kelvin / kelvin) / _scale_fahrenheit - _offset_fahrenheit
+
+@description("An alias for `°F`.")
+fn fahrenheit(t_kelvin: Temperature) -> Scalar = °F(t_kelvin)
+
+@description("An alias for `°F`.")
+fn degree_fahrenheit(t_kelvin: Temperature) -> Scalar = °F(t_kelvin)

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -299,9 +299,20 @@ impl Context {
             add_if_valid(variable.into());
         }
 
+        // Temperature conversion functions that are used as pseudo-units (e.g., "20 celsius")
+        // should not have parentheses added during completion
+        const TEMPERATURE_PSEUDO_UNITS: &[&str] = &[
+            "celsius",
+            "degree_celsius",
+            "fahrenheit",
+            "degree_fahrenheit",
+            "°C",
+            "°F",
+        ];
+
         for function_name in self.function_names() {
             let mut function = function_name.clone();
-            if add_paren {
+            if add_paren && !TEMPERATURE_PSEUDO_UNITS.contains(&function_name.as_str()) {
                 if let Some((signature, _)) = self.typechecker.lookup_function(&function_name) {
                     if signature.parameters.is_empty() {
                         function.push_str("()");

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -486,16 +486,16 @@ fn test_incompatible_dimension_errors() {
 
 #[test]
 fn test_temperature_conversions() {
-    expect_output("from_celsius(11.5)", "284.65 K");
-    expect_output("from_fahrenheit(89.3)", "304.983 K");
-    expect_output("0 K -> celsius", "-273.15");
+    expect_output("11.5 °C", "284.65 K");
+    expect_output("89.3 °F", "304.983 K");
+    expect_output("0 K -> °C", "-273.15");
     expect_output("fahrenheit(30 K)", "-405.67");
-    expect_output("from_celsius(100) -> celsius", "100");
-    expect_output("from_fahrenheit(100) -> fahrenheit", "100.0");
-    expect_output("from_celsius(123 K -> celsius)", "123 K");
-    expect_output("from_fahrenheit(123 K -> fahrenheit)", "123 K");
+    expect_output("100 °C -> °C", "100");
+    expect_output("100 °F -> °F", "100.0");
+    expect_output("(123 K -> °C) °C", "123 K");
+    expect_output("(123 K -> °F) °F", "123 K");
 
-    expect_output("-40 -> from_fahrenheit -> celsius", "-40");
+    expect_output("-40 °F -> °C", "-40");
 }
 
 #[test]
@@ -1158,6 +1158,46 @@ fn test_parse() {
         "unit leap = 2 meter\nlet x: Length = parse(\"3 leap\"); x",
         "3 leap",
     );
+}
+
+#[test]
+fn test_temperature_syntactic_sugar() {
+    // Entering temperatures in °C/°F
+    expect_output("0 °C", "273.15 K");
+    expect_output("100 °C", "373.15 K");
+    expect_output("-5 °C", "268.15 K");
+    expect_output("32 °F", "273.15 K");
+    expect_output("212 °F", "373.15 K");
+
+    // Conversions to °C/°F
+    expect_output("273.15 K -> °C", "0");
+    expect_output("373.15 K -> °F", "212");
+
+    // Conversions between °C and °F
+    expect_output("100 °C -> °F", "212");
+    expect_output("212 °F -> °C", "100.0");
+    expect_output("-40 °C -> °F", "-40.0");
+    expect_output("-40 °F -> °C", "-40");
+
+    // Expressions
+    expect_output("(50 + 50) °C", "373.15 K");
+    expect_output("0 °C + 10 K -> °C", "10");
+
+    // Aliases work too
+    expect_output("20 celsius", "293.15 K");
+    expect_output("20 degree_celsius", "293.15 K");
+    expect_output("68 fahrenheit", "293.15 K");
+    expect_output("68 degree_fahrenheit", "293.15 K");
+
+    // Pretty-printing renders using °C/°F syntax
+    expect_pretty_print("let t = 20 °C", "let t: Temperature = 20 °C");
+    expect_pretty_print("let t = -5 °F", "let t: Temperature = (-5) °F");
+    expect_pretty_print("let v = 300 K -> °C", "let v: Scalar = 300 kelvin -> °C");
+    expect_pretty_print("let v = 300 K -> °F", "let v: Scalar = 300 kelvin -> °F");
+
+    // Aliases pretty-print as °C/°F
+    expect_pretty_print("let t = 20 celsius", "let t: Temperature = 20 °C");
+    expect_pretty_print("let t = 68 fahrenheit", "let t: Temperature = 68 °F");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a very pragmatic implementation of °C and °F. I'm not completely happy with it (see warning in the docs below), but if we're being honest, this serves 95% of all use cases. And it's just extremely useful to be able to say `25 °C to °F`, `80 fahrenheit -> celsius`, or `speed_of_sound(25 °C)`.

The way this works is that we treat `25 °C` as syntactic sugar for `from_celsius(25)`. This way, entering `25 °C` gives you a temperature value of `298.15 K`. It's not great that we need special support in the compiler for this, but it solves the "entering temperatures in a convenient way" part of the problem. Since this is handled entirely in the compiler, the names `°C` and `°F` are still free to use, this let's use define a conversion function `fn °C(t_kelvin: Temperature) -> Scalar` that can be used on the right hand side of a conversion operator. Finally, we add some special handling in the AST pretty-printer to turn a `from_celsius(25)` call back into `25 °C`.

closes #184 
closes #820 

Screenshot of the new temperature conversion section in the docs:

<img width="860" height="958" alt="image" src="https://github.com/user-attachments/assets/3bc84632-0967-4e78-8f88-42d4ea4a4cb9" />
