### PR TITLE
Fix unit simplification picking unrelated unit when the value is very small

### DIFF
--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -308,8 +308,12 @@ impl Quantity {
                     let (_, target_factor) = target_unit.to_base_unit_representation();
 
                     // Only simplify if conversion factors are equal (within tolerance)
-                    let factors_match = (source_factor.to_f64() - target_factor.to_f64()).abs()
-                        < 1e-9 * source_factor.to_f64().abs().max(1.0);
+                    let scale = source_factor
+                        .to_f64()
+                        .abs()
+                        .max(target_factor.to_f64().abs());
+                    let factors_match = scale == 0.0
+                        || (source_factor.to_f64() - target_factor.to_f64()).abs() < 1e-9 * scale;
 
                     if factors_match && let Ok(converted) = simplified.convert_to(&target_unit) {
                         // Can't get simpler than 1 factor, return immediately


### PR DESCRIPTION
Iiuc while trying to convert a multi unit expression to single unit it checks whether they are the same size, but for very small numbers (< 1e-9) the check stops comparing.

The pr scales the tolerance to mitigate this. Example:

Input
```
print(4 mPa * 3 mm³)
print(3 pN * 2 nm)
print(3 pN * 2 pm)
print(3 N * 2 pm)
print(3 N * 2 m)
```
Before
```
5.50491e+6 Ry
0.00275245 Ry
0.00000275245 Ry
2.75245e+6 Ry
6 J
```
After
```
12 mPa·mm³
6 pN·nm
6 pN·pm
6 N·pm
6 J
```