### PR TITLE
Fix infinite recursion for bin(inf), hex(NaN), etc.

### DIFF
--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -106,11 +106,11 @@ fn base(b: Scalar, x: Scalar) -> String =
     then error("NaN has no base-{b} representation")
   else if b < 2 || b > 16
     then error("base must be between 2 and 16")
-    else if x < 0
-      then "-{base(b, -x)}"
-      else if x < b
-        then _digit_in_base(b, x)
-        else str_append(base(b, floor(x / b)), _digit_in_base(b, mod(x, b)))
+  else if x < 0
+    then "-{base(b, -x)}"
+  else if x < b
+    then _digit_in_base(b, x)
+    else str_append(base(b, floor(x / b)), _digit_in_base(b, mod(x, b)))
 
 @description("Get a binary representation of a number.")
 @example("42 -> bin")

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -1,6 +1,7 @@
 use core::scalar
 use core::functions
 use core::error
+use core::numbers
 
 @description("The length of a string")
 @example("str_length(\"Numbat\")")
@@ -99,7 +100,11 @@ fn _digit_in_base(base: Scalar, x: Scalar) -> String =
 @description("Convert a number to the given base.")
 @example("42 |> base(16)")
 fn base(b: Scalar, x: Scalar) -> String =
-  if b < 2 || b > 16
+  if is_infinite(x)
+    then error("Infinity has no base-{b} representation")
+  else if is_nan(x)
+    then error("NaN has no base-{b} representation")
+  else if b < 2 || b > 16
     then error("base must be between 2 and 16")
     else if x < 0
       then "-{base(b, -x)}"

--- a/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@invalid_base.nbt.snap
+++ b/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@invalid_base.nbt.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/runtime_error/invalid_base.nbt
 ---
 error: runtime error
-    ┌─ Module 'core::strings', File [PRELUDE_FILE]:103:10
+    ┌─ Module 'core::strings', File [PRELUDE_FILE]:108:10
     │
-103 │     then error("base must be between 2 and 16")
+108 │     then error("base must be between 2 and 16")
     │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     ┌─ <internal:3>:1:1
@@ -18,6 +18,6 @@ error: runtime error
 
 help: Backtrace:
  = 0: error("base must be between 2 and 16")
-   	at base - Module 'core::strings', File [PRELUDE_FILE]:103:10
+   	at base - Module 'core::strings', File [PRELUDE_FILE]:108:10
  = 1: base(-4, 10)
    	at <main> - <internal:3>:1:0


### PR DESCRIPTION
As mentioned in #851, when `bin(inf)` is called, numbat just enters a recursive loop that never ends. This PR fixes that in the one case of converting bases.

Perhaps a maximum recursion depth could be introduced to stop this from happening with other functions like `str_repeat`.