### PR TITLE
Fix infinite loop in str_repeat for non-finite repetition counts

### DIFF
--- a/examples/runtime_error/str_repeat_infinite.nbt
+++ b/examples/runtime_error/str_repeat_infinite.nbt
@@ -1,0 +1,1 @@
+str_repeat(inf, "x")

--- a/examples/runtime_error/str_repeat_nan.nbt
+++ b/examples/runtime_error/str_repeat_nan.nbt
@@ -1,0 +1,1 @@
+str_repeat(NaN, "x")

--- a/numbat/modules/core/strings.nbt
+++ b/numbat/modules/core/strings.nbt
@@ -72,7 +72,11 @@ fn str_replace(pattern: String, replacement: String, s: String) -> String =
 @description("Repeat the input string `n` times")
 @example("str_repeat(4, \"abc\")")
 fn str_repeat(n: Scalar, a: String) -> String =
-  if n > 0
+  if is_infinite(n)
+    then error("Cannot repeat a string an infinite number of times")
+  else if is_nan(n)
+    then error("Cannot repeat a string NaN number of times")
+  else if n > 0
     then str_append(a, str_repeat(n - 1, a))
     else ""
 

--- a/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@invalid_base.nbt.snap
+++ b/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@invalid_base.nbt.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/runtime_error/invalid_base.nbt
 ---
 error: runtime error
-    ┌─ Module 'core::strings', File [PRELUDE_FILE]:108:10
+    ┌─ Module 'core::strings', File [PRELUDE_FILE]:112:10
     │
-108 │     then error("base must be between 2 and 16")
+112 │     then error("base must be between 2 and 16")
     │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     ┌─ <internal:3>:1:1
@@ -18,6 +18,6 @@ error: runtime error
 
 help: Backtrace:
  = 0: error("base must be between 2 and 16")
-   	at base - Module 'core::strings', File [PRELUDE_FILE]:108:10
+   	at base - Module 'core::strings', File [PRELUDE_FILE]:112:10
  = 1: base(-4, 10)
    	at <main> - <internal:3>:1:0

--- a/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@str_repeat_infinite.nbt.snap
+++ b/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@str_repeat_infinite.nbt.snap
@@ -1,0 +1,23 @@
+---
+source: numbat/tests/prelude_and_examples.rs
+expression: output
+input_file: examples/runtime_error/str_repeat_infinite.nbt
+---
+error: runtime error
+   ┌─ Module 'core::strings', File [PRELUDE_FILE]:76:10
+   │
+76 │     then error("Cannot repeat a string an infinite number of times")
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   ┌─ <internal:3>:1:1
+   │
+ 1 │ str_repeat(inf, "x")
+   │ ^^^^^^^^^^^^^^^^^^^^
+   │
+   = User error: Cannot repeat a string an infinite number of times
+
+help: Backtrace:
+ = 0: error("Cannot repeat a string an infinite number of times")
+   	at str_repeat - Module 'core::strings', File [PRELUDE_FILE]:76:10
+ = 1: str_repeat(inf, "x")
+   	at <main> - <internal:3>:1:0

--- a/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@str_repeat_nan.nbt.snap
+++ b/numbat/tests/snapshots/prelude_and_examples__runtime_error_snapshots@str_repeat_nan.nbt.snap
@@ -1,0 +1,23 @@
+---
+source: numbat/tests/prelude_and_examples.rs
+expression: output
+input_file: examples/runtime_error/str_repeat_nan.nbt
+---
+error: runtime error
+   ┌─ Module 'core::strings', File [PRELUDE_FILE]:78:10
+   │
+78 │     then error("Cannot repeat a string NaN number of times")
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   ┌─ <internal:3>:1:1
+   │
+ 1 │ str_repeat(NaN, "x")
+   │ ^^^^^^^^^^^^^^^^^^^^
+   │
+   = User error: Cannot repeat a string NaN number of times
+
+help: Backtrace:
+ = 0: error("Cannot repeat a string NaN number of times")
+   	at str_repeat - Module 'core::strings', File [PRELUDE_FILE]:78:10
+ = 1: str_repeat(NaN, "x")
+   	at <main> - <internal:3>:1:0


### PR DESCRIPTION
Fixes the `str_repeat` half of #851.

## Problem

`str_repeat(inf, "x")` and `str_repeat(NaN, "x")` loop forever. The function
recurses with `n - 1` while `n > 0`, and both comparisons are false for
non-finite `n`, so the recursion never terminates.

## Fix

Guard the two non-finite cases up front and raise a user error, mirroring the
`is_infinite` / `is_nan` guards added to `base()` in #853:

```numbat
fn str_repeat(n: Scalar, a: String) -> String =
  if is_infinite(n)
    then error("Cannot repeat a string an infinite number of times")
  else if is_nan(n)
    then error("Cannot repeat a string NaN number of times")
  else if n > 0
    then str_append(a, str_repeat(n - 1, a))
    else ""
```

Behavior for finite counts is unchanged.

## Tests

- New runtime-error examples for each branch: `examples/runtime_error/str_repeat_infinite.nbt` and `str_repeat_nan.nbt`, plus regenerated insta snapshots.
- The `invalid_base` snapshot line numbers were refreshed (108 → 112) because the `str_repeat` guards shift `base()` down by three lines.
- Full workspace test suite passes (`cargo test --workspace --all-features`), `cargo fmt --check` is clean.

Note: `cargo clippy --workspace --all-targets --all-features -- -D warnings` reports one pre-existing `map_or` → `unwrap_or` lint in `numbat/src/list.rs:94` (unrelated to this change; likely a newer-clippy artifact) — left untouched to keep this change focused.

## Disclosure

I used an AI coding assistant to develop and verify this change; I reviewed and tested everything myself.