### PR TITLE
Resolve unit names in the callable position of a call

### DIFF
--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -125,7 +125,8 @@ impl Transformer {
                     };
                 }
             }
-            Expression::FunctionCall { args, .. } => {
+            Expression::FunctionCall { callable, args, .. } => {
+                self.transform_expression(callable);
                 for arg in args {
                     self.transform_expression(arg);
                 }

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -653,6 +653,41 @@ fn test_prefixes() {
 }
 
 #[test]
+fn test_units_in_callable_position() {
+    // The callable of a call can be an arbitrary expression, and unit names
+    // inside it need to be recognized just like anywhere else.
+    expect_output(
+        "fn identity(x: Length) -> Length = x
+         fn pick(d: Length) -> Fn[(Length) -> Length] = identity
+         pick(1 metre)(2 metre)",
+        "2 m",
+    );
+
+    // … including prefixed units and aliases
+    expect_output(
+        "fn identity(x: Length) -> Length = x
+         fn pick(d: Length) -> Fn[(Length) -> Length] = identity
+         pick(1 kilometre)(2 m)",
+        "2 m",
+    );
+
+    // … and the °C/°F syntax, which is desugared by the same pass
+    expect_output(
+        "fn identity(x: Length) -> Length = x
+         fn pick(t: Temperature) -> Fn[(Length) -> Length] = identity
+         pick(20 °C)(2 metre)",
+        "2 m",
+    );
+
+    // The callable does not have to be a call itself
+    expect_output(
+        "fn identity(x: Length) -> Length = x
+         (if 1 metre > 0 metre then identity else identity)(2 metre)",
+        "2 m",
+    );
+}
+
+#[test]
 fn test_parse_errors() {
     expect_failure(
         "3kg+",


### PR DESCRIPTION
Fixes #879.

`Transformer::transform_expression` walked the arguments of a function call but never the callable itself, so no expression nested inside a callable was ever visited. Unit names in that position stayed bare identifiers: a plain unit reached the bytecode compiler and panicked on `unreachable!`, a prefixed unit or an alias was reported as an unknown identifier, and the `°C`/`°F` desugaring, which happens in the same pass, silently did not fire.

Function names cannot be mistaken for units here. They are registered with the prefix parser through `add_other_identifier`, as are parameters and where-clause locals through `add_shadowing_identifier`, so `PrefixParser::parse` never returns a `UnitIdentifier` for them. Checked explicitly against `min`, which is an alias for `minute`: `min(3, 4)` reports the same "has type 'Time' and can not be called as a function" error before and after.

The new test covers a bare unit, a prefixed unit, the `°C` sugar, and a callable that is not itself a call. It panics on `main` and passes here.
