### PR TITLE
Fix panic in full_simplify when a group is not convertible to its target unit

### DIFF
--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -237,12 +237,18 @@ impl Quantity {
                 })
             };
 
-            let converted = Quantity::from_unit(group_as_unit)
-                .convert_to(&target_unit)
-                .unwrap();
-
-            simplified_unit = simplified_unit * target_unit;
-            factor = factor * converted.value;
+            match Quantity::from_unit(group_as_unit.clone()).convert_to(&target_unit) {
+                Ok(converted) => {
+                    simplified_unit = simplified_unit * target_unit;
+                    factor = factor * converted.value;
+                }
+                // If this group can not be converted to the chosen target unit,
+                // simplification is best-effort: keep the group's original unit
+                // instead of panicking (issue #873).
+                Err(_) => {
+                    simplified_unit = simplified_unit * group_as_unit;
+                }
+            }
         }
 
         simplified_unit.canonicalize();

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -635,6 +635,14 @@ fn test_full_simplify() {
     expect_output("1 dpi * 1 in", "1 dot");
     expect_output("1 mph * 1 hour", "1 mi");
     expect_output("1 dot / 96 dpi", "0.0104167 in");
+
+    // A group whose representative unit is not convertible to the chosen
+    // target unit must not panic during simplification (issue #873).
+    expect_output(
+        "elementary_charge * (magnetic_flux_quantum / planck_time / planck_length) \
+         + elementary_charge * speed_of_light * (magnetic_flux_quantum / planck_length^2)",
+        "1.98645e-25 J·m/planck_length²",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #873.

`full_simplify` picks a target unit for each unit group and converts to it with `.unwrap()`. When that conversion returns `IncompatibleUnits`, the whole evaluation panics (it shows up when printing certain expressions, e.g. the Lorentz-force reproducer in the issue).

Since simplification is best-effort, this falls back to keeping the group's original unit when the conversion fails instead of panicking, mirroring the `if let Ok(q) = self.convert_to(..)` handling already used a few lines above. Added a regression test to `test_full_simplify`.