### PR TITLE
Fix Unix timestamp conversion precision

### DIFF
--- a/examples/tests/datetime.nbt
+++ b/examples/tests/datetime.nbt
@@ -117,6 +117,10 @@ assert_eq(dt_unixtime_2 -> unixtime_s -> from_unixtime_s -> unixtime_s, 16583467
 assert_eq(dt_unixtime_2 -> unixtime_ms -> from_unixtime_ms -> unixtime_ms, 1658346725123)
 assert_eq(dt_unixtime_2 -> unixtime_µs -> from_unixtime_µs -> unixtime_µs, 1658346725123456)
 
+# Regression test for #871
+assert_eq(from_unixtime_ms(1783591946381) -> unixtime_ms, 1783591946381)
+assert_eq(from_unixtime_ms(1783598716223) -> unixtime_ms, 1783598716223)
+
 
 # Calendar arithmetic
 

--- a/numbat/modules/datetime/unixtime.nbt
+++ b/numbat/modules/datetime/unixtime.nbt
@@ -23,15 +23,15 @@ fn unixtime(input: DateTime) -> UnixTime = _unixtime_µs(input) * unix_µs -> un
 
 @description("Converts a `DateTime` to a UNIX timestamp in seconds.")
 @example("datetime(\"2022-07-20 21:52 +0200\") -> unixtime_s")
-fn unixtime_s(input: DateTime) -> Scalar = unixtime(input) |> floor_in(unix_s) |> value_of
+fn unixtime_s(input: DateTime) -> Scalar = _unixtime_µs(input) / 1_000_000 |> floor
 
 @description("Converts a `DateTime` to a UNIX timestamp in milliseconds.")
 @example("datetime(\"2022-07-20 21:52:05.123 +0200\") -> unixtime_ms")
-fn unixtime_ms(input: DateTime) -> Scalar = unixtime(input) |> floor_in(unix_ms) |> value_of
+fn unixtime_ms(input: DateTime) -> Scalar = _unixtime_µs(input) / 1_000 |> floor
 
 @description("Converts a `DateTime` to a UNIX timestamp in microseconds.")
 @example("datetime(\"2022-07-20 21:52:05.123456 +0200\") -> unixtime_µs")
-fn unixtime_µs(input: DateTime) -> Scalar = unixtime(input) |> floor_in(unix_µs) |> value_of
+fn unixtime_µs(input: DateTime) -> Scalar = _unixtime_µs(input)
 
 @description("Alias for `unixtime_µs`.")
 fn unixtime_us(input: DateTime) -> Scalar = unixtime_µs(input)

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -1025,6 +1025,19 @@ fn test_datetime_runtime_errors() {
 }
 
 #[test]
+fn test_unixtime_ms_roundtrip() {
+    // Regression test for https://github.com/sharkdp/numbat/issues/871
+    expect_output(
+        "from_unixtime_ms(1783591946381) -> unixtime_ms",
+        "1_783_591_946_381",
+    );
+    expect_output(
+        "from_unixtime_ms(1783598716223) -> unixtime_ms",
+        "1_783_598_716_223",
+    );
+}
+
+#[test]
 fn test_user_errors() {
     expect_failure("error(\"test\")", "User error: test");
 

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -1025,19 +1025,6 @@ fn test_datetime_runtime_errors() {
 }
 
 #[test]
-fn test_unixtime_ms_roundtrip() {
-    // Regression test for https://github.com/sharkdp/numbat/issues/871
-    expect_output(
-        "from_unixtime_ms(1783591946381) -> unixtime_ms",
-        "1_783_591_946_381",
-    );
-    expect_output(
-        "from_unixtime_ms(1783598716223) -> unixtime_ms",
-        "1_783_598_716_223",
-    );
-}
-
-#[test]
 fn test_user_errors() {
     expect_failure("error(\"test\")", "User error: test");
 


### PR DESCRIPTION
## What changed

- derive second and millisecond timestamps directly from the exact microsecond value returned by the DateTime FFI
- return that exact value for `unixtime_µs` instead of converting through floating-point seconds
- add regression coverage for the two millisecond timestamps from the report

## Why

Converting microseconds to `unix_s` and then back to milliseconds could produce a value just below an integer boundary. `floor_in(unix_ms)` would consequently lose one millisecond. Keeping integer-valued microseconds until the final division avoids that intermediate rounding.

Fixes #871

## Validation

- reproduced the original `-1 ms` results with the official v1.23.0 Windows binary
- loaded the modified module through `NUMBAT_MODULES_PATH` and verified exact round trips for both reported timestamps, epoch zero, a pre-epoch value, microseconds, and seconds
- `cargo fmt --check`
- `git diff --check`

The focused Rust test target could not be compiled locally because this Windows host has Rust but not the MSVC linker. No system SDK was installed; GitHub CI provides native build/test coverage across the supported targets.

