### PR TITLE
Fix binom for negative integer n

### DIFF
--- a/examples/tests/math_functions.nbt
+++ b/examples/tests/math_functions.nbt
@@ -186,6 +186,20 @@ assert_eq(binom(1.5, 2), 0.375)
 assert_eq(binom(1.5, 3), -0.0625)
 assert_eq(binom(1.5, 4), 0.0234375)
 
+# generalized binomial coefficient for negative integer n
+# (coefficients of the binomial series of (1 + x)^n)
+assert_eq(binom(-1, 0), 1)
+assert_eq(binom(-1, 1), -1)
+assert_eq(binom(-1, 2), 1)
+assert_eq(binom(-1, 3), -1)
+
+assert_eq(binom(-2, 0), 1)
+assert_eq(binom(-2, 1), -2)
+assert_eq(binom(-2, 2), 3)
+assert_eq(binom(-2, 3), -4)
+
+assert_eq(binom(-1, -1), 0)
+
 # combinatoric sequences
 assert_eq(fibonacci(0), 0)
 assert_eq(fibonacci(1), 1)

--- a/numbat/modules/math/combinatorics.nbt
+++ b/numbat/modules/math/combinatorics.nbt
@@ -29,7 +29,7 @@ fn falling_factorial(n: Scalar, k: Scalar) -> Scalar =
 fn binom(n: Scalar, k: Scalar) -> Scalar =
    if !is_integer(k) then
     error("in binom(n, k), k must be an integer")
-  else if k < 0 || (k > n && is_integer(n)) then
+  else if k < 0 || (k > n && is_integer(n) && n >= 0) then
     0
   else
     falling_factorial(n, k) / k!


### PR DESCRIPTION
`binom` already computes the generalized binomial coefficient (it works for fractional `n`), but the `k > n` shortcut returned `0` for every integer `n`, including negatives - so `binom(-1, 0)` gave `0` instead of `1`, and `binom(-1, 2)` gave `0` instead of the binomial-series coefficient `1`. The shortcut is only valid for non-negative integer `n`, so I restricted it to that case and added tests for negative `n`.
