### PR TITLE
Track free parentheses in the AST to preserve their source spans

### DIFF
--- a/numbat/src/ast.rs
+++ b/numbat/src/ast.rs
@@ -122,6 +122,10 @@ pub enum Expression<'a> {
         expr: Box<Expression<'a>>,
         field_name: &'a str,
     },
+    Parens {
+        full_span: Span,
+        expr: Box<Expression<'a>>,
+    },
     List(Span, Vec<Expression<'a>>),
 }
 
@@ -156,6 +160,7 @@ impl Expression<'_> {
             Expression::String(span, _) => *span,
             Expression::InstantiateStruct { full_span, .. } => *full_span,
             Expression::AccessField { full_span, .. } => *full_span,
+            Expression::Parens { full_span, .. } => *full_span,
             Expression::List(span, _) => *span,
             Expression::TypedHole(span) => *span,
         }
@@ -715,6 +720,10 @@ impl ReplaceSpans for Expression<'_> {
                 ident_span: Span::dummy(),
                 expr: Box::new(expr.replace_spans()),
                 field_name,
+            },
+            Expression::Parens { expr, .. } => Expression::Parens {
+                full_span: Span::dummy(),
+                expr: Box::new(expr.replace_spans()),
             },
             Expression::List(_, elements) => Expression::List(
                 Span::dummy(),

--- a/numbat/src/parse_quantity.rs
+++ b/numbat/src/parse_quantity.rs
@@ -69,6 +69,8 @@ fn get_expression_type(
     match expr {
         Expression::Scalar(_, _) => Ok(TypeScheme::concrete(Type::scalar())),
 
+        Expression::Parens { expr, .. } => get_expression_type(expr, typechecker),
+
         Expression::BinaryOperator {
             op: BinaryOperator::Mul,
             rhs,
@@ -106,6 +108,9 @@ fn evaluate_quantity_expression(
         // Plain scalar
         Expression::Scalar(_, n) => Ok(Quantity::from_scalar(n.to_f64())),
 
+        // Parentheses
+        Expression::Parens { expr, .. } => evaluate_quantity_expression(expr, unit_lookup),
+
         // Scalar × Unit
         Expression::BinaryOperator {
             op: BinaryOperator::Mul,
@@ -138,6 +143,7 @@ fn evaluate_quantity_expression(
 fn extract_scalar(expr: &Expression) -> Result<f64, QuantityLiteralError> {
     match expr {
         Expression::Scalar(_, n) => Ok(n.to_f64()),
+        Expression::Parens { expr, .. } => extract_scalar(expr),
         _ => Err(QuantityLiteralError::InvalidPattern(
             "Expected scalar".to_string(),
         )),
@@ -156,6 +162,7 @@ fn extract_unit(
             })?;
             Ok(base_unit.with_prefix(*prefix))
         }
+        Expression::Parens { expr, .. } => extract_unit(expr, unit_lookup),
         _ => Err(QuantityLiteralError::InvalidPattern(
             "Expected unit identifier".to_string(),
         )),
@@ -224,6 +231,8 @@ pub fn parse_quantity_ast(input: &str) -> Result<Expression<'_>, QuantityLiteral
 fn is_valid_quantity_literal(expr: &Expression) -> bool {
     match expr {
         Expression::Scalar(_, _) => true,
+
+        Expression::Parens { expr, .. } => is_valid_quantity_literal(expr),
 
         // Scalar times unit (implicit or explicit multiplication)
         Expression::BinaryOperator {

--- a/numbat/src/parser.rs
+++ b/numbat/src/parser.rs
@@ -1654,17 +1654,20 @@ impl<'a> Parser<'a> {
             parts.retain(|p| !matches!(p, StringPart::Fixed(s) if s.is_empty()));
 
             Ok(Expression::String(span_full_string, parts))
-        } else if self.match_exact(tokens, TokenKind::LeftParen).is_some() {
+        } else if let Some(token_left_paren) = self.match_exact(tokens, TokenKind::LeftParen) {
             let inner = self.expression(tokens)?;
 
-            if self.match_exact(tokens, TokenKind::RightParen).is_none() {
+            let Some(token_right_paren) = self.match_exact(tokens, TokenKind::RightParen) else {
                 return Err(ParseError::new(
                     ParseErrorKind::MissingClosingParen,
                     self.peek(tokens).span,
                 ));
-            }
+            };
 
-            Ok(inner)
+            Ok(Expression::Parens {
+                full_span: token_left_paren.span.extend(&token_right_paren.span),
+                expr: Box::new(inner),
+            })
         } else if matches!(
             self.peek(tokens).kind,
             TokenKind::ProcedurePrint | TokenKind::ProcedureAssertEq
@@ -2194,9 +2197,109 @@ mod tests {
             let statements = parse(input, 0).expect("parse error").replace_spans();
 
             assert!(statements.len() == 1);
-            let statement = &statements[0];
+            let statement = strip_parens_stmt(statements.into_iter().next().unwrap());
 
-            assert_eq!(*statement, statement_expected);
+            assert_eq!(statement, statement_expected);
+        }
+    }
+
+    /// Drop `Parens` nodes (which are semantically transparent) so that tests can
+    /// compare against ASTs constructed without explicit parentheses.
+    fn strip_parens<'a>(expression: &Expression<'a>) -> Expression<'a> {
+        match expression {
+            Expression::Parens { expr, .. } => strip_parens(expr),
+            Expression::UnaryOperator { op, expr, span_op } => Expression::UnaryOperator {
+                op: *op,
+                expr: Box::new(strip_parens(expr)),
+                span_op: *span_op,
+            },
+            Expression::BinaryOperator {
+                op,
+                lhs,
+                rhs,
+                span_op,
+            } => Expression::BinaryOperator {
+                op: *op,
+                lhs: Box::new(strip_parens(lhs)),
+                rhs: Box::new(strip_parens(rhs)),
+                span_op: *span_op,
+            },
+            Expression::FunctionCall {
+                ident_span,
+                full_span,
+                callable,
+                args,
+            } => Expression::FunctionCall {
+                ident_span: *ident_span,
+                full_span: *full_span,
+                callable: Box::new(strip_parens(callable)),
+                args: args.iter().map(strip_parens).collect(),
+            },
+            Expression::Condition {
+                span,
+                condition,
+                then_expr,
+                else_expr,
+            } => Expression::Condition {
+                span: *span,
+                condition: Box::new(strip_parens(condition)),
+                then_expr: Box::new(strip_parens(then_expr)),
+                else_expr: Box::new(strip_parens(else_expr)),
+            },
+            Expression::InstantiateStruct {
+                full_span,
+                ident_span,
+                name,
+                fields,
+            } => Expression::InstantiateStruct {
+                full_span: *full_span,
+                ident_span: *ident_span,
+                name,
+                fields: fields
+                    .iter()
+                    .map(|(s, n, v)| (*s, *n, strip_parens(v)))
+                    .collect(),
+            },
+            Expression::AccessField {
+                full_span,
+                ident_span,
+                expr,
+                field_name,
+            } => Expression::AccessField {
+                full_span: *full_span,
+                ident_span: *ident_span,
+                expr: Box::new(strip_parens(expr)),
+                field_name,
+            },
+            Expression::List(span, elements) => {
+                Expression::List(*span, elements.iter().map(strip_parens).collect())
+            }
+            Expression::String(span, parts) => Expression::String(
+                *span,
+                parts
+                    .iter()
+                    .map(|p| match p {
+                        StringPart::Fixed(s) => StringPart::Fixed(s.clone()),
+                        StringPart::Interpolation {
+                            span,
+                            expr,
+                            format_specifiers,
+                        } => StringPart::Interpolation {
+                            span: *span,
+                            expr: Box::new(strip_parens(expr)),
+                            format_specifiers: *format_specifiers,
+                        },
+                    })
+                    .collect(),
+            ),
+            other => other.clone(),
+        }
+    }
+
+    fn strip_parens_stmt(statement: Statement) -> Statement {
+        match statement {
+            Statement::Expression(expression) => Statement::Expression(strip_parens(&expression)),
+            other => other,
         }
     }
 
@@ -2259,6 +2362,64 @@ mod tests {
             &["1)", "(1))"],
             ParseErrorKind::TrailingCharacters(")".into()),
         );
+    }
+
+    #[test]
+    fn parens_preserved_in_ast() {
+        let statements = parse("(1)", 0).expect("parse error");
+        let Statement::Expression(expr) = &statements[0] else {
+            panic!("expected expression statement")
+        };
+        match expr {
+            Expression::Parens { full_span, expr } => {
+                assert_eq!(full_span.start, 0.into());
+                assert_eq!(full_span.end, 3.into());
+                assert_eq!(expr.full_span().start, 1.into());
+                assert_eq!(expr.full_span().end, 2.into());
+            }
+            _ => panic!("expected Parens node, got {expr:?}"),
+        }
+
+        let statements = parse("((1))", 0).expect("parse error");
+        let Statement::Expression(expr) = &statements[0] else {
+            panic!("expected expression statement")
+        };
+        match expr {
+            Expression::Parens { full_span, expr } => {
+                assert_eq!(full_span.start, 0.into());
+                assert_eq!(full_span.end, 5.into());
+                match expr.as_ref() {
+                    Expression::Parens { full_span, expr } => {
+                        assert_eq!(full_span.start, 1.into());
+                        assert_eq!(full_span.end, 4.into());
+                        assert_eq!(expr.full_span().start, 2.into());
+                        assert_eq!(expr.full_span().end, 3.into());
+                    }
+                    _ => panic!("expected inner Parens node, got {expr:?}"),
+                }
+            }
+            _ => panic!("expected outer Parens node, got {expr:?}"),
+        }
+    }
+
+    #[test]
+    fn parens_spans_in_binary_operation() {
+        let statements = parse("1 + (2 * 3)", 0).expect("parse error");
+        let Statement::Expression(expr) = &statements[0] else {
+            panic!("expected expression statement")
+        };
+        match expr {
+            Expression::BinaryOperator { rhs, .. } => match rhs.as_ref() {
+                Expression::Parens { full_span, expr } => {
+                    assert_eq!(full_span.start, 4.into());
+                    assert_eq!(full_span.end, 11.into());
+                    assert_eq!(expr.full_span().start, 5.into());
+                    assert_eq!(expr.full_span().end, 10.into());
+                }
+                _ => panic!("expected Parens node on the right-hand side, got {rhs:?}"),
+            },
+            _ => panic!("expected BinaryOperator node, got {expr:?}"),
+        }
     }
 
     #[test]

--- a/numbat/src/prefix_transformer.rs
+++ b/numbat/src/prefix_transformer.rs
@@ -157,6 +157,9 @@ impl Transformer {
             Expression::AccessField { expr, .. } => {
                 self.transform_expression(expr);
             }
+            Expression::Parens { expr, .. } => {
+                self.transform_expression(expr);
+            }
             Expression::List(_, elements) => {
                 for e in elements {
                     self.transform_expression(e);

--- a/numbat/src/typechecker/mod.rs
+++ b/numbat/src/typechecker/mod.rs
@@ -1213,6 +1213,7 @@ impl TypeChecker {
                     field_type: TypeScheme::concrete(field_type),
                 }
             }
+            ast::Expression::Parens { expr, .. } => self.elaborate_expression(expr)?,
             ast::Expression::List(span, elements) => {
                 let elements_checked = elements
                     .iter()

--- a/numbat/tests/snapshots/prelude_and_examples__typecheck_error_snapshots@non_scalar_exponent.nbt.snap
+++ b/numbat/tests/snapshots/prelude_and_examples__typecheck_error_snapshots@non_scalar_exponent.nbt.snap
@@ -1,12 +1,13 @@
 ---
 source: numbat/tests/prelude_and_examples.rs
+assertion_line: 120
 expression: output
 input_file: examples/typecheck_error/non_scalar_exponent.nbt
 ---
 error: while type checking
-  ┌─ <internal:3>:4:4
+  ┌─ <internal:3>:4:3
   │
 4 │ e^(-x^2/sigma)
-  │    ^^^^^^^^^^ Length
+  │   ^^^^^^^^^^^^ Length
   │
   = Exponents need to be dimensionless (got Length).


### PR DESCRIPTION
Fixes #102.

## Problem

Type-checking errors attribute spans to the expression *inside* parentheses, dropping the surrounding "free" parens. For example:

```
meter + ((((second) * 2)))
```

renders the `Time` label under `second) * 2)` instead of over the fully parenthesized `((((second) * 2)))`:

```
1 │ meter + ((((second) * 2)))
  │ ^^^^^ -     ^^^^^^^^^^^ Time
```

## Fix

Introduce an `Expression::Parens` node that keeps the span of the whole parenthesized expression while remaining semantically transparent:

- `parser.rs` now builds a `Parens` node for every `( ... )` primary, recording the span from `(` to `)` (previously both tokens were discarded).
- the type checker elaborates `Parens` by elaborating its inner expression and discarding the wrapper, so the typed AST (and thus evaluation, bytecode, and pretty-printing) is unchanged.
- `prefix_transformer` and the quantity-literal parser look through `Parens` without changing semantics.

The example above now highlights the entire `((((second) * 2)))`:

```
1 │ meter + ((((second) * 2)))
  │ ^^^^^ - ^^^^^^^^^^^^^^^^^^ Time
```

## Tests

- New unit tests for `Parens` spans: `(1)`, nested `((1))`, and `1 + (2 * 3)` (right-hand operand).
- Parser test helpers normalize away `Parens` before comparing, since it is semantically transparent.
- One type-checking error snapshot updated: the exponent error in `non_scalar_exponent.nbt` now spans the full `(x^2/sigma)`.
- Full workspace test suite passes; `cargo fmt --check` is clean.

Note: `cargo clippy --workspace --all-targets --all-features -- -D warnings` still reports the pre-existing `list.rs:94` lint (unrelated to this change).

## Disclosure

I used an AI coding assistant to develop and verify this change; I reviewed and tested everything myself.