### PR TITLE
Add typographic length units

### DIFF
--- a/book/src/prelude/list-units.md
+++ b/book/src/prelude/list-units.md
@@ -91,13 +91,18 @@ and — where sensible — units allow for [binary prefixes](https://en.wikipedi
 | `Length` | [Mile](https://en.wikipedia.org/wiki/Mile) | `mi`, `mile`, `miles` |
 | `Length` | [Nautical Mile](https://en.wikipedia.org/wiki/Nautical_mile) | `nautical_mile`, `nautical_miles`, `NM`, `nmi` |
 | `Length` | [Parsec](https://en.wikipedia.org/wiki/Parsec) | `parsec`, `parsecs`, `pc` |
+| `Length` | [Pica](https://en.wikipedia.org/wiki/Pica_(typography)) | `pica`, `picas` |
 | `Length` | [Planck length](https://en.wikipedia.org/wiki/Planck_length) | `planck_length` |
+| `Length` | [Point](https://en.wikipedia.org/wiki/Point_(typography)) | `point`, `points`, `pt` |
 | `Length` | [Rack unit](https://en.wikipedia.org/wiki/Rack_unit) | `rackunit`, `rackunits`, `RU`, `U` |
 | `Length` | [US rod](https://en.wikipedia.org/wiki/Rod_(unit)) | `perch`, `rod`, `rods` |
 | `Length` | [Smoot](https://en.wikipedia.org/wiki/Smoot) | `smoot` |
 | `Length` | [Solar radius](https://en.wikipedia.org/wiki/Sun) | `solar_radius` <br/> (`use extra::astronomy`) |
 | `Length` | [Stoney length](https://en.wikipedia.org/wiki/Stoney_units) | `stoney_length` <br/> (`use units::stoney`) |
+| `Length` | [TeX pica](https://en.wikipedia.org/wiki/Pica_(typography)) | `tex_pica`, `tex_picas` |
+| `Length` | [TeX point](https://en.wikipedia.org/wiki/Point_(typography)#TeX_point) | `tex_point`, `tex_points` |
 | `Length` | [Thousandth of an inch](https://en.wikipedia.org/wiki/Thousandth_of_an_inch) | `mil`, `mils`, `thou` |
+| `Length` | [Twip](https://en.wikipedia.org/wiki/Twip) | `twip`, `twips` |
 | `Length` | [Yard](https://en.wikipedia.org/wiki/Yard) | `yard`, `yards`, `yd` |
 | `Length / Volume` | [Miles per gallon](https://en.wikipedia.org/wiki/Fuel_economy_in_automobiles) | `mpg` |
 | `Length^2` | [darcy](https://en.wikipedia.org/wiki/Darcy_(unit)) | `darcies`, `darcy`, `darcys` |

--- a/examples/tests/unit_consistency_misc.nbt
+++ b/examples/tests/unit_consistency_misc.nbt
@@ -82,3 +82,11 @@ assert_eq(1 PSI, 6.894757 kPa)
 assert_eq(1 atm, 101_325.0 Pa)
 
 assert_eq(1 maxwell, 1e-8 weber)
+
+assert_eq(72 point, 1 inch, 1e-9 inch)
+assert_eq(1 pica, 12 point)
+assert_eq(6 pica, 1 inch, 1e-9 inch)
+assert_eq(20 twip, 1 point, 1e-9 point)
+assert_eq(1440 twip, 1 inch, 1e-9 inch)
+assert_eq(72.27 tex_point, 1 inch, 1e-9 inch)
+assert_eq(1 tex_pica, 12 tex_point)

--- a/numbat/modules/prelude.nbt
+++ b/numbat/modules/prelude.nbt
@@ -31,6 +31,7 @@ use units::cgs
 use units::planck
 use units::fff
 use units::misc
+use units::typography
 use units::humorous
 use units::partsperx
 use units::mixed

--- a/numbat/modules/units/typography.nbt
+++ b/numbat/modules/units/typography.nbt
@@ -1,0 +1,29 @@
+use units::si
+use units::imperial
+
+### Typographic units
+
+@name("Point")
+@url("https://en.wikipedia.org/wiki/Point_(typography)")
+@aliases(points, pt: short)
+unit point: Length = inch / 72
+
+@name("Pica")
+@url("https://en.wikipedia.org/wiki/Pica_(typography)")
+@aliases(picas)
+unit pica: Length = 12 point
+
+@name("Twip")
+@url("https://en.wikipedia.org/wiki/Twip")
+@aliases(twips)
+unit twip: Length = point / 20
+
+@name("TeX point")
+@url("https://en.wikipedia.org/wiki/Point_(typography)#TeX_point")
+@aliases(tex_points)
+unit tex_point: Length = inch / 72.27
+
+@name("TeX pica")
+@url("https://en.wikipedia.org/wiki/Pica_(typography)")
+@aliases(tex_picas)
+unit tex_pica: Length = 12 tex_point


### PR DESCRIPTION
This adds a `units::typography` module with `point`, `pica` and `twip`, plus the TeX `point`/`pica`, and imports it in the prelude so they are available by default. Closes #797.

The point is defined as `inch / 72` (the PostScript/DTP/CSS point), pica as 12 points, twip as 1/20 of a point, and the TeX variants are based off `inch / 72.27`. So you can do things like `12 pt -> mm` or `1 pica -> inch`.

I left `Q` out of the original request on purpose. Defining it would claim the single-letter `Q` identifier globally, which already collides with existing use (one of the examples uses `Q` for a flow rate), and it felt like exactly the kind of one-character name the project would rather keep free for variables. Happy to add it under a longer name if you want it.

Consistency checks are in `examples/tests/unit_consistency_misc.nbt`, and I regenerated `book/src/prelude/list-units.md`.