### PR TITLE
Follow XDG base directories on macOS when set

### DIFF
--- a/book/src/cli/customization.md
+++ b/book/src/cli/customization.md
@@ -18,7 +18,7 @@ Numbat's configuration folder (`<config-path>` above) can be found under:
 |Platform|Path|
 |---|---|
 |Linux|`$HOME/.config/numbat` or `$XDG_CONFIG_HOME/numbat`|
-|macOS|`$HOME/Library/Application Support/numbat`|
+|macOS|`$HOME/Library/Application Support/numbat` or `$XDG_CONFIG_HOME/numbat`|
 |Windows|`C:\Users\Alice\AppData\Roaming\numbat`|
 
 ## Module paths

--- a/numbat-cli/src/main.rs
+++ b/numbat-cli/src/main.rs
@@ -594,7 +594,12 @@ impl Cli {
     }
 
     fn get_config_path() -> PathBuf {
-        let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+        // Respect XDG_CONFIG_HOME if it is set, even on platforms where it is
+        // not the default (macOS, Windows). Many command line tools follow this
+        // convention, see https://github.com/sharkdp/numbat/issues/744.
+        let config_dir = xdg_dir("XDG_CONFIG_HOME")
+            .or_else(dirs::config_dir)
+            .unwrap_or_else(|| PathBuf::from("."));
         config_dir.join("numbat")
     }
 
@@ -633,12 +638,23 @@ impl Cli {
             return Ok(history_path);
         }
 
-        let data_dir = dirs::data_dir()
+        let data_dir = xdg_dir("XDG_DATA_HOME")
+            .or_else(dirs::data_dir)
             .unwrap_or_else(|| PathBuf::from("."))
             .join("numbat");
         fs::create_dir_all(&data_dir).ok();
         Ok(data_dir.join("history"))
     }
+}
+
+/// Return the directory pointed to by the given XDG environment variable, but
+/// only if it is set to a non-empty, absolute path. Per the XDG Base Directory
+/// specification, relative paths must be ignored. This lets users opt into XDG
+/// directories even on platforms where they are not the default (macOS,
+/// Windows).
+fn xdg_dir(env_var: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(env::var_os(env_var)?);
+    path.is_absolute().then_some(path)
 }
 
 fn generate_config() -> Result<()> {


### PR DESCRIPTION
Closes #744.

On macOS (and Windows), the `dirs` crate intentionally ignores `XDG_CONFIG_HOME` /
`XDG_DATA_HOME` and always returns the platform-native locations
(`~/Library/Application Support`, `%APPDATA%`). This makes Numbat honor those variables
when they are set, so config and history land in the same place as on Linux — which is
what many command-line tools do, and which keeps CLI state separate from GUI-app state
(the issue mentions tools like *pearcleaner* flagging the native-dir files as orphaned).

> **On the approach:** you noted in the issue that switching to
> [`etcetera`](https://docs.rs/etcetera/) would probably be needed. **If you'd prefer
> that route, I'm very happy to convert this PR to use `etcetera` instead — just say the
> word.** I went with a smaller, dependency-free change here because it resolves the issue
> directly without adding a dependency or reworking the rest of the path logic, but I'm
> equally glad to do the `etcetera` migration if that's the direction you'd like.

## What changed

`numbat-cli/src/main.rs`:
- `get_config_path()` now prefers `XDG_CONFIG_HOME` when set, falling back to
  `dirs::config_dir()`.
- `get_history_path()` now prefers `XDG_DATA_HOME` when set, falling back to
  `dirs::data_dir()`.
- A small helper does the lookup:
  ```rust
  fn xdg_dir(env_var: &str) -> Option<PathBuf> {
      let path = PathBuf::from(env::var_os(env_var)?);
      path.is_absolute().then_some(path)
  }
  ```
  Per the XDG Base Directory specification, a relative `XDG_*` value must be ignored, so
  the helper only returns the path when it is absolute and otherwise falls back to the
  previous behavior.

`book/src/cli/customization.md`: documents `$XDG_CONFIG_HOME/numbat` in the macOS
config-path row.

## Notes

- **Linux is unaffected.** `dirs` already respects `XDG_*` there; when the variable is set
  to an absolute path the helper returns the same value, and otherwise it falls back, so
  there is no behavior change on Linux.
- This is purely opt-in: users who don't set `XDG_*` keep the exact current locations.
- The helper is platform-agnostic, so it also lets Windows users opt in via
  `XDG_CONFIG_HOME` (where `dirs` likewise ignores it). I kept the docs change to the
  macOS row from the issue — happy to add a Windows note as well if you'd like.

## Testing

Built and tested locally on Windows with Rust 1.96.0:

- `cargo build -p numbat-cli` — ok
- `cargo fmt --check` — clean
- `cargo clippy -p numbat-cli --all-targets -- -D warnings` — zero warnings
- `cargo test --workspace` — all green (numbat, numbat-cli, numbat-exchange-rates)

Manual end-to-end (Windows runs the same code path as macOS, since both fall through
`xdg_dir` before `dirs`):

- With `XDG_CONFIG_HOME` set to an absolute directory, `numbat --generate-config` wrote
  the config to `$XDG_CONFIG_HOME/numbat/config.toml`.
- With `XDG_DATA_HOME` set to an absolute directory, the data/history directory was created
  under `$XDG_DATA_HOME/numbat`.
- A relative `XDG_*` value is ignored and falls back to `dirs`, per the spec.

(Unrelated heads-up: a workspace-wide `cargo clippy --all-features` under clippy 1.96 flags
one pre-existing `unnecessary_to_owned` in `numbat/examples/inspect.rs`, which this PR
doesn't touch — left as-is to keep the change focused.)
