### PR TITLE
fix: avoid panic in full_simplify on incompatible unit groups

### DIFF
--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -237,12 +237,19 @@ impl Quantity {
                 })
             };
 
-            let converted = Quantity::from_unit(group_as_unit)
-                .convert_to(&target_unit)
-                .unwrap();
-
-            simplified_unit = simplified_unit * target_unit;
-            factor = factor * converted.value;
+            match Quantity::from_unit(group_as_unit.clone()).convert_to(&target_unit) {
+                Ok(converted) => {
+                    simplified_unit = simplified_unit * target_unit;
+                    factor = factor * converted.value;
+                }
+                Err(_) => {
+                    // This group cannot be converted to its computed target
+                    // unit (some combinations reduce to incompatible units);
+                    // full_simplify is best-effort, so leave the group
+                    // unsimplified instead of panicking. See issue #873.
+                    simplified_unit = simplified_unit * group_as_unit;
+                }
+            }
         }
 
         simplified_unit.canonicalize();

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -182,6 +182,23 @@ fn simple_value() {
 }
 
 #[test]
+fn test_full_simplify_incompatible_group_does_not_panic() {
+    // Regression test for https://github.com/sharkdp/numbat/issues/873:
+    // printing a value whose automatic unit simplification produces a group
+    // that cannot be converted to its target unit used to panic (unwrap on an
+    // Err). full_simplify is best-effort, so such a group must now be left
+    // unsimplified instead of crashing.
+    let output = succeed(
+        "elementary_charge * (magnetic_flux_quantum / planck_time / planck_length) \
+         + elementary_charge * speed_of_light * (magnetic_flux_quantum / planck_length^2)",
+    );
+    assert!(
+        output.contains("planck_length"),
+        "expected the unsimplifiable group to be left as-is, got: {output}"
+    );
+}
+
+#[test]
 fn test_factorial() {
     expect_output("0!", "1");
     expect_output("4!", "24");


### PR DESCRIPTION
## Summary

`full_simplify()` converts each unit-factor group to a computed target unit with `Quantity::from_unit(group_as_unit).convert_to(&target_unit).unwrap()`. Some combinations reduce to incompatible units, so that `.unwrap()` panics — and because simplification runs when a value is *printed*, printing certain quantities crashes while assigning them to a variable is fine.

Closes #873.

## Why this matters

`full_simplify` is a display convenience: it tidies up the units of a result for presentation. A best-effort formatting step should never be able to take down the interpreter. Today, evaluating the reporter's expression (a mix of Planck units) — or the concise form below — panics instead of printing a result:

```numbat
elementary_charge * (magnetic_flux_quantum / planck_time / planck_length)
  + elementary_charge * speed_of_light * (magnetic_flux_quantum / planck_length^2)
```

## Fix

When a group cannot be converted to its computed target unit, leave that group unsimplified instead of unwrapping:

```rust
match Quantity::from_unit(group_as_unit.clone()).convert_to(&target_unit) {
    Ok(converted) => {
        simplified_unit = simplified_unit * target_unit;
        factor = factor * converted.value;
    }
    Err(_) => {
        // best-effort: keep the group as-is rather than panicking
        simplified_unit = simplified_unit * group_as_unit;
    }
}
```

The value is preserved exactly (the un-simplifiable group keeps its original factors, no numeric change); only the panic path changes.

## Testing

- The reporter's expression now returns `1.98645e-25 J·m/planck_length²` instead of panicking.
- Normal expressions are unaffected: `2 m + 3 m` → `5 m`, `5 kW * 2 h -> kWh` → `10 kWh`.
- Added `test_full_simplify_incompatible_group_does_not_panic`; it fails on `master` (the exact reported panic) and passes with this change.
- `cargo test -p numbat --test interpreter` (53 tests) passes; `cargo clippy -p numbat` is clean.
