### PR TITLE
Don't panic when a unit group can't be simplified for display

### DIFF
--- a/numbat/src/quantity.rs
+++ b/numbat/src/quantity.rs
@@ -237,12 +237,22 @@ impl Quantity {
                 })
             };
 
-            let converted = Quantity::from_unit(group_as_unit)
-                .convert_to(&target_unit)
-                .unwrap();
+            let converted = Quantity::from_unit(group_as_unit.clone()).convert_to(&target_unit);
 
-            simplified_unit = simplified_unit * target_unit;
-            factor = factor * converted.value;
+            match converted {
+                Ok(converted) => {
+                    simplified_unit = simplified_unit * target_unit;
+                    factor = factor * converted.value;
+                }
+                Err(_) => {
+                    // This group cannot be converted to its simplified representative. This can
+                    // happen for exotic nested derived units with fractional exponents (see #873).
+                    // Rather than panicking, leave the group un-simplified: the value is unchanged
+                    // because the unit is unchanged, so the result stays correct — just displayed
+                    // in a less-simplified form.
+                    simplified_unit = simplified_unit * group_as_unit;
+                }
+            }
         }
 
         simplified_unit.canonicalize();

--- a/numbat/tests/interpreter.rs
+++ b/numbat/tests/interpreter.rs
@@ -599,6 +599,17 @@ fn test_bohr_radius_regression() {
 }
 
 #[test]
+fn test_simplify_incompatible_units_regression() {
+    // regression test for https://github.com/sharkdp/numbat/issues/873
+    // Printing this quantity used to panic in unit simplification (unwrap on an
+    // `IncompatibleUnits` conversion). It must now evaluate and display without panicking.
+    expect_output(
+        "elementary_charge * (magnetic_flux_quantum / planck_time / planck_length) + elementary_charge * speed_of_light * (magnetic_flux_quantum / planck_length^2)",
+        "1.98645e-25 J·m/planck_length²",
+    );
+}
+
+#[test]
 fn test_full_simplify() {
     expect_output("5 cm/m", "0.05");
     expect_output("hour/second", "3600");


### PR DESCRIPTION
Printing certain quantities with exotic nested derived units and fractional exponents (e.g. combinations of planck_length, magnetic_flux_ quantum, ...) panicked in Quantity::simplify: a per-group convert_to(target_unit) returned Err(IncompatibleUnits) and was unwrapped.

When a group can't be converted to its simplified representative, leave that group un-simplified instead of unwrapping. The value is unchanged (the unit is unchanged), so the result stays correct — it is just shown in a less-simplified form rather than crashing. The successful path is untouched, so existing simplification output is unaffected.

Adds a regression test (verified failing before the fix). Closes #873.


Closes #873.

Printing certain quantities with exotic nested derived units and fractional exponents panicked in Quantity::simplify: a per-group
  convert_to(target_unit) returned Err(IncompatibleUnits) and was .unwrap()ed (quantity.rs:242).


  
  > elementary_charge * (magnetic_flux_quantum / planck_time / planck_length) + elementary_charge * speed_of_light * (magnetic_flux_quantum /
  planck_length^2)
  > 
  

Fix: when a group can't be converted to its simplified representative, leave that group un-simplified instead of unwrapping. The value is unchanged (the unit is unchanged), so the result stays correct — just displayed in a less-simplified form (verified it equals the -> newtons value). The successful path is untouched, so existing simplification output is unaffected.

Adds a regression test (verified failing before the fix). cargo fmt --check, cargo clippy, and the full test suite pass.

