### PR TITLE
Load currency units on demand for `info` and `list` commands

### DIFF
--- a/numbat/src/command.rs
+++ b/numbat/src/command.rs
@@ -94,6 +94,21 @@ impl From<RuntimeError> for CommandError {
     }
 }
 
+impl From<Box<crate::NumbatError>> for CommandError {
+    fn from(err: Box<crate::NumbatError>) -> Self {
+        let runtime = match *err {
+            crate::NumbatError::RuntimeError(e) => e,
+            // The on-demand currency load only surfaces runtime errors; other variants
+            // would indicate a bug in the internal `use units::currencies` module.
+            other => RuntimeError {
+                kind: crate::RuntimeErrorKind::UserError(other.to_string()),
+                backtrace: Vec::new(),
+            },
+        };
+        Self::Runtime(Box::new(runtime))
+    }
+}
+
 impl ErrorDiagnostic for ResolverDiagnostic<'_, CommandError> {
     fn diagnostics(&self) -> Vec<crate::Diagnostic> {
         match self.error {
@@ -527,6 +542,11 @@ impl<'a, Editor> CommandRunner<'a, Editor> {
                 CommandControlFlow::Continue
             }
             ParsedCommand::Info { item } => {
+                // `info <currency>` (e.g. `info USD`) needs the currency module loaded,
+                // otherwise the unit is reported as "Not found" until the user performs a
+                // currency calculation. Trigger the same on-demand load as the interpreter.
+                ctx.ensure_currency_module_loaded_for_command(item)
+                    .map_err(|e| Box::new(CommandError::from(e)))?;
                 let markup = ctx.print_info_for_keyword(item);
                 if let Some(print_fn) = self.print_markup.as_mut() {
                     print_fn(&markup);
@@ -534,6 +554,13 @@ impl<'a, Editor> CommandRunner<'a, Editor> {
                 CommandControlFlow::Continue
             }
             ParsedCommand::List { items } => {
+                // `list` and `list units` should include currency units, so load the
+                // currency module on demand (mirrors the interpreter's lazy loading).
+                // `list functions/dimensions/variables` never involve currencies.
+                if matches!(items, None | Some(ListItems::Units)) {
+                    ctx.ensure_currencies_loaded_for_list()
+                        .map_err(|e| Box::new(CommandError::from(e)))?;
+                }
                 let markup = match items {
                     None => ctx.print_environment(),
                     Some(ListItems::Functions) => ctx.print_functions(),
@@ -1061,5 +1088,51 @@ mod test {
         );
         test_case(&mut runner, &mut ctx, "quit", CommandControlFlow::Return);
         test_case(&mut runner, &mut ctx, "exit", CommandControlFlow::Return);
+    }
+
+    /// Regression test for https://github.com/sharkdp/numbat/issues/635:
+    /// `info USD` (and `list units`) must trigger the on-demand load of the currency
+    /// module, so currency units are found even before any currency calculation is run.
+    #[test]
+    fn test_info_and_list_load_currencies_on_demand() {
+        use crate::module_importer::BuiltinModuleImporter;
+
+        fn on_demand_ctx() -> Context {
+            Context::use_test_exchange_rates();
+            let mut ctx = Context::new(BuiltinModuleImporter::default());
+            // Load the prelude but deliberately NOT `units::currencies`, exactly as the
+            // CLI does; the module should only be pulled in on demand.
+            let _ = ctx.interpret("use prelude", CodeSource::Internal).unwrap();
+            ctx.load_currency_module_on_demand(true);
+            ctx
+        }
+
+        fn run_capture(ctx: &mut Context, input: &'static str) -> String {
+            let captured = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+            let sink = captured.clone();
+            let mut runner = CommandRunner::new()
+                .print_with(move |markup| sink.borrow_mut().push_str(&markup.to_string()));
+            let _ = runner
+                .try_run_command(input, ctx, &mut ())
+                .unwrap_or_else(|e| panic!("command `{input}` failed: {e:?}"));
+            captured.borrow().clone()
+        }
+
+        // `info USD` on a fresh session must resolve the currency, not report "Not found".
+        let mut ctx = on_demand_ctx();
+        let info = run_capture(&mut ctx, "info USD");
+        assert!(
+            info.contains("US dollar"),
+            "`info USD` should load currencies on demand, got:\n{info}"
+        );
+        assert!(!info.contains("Not found"), "got:\n{info}");
+
+        // `list units` must include currency units on a fresh session as well.
+        let mut ctx = on_demand_ctx();
+        let units = run_capture(&mut ctx, "list units");
+        assert!(
+            units.contains("dollar"),
+            "`list units` should include currencies, got:\n{units}"
+        );
     }
 }

--- a/numbat/src/lib.rs
+++ b/numbat/src/lib.rs
@@ -152,6 +152,76 @@ impl Context {
         self.load_currency_module_on_demand = yes;
     }
 
+    /// Whether `identifier` is one of the currency units defined in
+    /// `units::currencies` (e.g. `USD`, `dollar`, `€`).
+    fn is_currency_identifier(identifier: &str) -> bool {
+        const CURRENCY_IDENTIFIERS: &[&str] = &include!(concat!(env!("OUT_DIR"), "/currencies.rs"));
+        CURRENCY_IDENTIFIERS.contains(&identifier)
+    }
+
+    /// If `identifier` names a currency and the currency module has not been loaded yet,
+    /// fetch the exchange rates and load `units::currencies` now. Returns `Ok(true)` if
+    /// the module was just loaded, `Ok(false)` if there was nothing to do.
+    ///
+    /// This backs the lazy-loading of currencies: they are only pulled in the first time
+    /// a currency identifier is actually used (in an expression, or via `info`/`list`).
+    fn ensure_currency_module_loaded(&mut self, identifier: &str) -> Result<bool> {
+        if !self.load_currency_module_on_demand || !Self::is_currency_identifier(identifier) {
+            return Ok(false);
+        }
+
+        // We also call this from a thread at program startup, so if a user only starts
+        // to use currencies later on, this will already be available and return immediately.
+        // Otherwise, we fetch it now and make sure to block on this call.
+        if ExchangeRatesCache::fetch().is_none() {
+            return Err(Box::new(NumbatError::RuntimeError(
+                self.runtime_error(RuntimeErrorKind::CouldNotLoadExchangeRates),
+            )));
+        }
+
+        let mut no_print_settings = InterpreterSettings {
+            print_fn: Box::new(
+                move |_: &m::Markup| { /* ignore print statements while loading */ },
+            ),
+        };
+        let _ = self.interpret_with_settings(
+            &mut no_print_settings,
+            "use units::currencies",
+            CodeSource::Internal,
+        )?;
+
+        // Make sure we do not run into an infinite loop in case loading that
+        // module did not bring in the required currency unit identifier. This
+        // can happen if the list of currency identifiers is not in sync with
+        // what the module actually defines.
+        self.load_currency_module_on_demand = false;
+
+        Ok(true)
+    }
+
+    /// Load the currency module unconditionally (if still pending), regardless of any
+    /// identifier. Used by commands such as `list` / `list units` that should display
+    /// currency units even when no currency calculation has been performed yet.
+    fn ensure_currency_module_loaded_unconditional(&mut self) -> Result<()> {
+        // Any real currency identifier works to satisfy the guard; "USD" is guaranteed
+        // to be in the list.
+        self.ensure_currency_module_loaded("USD")?;
+        Ok(())
+    }
+
+    /// Command-facing hook: given the argument of an `info <keyword>` command, load the
+    /// currency module on demand if `keyword` names a currency. See
+    /// [`Self::ensure_currency_module_loaded`].
+    pub fn ensure_currency_module_loaded_for_command(&mut self, keyword: &str) -> Result<()> {
+        self.ensure_currency_module_loaded(keyword).map(|_| ())
+    }
+
+    /// Command-facing hook for `list` / `list units`: load the currency module
+    /// unconditionally so that currency units are listed.
+    pub fn ensure_currencies_loaded_for_list(&mut self) -> Result<()> {
+        self.ensure_currency_module_loaded_unconditional()
+    }
+
     /// Fill the currency exchange rate cache. This call is blocking.
     pub fn prefetch_exchange_rates() {
         let _unused = ExchangeRatesCache::fetch();
@@ -755,51 +825,15 @@ impl Context {
             self.prefix_transformer = prefix_transformer_old.clone();
             self.typechecker = typechecker_old.clone();
 
-            if self.load_currency_module_on_demand
-                && let Err(NumbatError::TypeCheckError(TypeCheckError::UnknownIdentifier(
-                    _,
-                    identifier,
-                    _,
-                ))) = &result
+            if let Err(NumbatError::TypeCheckError(TypeCheckError::UnknownIdentifier(
+                _,
+                identifier,
+                _,
+            ))) = &result
+                && self.ensure_currency_module_loaded(identifier)?
             {
-                const CURRENCY_IDENTIFIERS: &[&str] =
-                    &include!(concat!(env!("OUT_DIR"), "/currencies.rs"));
-                if CURRENCY_IDENTIFIERS.contains(&identifier.as_str()) {
-                    let mut no_print_settings = InterpreterSettings {
-                        print_fn: Box::new(
-                            move |_: &m::Markup| { // ignore any print statements when loading this module asynchronously
-                            },
-                        ),
-                    };
-
-                    // We also call this from a thread at program startup, so if a user only starts
-                    // to use currencies later on, this will already be available and return immediately.
-                    // Otherwise, we fetch it now and make sure to block on this call.
-                    {
-                        let erc = ExchangeRatesCache::fetch();
-
-                        if erc.is_none() {
-                            return Err(Box::new(NumbatError::RuntimeError(
-                                self.runtime_error(RuntimeErrorKind::CouldNotLoadExchangeRates),
-                            )));
-                        }
-                    }
-
-                    let _ = self.interpret_with_settings(
-                        &mut no_print_settings,
-                        "use units::currencies",
-                        CodeSource::Internal,
-                    )?;
-
-                    // Make sure we do not run into an infinite loop in case loading that
-                    // module did not bring in the required currency unit identifier. This
-                    // can happen if the list of currency identifiers is not in sync with
-                    // what the module actually defines.
-                    self.load_currency_module_on_demand = false;
-
-                    // Now we try to evaluate the user expression again:
-                    return self.interpret_with_settings(settings, code, code_source);
-                }
+                // Now we try to evaluate the user expression again:
+                return self.interpret_with_settings(settings, code, code_source);
             }
         }
 


### PR DESCRIPTION
Fixes #635.

## Problem
`info USD` (or any currency alias) reports `Not found` until the user first performs a currency calculation. On a fresh session the currency units simply aren't there yet.

## Root cause
On-demand loading of `units::currencies` was wired **only** into the expression-evaluation path (`interpret_with_settings`, triggered by an `UnknownIdentifier` type error). The `info` and `list` commands bypass the interpreter, so currencies were never pulled in for them.

## Approach
Extracted the existing inline lazy-load block into reusable `Context` methods and call them from the command handlers:
- `info <keyword>` loads currencies on demand when the keyword names a currency.
- `list` / `list units` load unconditionally; `list functions/dimensions/variables` do not.

The expression path is unchanged — it now calls the same shared method. No-prelude mode is unaffected (`load_currency_module_on_demand` stays false → early return).

## Testing
- Added `test_info_and_list_load_currencies_on_demand` — verified it **fails without the fix** (`info USD` → `Not found`).
- `cargo fmt --check` clean · `cargo clippy -p numbat` no new warnings · `cargo test -p numbat` green (lib 176, interpreter 53, prelude 6).

A maintainer suggested exactly this approach (load for `info`/`list`, not for `save`/`help`/`quit`) in the issue thread.
