### PR TITLE
Display litres as `L` instead of `l`

### DIFF
--- a/book/src/prelude/list-units.md
+++ b/book/src/prelude/list-units.md
@@ -237,7 +237,7 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Volume` | [Imperial Quart](https://en.wikipedia.org/wiki/Quart#Imperial_quart) | `imperial_quart`, `imperial_quarts`, `UK_qt`, `UK_quart`, `UK_quarts` |
 | `Volume` | [UK tablespoon](https://en.wikipedia.org/wiki/Tablespoon) | `imperial_tablespoon`, `UK_tablespoon`, `UK_tablespoons`, `UK_tbsp` |
 | `Volume` | [UK teaspoon](https://en.wikipedia.org/wiki/Teaspoon) | `imperial_teaspoon`, `imperial_teaspoons`, `UK_teaspoon`, `UK_teaspoons`, `UK_tsp` |
-| `Volume` | [Litre](https://en.wikipedia.org/wiki/Litre) | `l`, `L`, `liter`, `liters`, `litre`, `litres` |
+| `Volume` | [Litre](https://en.wikipedia.org/wiki/Litre) | `L`, `l`, `liter`, `liters`, `litre`, `litres` |
 | `Volume` | [Metric tablespoon](https://en.wikipedia.org/wiki/Tablespoon) | `metric_tablespoon`, `metric_tablespoons`, `metric_tbsp` |
 | `Volume` | [Metric teaspoon](https://en.wikipedia.org/wiki/Teaspoon) | `metric_teaspoon`, `metric_teaspoons`, `metric_tsp` |
 | `Volume` | [US liquid pint](https://en.wikipedia.org/wiki/Pint) | `pint`, `pints` |

--- a/numbat/modules/units/si.nbt
+++ b/numbat/modules/units/si.nbt
@@ -229,7 +229,7 @@ unit hectare: Area = 100 are
 @name("Litre")
 @url("https://en.wikipedia.org/wiki/Litre")
 @metric_prefixes
-@aliases(litres, liter, liters, l: short, L: short)
+@aliases(litres, liter, liters, L: short, l: short)
 unit litre: Volume = decimeter^3
 
 @name("Tonne")

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -274,7 +274,7 @@ fn test_conversions_with_nontrivial_magnitude() {
     expect_output("2 m -> 10 m", "0.2 × 10 m");
     expect_output("10 m -> 0.5 m", "20 × 0.5 m");
     expect_output("10 m -> (m/3)", "30 × 0.333333 m");
-    expect_output("1/(30 mpg) -> L/(100 km)", "7.84049 × 0.01 l/km");
+    expect_output("1/(30 mpg) -> L/(100 km)", "7.84049 × 0.01 L/km");
 
     // When RHS value is 1 (explicitly or implicitly), behave as usual
     expect_output("10 m -> m", "10 m");

--- a/numbat/tests/snapshots/example_snapshots__molarity@molarity.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__molarity@molarity.nbt.snap
@@ -3,4 +3,4 @@ source: numbat/tests/example_snapshots.rs
 expression: output
 input_file: examples/molarity.nbt
 ---
-154.004 mmol/l
+154.004 mmol/L

--- a/numbat/tests/snapshots/example_snapshots__numbat_syntax@numbat_syntax.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__numbat_syntax@numbat_syntax.nbt.snap
@@ -9,4 +9,4 @@ value of pi = 3.14159
 sqrt(10) = 3.16228
 value of π ≈ 3.142
 = Length / Time
-    = 0.08988 g/l
+    = 0.08988 g/L

--- a/numbat/tests/snapshots/example_snapshots__pipe_flow_rate@pipe_flow_rate.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__pipe_flow_rate@pipe_flow_rate.nbt.snap
@@ -3,4 +3,4 @@ source: numbat/tests/example_snapshots.rs
 expression: output
 input_file: examples/pipe_flow_rate.nbt
 ---
-Flow rate: 3.92699 l/s
+Flow rate: 3.92699 L/s

--- a/numbat/tests/snapshots/example_snapshots__recipe@recipe.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__recipe@recipe.nbt.snap
@@ -3,7 +3,7 @@ source: numbat/tests/example_snapshots.rs
 expression: output
 input_file: examples/recipe.nbt
 ---
-Milk:          750 ml
+Milk:          750 mL
 Flour:         375 g
 Sugar:         3 cup
 Baking powder: 6 tbsp


### PR DESCRIPTION
Fixes #839.