### PR TITLE
Add typographic length units (point, pica, didot, ...)

### DIFF
--- a/book/src/prelude/list-units.md
+++ b/book/src/prelude/list-units.md
@@ -74,6 +74,8 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Length` | [Ångström](https://en.wikipedia.org/wiki/Angstrom) | `angstrom`, `angstroms`, `Å`, `Å` |
 | `Length` | [Astronomical unit](https://en.wikipedia.org/wiki/Astronomical_unit) | `astronomicalunit`, `astronomicalunits`, `au`, `AU` |
 | `Length` | [Bohr](https://en.wikipedia.org/wiki/Hartree_atomic_units) | `bohr` <br/> (`use units::hartree`) |
+| `Length` | [Cicero](https://en.wikipedia.org/wiki/Cicero_(typography)) | `cicero`, `ciceros` <br/> (`use units::typography`) |
+| `Length` | [Didot](https://en.wikipedia.org/wiki/Point_(typography)#French_points) | `didot`, `didots` <br/> (`use units::typography`) |
 | `Length` | [Earth radius](https://en.wikipedia.org/wiki/Earth) | `earth_radius` <br/> (`use extra::astronomy`) |
 | `Length` | [Fathom](https://en.wikipedia.org/wiki/Fathom) | `fathom`, `fathoms` |
 | `Length` | [Fermi](https://en.wikipedia.org/wiki/Femtometre) | `fermi` |
@@ -91,7 +93,10 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Length` | [Mile](https://en.wikipedia.org/wiki/Mile) | `mi`, `mile`, `miles` |
 | `Length` | [Nautical Mile](https://en.wikipedia.org/wiki/Nautical_mile) | `nautical_mile`, `nautical_miles`, `NM`, `nmi` |
 | `Length` | [Parsec](https://en.wikipedia.org/wiki/Parsec) | `parsec`, `parsecs`, `pc` |
+| `Length` | [Pica](https://en.wikipedia.org/wiki/Pica_(typography)) | `pica`, `picas` <br/> (`use units::typography`) |
 | `Length` | [Planck length](https://en.wikipedia.org/wiki/Planck_length) | `planck_length` |
+| `Length` | [Point](https://en.wikipedia.org/wiki/Point_(typography)) | `point`, `points`, `pt` <br/> (`use units::typography`) |
+| `Length` | [Q (quarter millimeter)](https://en.wikipedia.org/wiki/Point_(typography)#Metric_points) | `Q`, `q` <br/> (`use units::typography`) |
 | `Length` | [Rack unit](https://en.wikipedia.org/wiki/Rack_unit) | `rackunit`, `rackunits`, `RU`, `U` |
 | `Length` | [US rod](https://en.wikipedia.org/wiki/Rod_(unit)) | `perch`, `rod`, `rods` |
 | `Length` | [Smoot](https://en.wikipedia.org/wiki/Smoot) | `smoot` |

--- a/examples/typography.nbt
+++ b/examples/typography.nbt
@@ -1,23 +1,29 @@
-# Typographic length units: point, pica, didot, cicero, Q
+# Typesetting a page of body text
 #
-# These specialised units are not part of the prelude, so we import them.
-# https://en.wikipedia.org/wiki/Point_(typography)
+# Work out the line height from a font size and its "leading" (line spacing),
+# then how many lines fit in the printable height of an A4 page, and give a
+# text-column width in metric units. The typographic units used here are not in
+# the prelude, so we import them.
+# https://en.wikipedia.org/wiki/Leading
 
 use units::typography
 
-# The DTP (PostScript) point is exactly 1/72 inch, and a pica is 12 points.
-assert_eq(1 pica, 12 point, 1 nm)
+# Body text at 11 pt with 125% leading (a common book setting).
+let font_size = 11 pt
+let leading = 1.25
+let line_height = font_size * leading
+
+# Printable height of an A4 page (297 mm tall) with 20 mm top and bottom margins.
+let text_height = 297 mm - 2 * 20 mm
+let lines_per_page = floor(text_height / line_height)
+
+# Book text columns are usually given in picas.
+let column_width = 26 pica
+
+print("Line height:       {line_height -> mm:.2f}")
+print("Column width:      {column_width -> cm:.1f}")
+print("Lines per A4 page: {lines_per_page}")
+
+# Sanity checks on the unit definitions:
 assert_eq(72 point, 1 inch, 1 nm)
-
-# The Didot system: 1 cicero = 12 didot, and 1 didot = 0.375 mm.
-assert_eq(1 cicero, 12 didot, 1 nm)
-assert_eq(1 didot, 0.375 mm, 1 nm)
-
-# The Q unit (used in Japanese phototypesetting) is a quarter of a millimetre.
-assert_eq(1 Q, 0.25 mm, 1 nm)
-
-# A few everyday typographic measures, in metric units:
-print("Body text:   12 pt   = {12 pt -> mm:.3f}")
-print("Text column: 30 pica = {30 pica -> cm:.2f}")
-print("Caption:     8 didot = {8 didot -> mm:.3f}")
-print("JIS heading: 20 Q    = {20 Q -> mm:.1f}")
+assert_eq(1 pica, 12 point, 1 nm)

--- a/examples/typography.nbt
+++ b/examples/typography.nbt
@@ -1,0 +1,23 @@
+# Typographic length units: point, pica, didot, cicero, Q
+#
+# These specialised units are not part of the prelude, so we import them.
+# https://en.wikipedia.org/wiki/Point_(typography)
+
+use units::typography
+
+# The DTP (PostScript) point is exactly 1/72 inch, and a pica is 12 points.
+assert_eq(1 pica, 12 point, 1 nm)
+assert_eq(72 point, 1 inch, 1 nm)
+
+# The Didot system: 1 cicero = 12 didot, and 1 didot = 0.375 mm.
+assert_eq(1 cicero, 12 didot, 1 nm)
+assert_eq(1 didot, 0.375 mm, 1 nm)
+
+# The Q unit (used in Japanese phototypesetting) is a quarter of a millimetre.
+assert_eq(1 Q, 0.25 mm, 1 nm)
+
+# A few everyday typographic measures, in metric units:
+print("Body text:   12 pt   = {12 pt -> mm:.3f}")
+print("Text column: 30 pica = {30 pica -> cm:.2f}")
+print("Caption:     8 didot = {8 didot -> mm:.3f}")
+print("JIS heading: 20 Q    = {20 Q -> mm:.1f}")

--- a/numbat/modules/all.nbt
+++ b/numbat/modules/all.nbt
@@ -3,6 +3,7 @@ use prelude
 use units::currencies
 use units::stoney
 use units::hartree
+use units::typography
 
 use extra::algebra
 use extra::color

--- a/numbat/modules/units/typography.nbt
+++ b/numbat/modules/units/typography.nbt
@@ -1,0 +1,32 @@
+use units::si
+use units::imperial
+
+### Typographic length units
+
+@name("Point")
+@description("The desktop publishing point (also known as the PostScript point), defined as 1/72 inch.")
+@url("https://en.wikipedia.org/wiki/Point_(typography)")
+@aliases(points, pt: short)
+unit point: Length = inch / 72
+
+@name("Pica")
+@url("https://en.wikipedia.org/wiki/Pica_(typography)")
+@aliases(picas)
+unit pica: Length = 12 point
+
+@name("Didot")
+@description("The metric Didot point, defined as exactly 0.375 mm (so that 1 cicero = 4.5 mm).")
+@url("https://en.wikipedia.org/wiki/Point_(typography)#French_points")
+@aliases(didots)
+unit didot: Length = 0.375 millimeter
+
+@name("Cicero")
+@url("https://en.wikipedia.org/wiki/Cicero_(typography)")
+@aliases(ciceros)
+unit cicero: Length = 12 didot
+
+@name("Q (quarter millimeter)")
+@description("A unit used in Japanese phototypesetting and in CSS, equal to a quarter of a millimeter.")
+@url("https://en.wikipedia.org/wiki/Point_(typography)#Metric_points")
+@aliases(q: short)
+unit Q: Length = millimeter / 4

--- a/numbat/tests/snapshots/example_snapshots__typography@typography.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__typography@typography.nbt.snap
@@ -1,0 +1,9 @@
+---
+source: numbat/tests/example_snapshots.rs
+expression: output
+input_file: examples/typography.nbt
+---
+Body text:   12 pt   = 4.233 mm
+Text column: 30 pica = 12.70 cm
+Caption:     8 didot = 3.000 mm
+JIS heading: 20 Q    = 5.0 mm

--- a/numbat/tests/snapshots/example_snapshots__typography@typography.nbt.snap
+++ b/numbat/tests/snapshots/example_snapshots__typography@typography.nbt.snap
@@ -3,7 +3,6 @@ source: numbat/tests/example_snapshots.rs
 expression: output
 input_file: examples/typography.nbt
 ---
-Body text:   12 pt   = 4.233 mm
-Text column: 30 pica = 12.70 cm
-Caption:     8 didot = 3.000 mm
-JIS heading: 20 Q    = 5.0 mm
+Line height:       4.85 mm
+Column width:      11.0 cm
+Lines per A4 page: 52


### PR DESCRIPTION
Closes #797.

### Summary

Adds a new `units::typography` standard-library module with the common typographic **length** units, following @sharkdp's suggestion in the issue that this can be done by adding a `units::typography` module.

| Unit | Definition | Identifiers |
|------|------------|-------------|
| Point | `inch / 72` (DTP / PostScript point) | `point`, `points`, `pt` |
| Pica | `12 point` (= 1/6 inch) | `pica`, `picas` |
| Didot | `0.375 mm` (metric Didot point) | `didot`, `didots` |
| Cicero | `12 didot` (= 4.5 mm) | `cicero`, `ciceros` |
| Q | `mm / 4` | `Q`, `q` |

### `use units::typography` vs. the prelude (one decision for you)

I made the module **opt-in** (registered in `all.nbt`, imported with `use units::typography`) rather than adding it to the prelude. The reason is the `Q` unit: `Q` is also a very common *variable* name (electric charge, heat, volumetric flow). If `Q` were in the prelude it would shadow such variables everywhere — for example `examples/pipe_flow_rate.nbt` uses `let Q = flow_rate(...)`, which stops compiling ("identifier `Q` is already in use") the moment `Q` becomes a prelude unit.

Keeping the module opt-in avoids that and doesn't require touching any example. If you'd rather have these units available by default, I'm happy to move the `use units::typography` line into `prelude.nbt` and rename the `Q` variable in `pipe_flow_rate.nbt` — just let me know which you prefer.

### Notes

- **`point`** is the modern desktop-publishing / PostScript point (`1/72 inch`). The TeX point (`1/72.27 inch`) differs slightly; the chosen definition is documented in the unit's `@description`.
- **`didot` / `cicero`** use the *metric* convention: `1 didot = 0.375 mm` exactly, so `1 cicero = 4.5 mm`. The historical Didot point has several slightly different values (≈ 0.376 mm); I chose the metric one because it is exact and self-consistent, and noted it in the `@description`. Easy to switch if you prefer a traditional value.
- **Short aliases:** only `pt` (point) and `q` (Q). I avoided `pc` (parsec) and added no short aliases for pica/didot/cicero. Adding `Q`/`q` does not interfere with the `quetta`/`quecto` SI prefixes — `Qm` and `qm` still parse as quetta-/quecto-metre.
- The autogenerated `book/src/prelude/list-units.md` has been regenerated; the units appear with a `(use units::typography)` hint, like the other opt-in unit modules.
- **Scope:** length units only. `em`/`rem` would need a new `RelativeLength` dimension (which @sharkdp noted is uncertain), so they are intentionally left out — matching the issue title.

### Verification (built and run locally)

- `cargo build` / `cargo build -p numbat-cli` succeed; modules load without identifier clashes.
- Example conversions (after `use units::typography`):
  - `12 point -> inch` → `0.166667 in`
  - `1 pica -> point` → `12`
  - `1 didot -> mm` → `0.375 mm`
  - `1 cicero -> mm` → `4.5 mm`
  - `1 Q -> mm` → `0.25 mm`
  - `1 point -> mm` → `0.352778 mm`
  - `1 Qm -> m` → `1e30 m`, `1 qm -> m` → `1e-30 m` (SI prefixes still work)
- `cargo test --workspace --all-features --locked`: all 243 tests pass, 0 failures (including the `example_snapshots`, `prelude_and_examples`, and identifier-clash snapshot tests).
- `cargo fmt --check`: clean.
- `book/src/prelude/list-units.md` regenerated with the documented generator; the only change is the five new rows.
