### PR TITLE
Expose TypeCheckError as a public type

### DIFF
--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -72,7 +72,7 @@ use resolver::CodeSource;
 use resolver::Resolver;
 use resolver::ResolverError;
 use thiserror::Error;
-use typechecker::{TypeCheckError, TypeChecker};
+use typechecker::TypeChecker;
 
 pub use diagnostic::Diagnostic;
 pub use interpreter::InterpreterResult;
@@ -83,6 +83,7 @@ pub use parser::ParseError;
 pub use pretty_print::FormatOptions;
 pub use registry::BaseRepresentation;
 pub use registry::BaseRepresentationFactor;
+pub use typechecker::TypeCheckError;
 pub use typed_ast::Statement;
 pub use typed_ast::Type;
 use unit::BaseUnitAndFactor;


### PR DESCRIPTION
The public type [`NumbatError`](https://docs.rs/numbat/1.22.0/numbat/enum.NumbatError.html) references the type `TypeCheckError` but this isn't pubic.  Now it is.